### PR TITLE
Paypal ssl fix

### DIFF
--- a/lib/gateway/paypal.php
+++ b/lib/gateway/paypal.php
@@ -64,7 +64,7 @@ class WPUF_Paypal {
         // Send back post vars to paypal
         $params = array(
             'body'       => $args,
-            'sslverify'  => false,
+            'sslverify'  => true,
             'timeout'    => 30,
             'user-agent' => 'WP User Frontend Pro/' . WPUF_VERSION,
         );


### PR DESCRIPTION
Paypal ssl security issue fix.
According to Paypal Security Notice, SSL is required for the paypal gateway to function properly. More details can be found below.
[https://www.paypal-notice.com/en/IPN-Verification-Postback-to-HTTPS/](url)