### PR TITLE
clean $dashboard_query from corrupting theme

### DIFF
--- a/wpuf-dashboard.php
+++ b/wpuf-dashboard.php
@@ -198,6 +198,9 @@ class WPUF_Dashboard {
 
         <?php
         $this->user_info();
+
+        // clean $dashboard_query from corrupting beyond use
+        wp_reset_query();
     }
 
     /**


### PR DESCRIPTION
reset query to prevent new WP_Query from corrupting rest of the page
load with tainted query from listing the current author’s posts on the
[wpuf_dashboard]
