### PR TITLE
Added filter to show WPUF meta boxes even when ACF is active

### DIFF
--- a/admin/posting.php
+++ b/admin/posting.php
@@ -198,9 +198,16 @@ class WPUF_Admin_Posting extends WPUF_Render_Form {
 
         $form_id = get_post_meta( $post->ID, '_wpuf_form_id', true );
         $form_settings = wpuf_get_form_settings( $form_id );
+        
+        /**
+         * There may be incompatibilities with WPUF metabox display when Advanced Custom Fields
+         * is active. By default WPUF metaboxes will be hidden when ACF is detected. However,
+         * you can override that by using the following filter.
+         */
+        $hide_with_acf = class_exists( 'acf' ) ? apply_filters( 'wpuf_hide_meta_when_acf_active', true ) : false;
 
         // hide the metabox itself if no form ID is set
-        if ( !$form_id || class_exists('acf') ) {
+        if ( !$form_id || $hide_with_acf ) {
             $this->hide_form();
             return;
         }


### PR DESCRIPTION
After updating from wpuf pro 2.4 I have had issues displaying WPUF meta boxes. With the help of Mehedi from WPUF support we have found the problem is due to an incompatibility with ACF. By default WPUF meta boxes are currently hidden when ACF is active. This pull request allows the user to change the default behaviour so that WPUF meta boxes are still shown even when ACF is active.