### PR TITLE
Fix conflict file upload and image upload issue

### DIFF
--- a/assets/js/upload.js
+++ b/assets/js/upload.js
@@ -174,10 +174,9 @@
             }
 
             var uploaded        = this.UploadedFiles,
-                FileProgress    = up.files.length,
-                imageCount      = $('ul.wpuf-attachment-list > li').length;
+                FileProgress    = up.files.length;
 
-            if ( imageCount >= this.max ) {
+            if ( this.count >= this.max ) {
                 $('#' + this.container).find('.file-selector').hide();
             }
 


### PR DESCRIPTION
If there is an image upload field and a file upload field in a form, a separate max file should be counted, but the two field combine to one max file.