### PR TITLE
Fix file upload with same file name

### DIFF
--- a/class/upload.php
+++ b/class/upload.php
@@ -85,8 +85,11 @@ class WPUF_Upload {
         $wpuf_file = isset( $_FILES['wpuf_file'] ) ? $_FILES['wpuf_file'] : []; // WPCS: sanitization ok.
 
         $file_extension = pathinfo( $wpuf_file['name'], PATHINFO_EXTENSION );
+        $hash           = wp_hash( time() );
+        $hash           = substr( $hash, 0, 8 );
+
         $upload = [
-            'name'     => wp_hash( time() ) . '.' . $file_extension,
+            'name' => $wpuf_file['name'] . '-' . $hash . '.' . $file_extension,
             'type'     => $wpuf_file['type'],
             'tmp_name' => $wpuf_file['tmp_name'],
             'error'    => $wpuf_file['error'],

--- a/class/upload.php
+++ b/class/upload.php
@@ -84,8 +84,9 @@ class WPUF_Upload {
         //$wpuf_file = isset( $_FILES['wpuf_file'] ) ? array_map( 'sanitize_text_field', wp_unslash( $_FILES['wpuf_file'] ) ) : []; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
         $wpuf_file = isset( $_FILES['wpuf_file'] ) ? $_FILES['wpuf_file'] : []; // WPCS: sanitization ok.
 
+        $file_extension = pathinfo( $wpuf_file['name'], PATHINFO_EXTENSION );
         $upload = [
-            'name'     => $wpuf_file['name'],
+            'name'     => wp_hash( time() ) . '.' . $file_extension,
             'type'     => $wpuf_file['type'],
             'tmp_name' => $wpuf_file['tmp_name'],
             'error'    => $wpuf_file['error'],

--- a/class/upload.php
+++ b/class/upload.php
@@ -89,7 +89,7 @@ class WPUF_Upload {
         $hash           = substr( $hash, 0, 8 );
 
         $upload = [
-            'name' => $wpuf_file['name'] . '-' . $hash . '.' . $file_extension,
+            'name'     => $wpuf_file['name'] . '-' . $hash . '.' . $file_extension,
             'type'     => $wpuf_file['type'],
             'tmp_name' => $wpuf_file['tmp_name'],
             'error'    => $wpuf_file['error'],


### PR DESCRIPTION
If multiple files with the same name were saved, the previous file would be there but the next file would not be saved. This is why these problems have been created.

Fixes https://github.com/weDevsOfficial/wp-user-frontend/issues/916, https://github.com/weDevsOfficial/wp-user-frontend/issues/913