### PR TITLE
Made Hard-Coded Strings Translation-ready

### DIFF
--- a/class/frontend-form-post.php
+++ b/class/frontend-form-post.php
@@ -688,14 +688,14 @@ class WPUF_Frontend_Form_Post extends WPUF_Render_Form {
                 wpuf_send_mail_to_guest ( $post_id_encoded, $form_id_encoded, 'no', 1 );
                 $response['show_message'] = true;
                 $response['redirect_to'] = add_query_arg( $wp->query_string, '', home_url( $wp->request ) );
-                $response['message'] = 'Thank you for posting on our site. We have sent you an confirmation email. Please check your inbox!';
+                $response['message'] = __( 'Thank you for posting on our site. We have sent you an confirmation email. Please check your inbox!', 'wp-user-frontend' );
 
             } elseif ( $guest_mode == 'true' && $guest_verify == 'true' && !is_user_logged_in() && $charging_enabled == 'yes' ) {
                 $post_id_encoded   = wpuf_encryption( $post_id ) ;
                 $form_id_encoded   = wpuf_encryption( $form_id ) ;
                 $response['show_message'] = true;
                 $response['redirect_to'] = add_query_arg( $wp->query_string, '', home_url( $wp->request ) );
-                $response['message'] = 'Thank you for posting on our site. We have sent you an confirmation email. Please check your inbox!';
+                $response['message'] = __( 'Thank you for posting on our site. We have sent you an confirmation email. Please check your inbox!', 'wp-user-frontend' );
                 update_post_meta ( $post_id, '_wpuf_payment_status', 'pending' );
                 wpuf_send_mail_to_guest ( $post_id_encoded, $form_id_encoded, 'yes', 2 );
             }


### PR DESCRIPTION
Some notification messages are not translation-ready; made 'em translatable.