### PR TITLE
Add the login_errors filter

### DIFF
--- a/includes/free/class-login.php
+++ b/includes/free/class-login.php
@@ -932,7 +932,7 @@ class WPUF_Simple_Login {
         if ( $this->login_errors ) {
             foreach ($this->login_errors as $error) {
                 echo '<div class="wpuf-error">';
-                _e( $error,'wp-user-frontend' );
+                _e( apply_filters( 'login_errors', $error),'wp-user-frontend' );
                 echo '</div>';
             }
         }

--- a/wpuf.php
+++ b/wpuf.php
@@ -592,7 +592,7 @@ final class WP_User_Frontend {
      * @since 2.2.3
      * @return void
      */
-    function show_admin_bar($val) {
+    function show_admin_bar() {
 
         if ( !is_user_logged_in() ) {
             return false;
@@ -605,7 +605,7 @@ final class WP_User_Frontend {
             return false;
         }
 
-        return $val;
+        return true;
     }
 
     /**

--- a/wpuf.php
+++ b/wpuf.php
@@ -592,7 +592,7 @@ final class WP_User_Frontend {
      * @since 2.2.3
      * @return void
      */
-    function show_admin_bar() {
+    function show_admin_bar($val) {
 
         if ( !is_user_logged_in() ) {
             return false;
@@ -605,7 +605,7 @@ final class WP_User_Frontend {
             return false;
         }
 
-        return true;
+        return $val;
     }
 
     /**


### PR DESCRIPTION
Apply the [login_errors](https://codex.wordpress.org/Plugin_API/Filter_Reference/login_errors) filter to the error messages returned in the login form.

Now adding this filter will allow the user to override the message before it's displayed.
```
add_filter( 'login_errors', 'custom_login_errors');
```


![default](https://user-images.githubusercontent.com/80420/51159195-970bc900-1890-11e9-8512-9ab5be1798ec.png)

![wpuf](https://user-images.githubusercontent.com/80420/51159201-9d9a4080-1890-11e9-99fe-a6c90e499e62.png)
