### PR TITLE
Illigal variable declartion

### DIFF
--- a/admin/class-admin-subscription.php
+++ b/admin/class-admin-subscription.php
@@ -136,7 +136,7 @@ class WPUF_Admin_Subscription {
             if ( isset( $_POST['post_expiration_settings'] ) ) {
                 $post_expiration_settings = array_map( 'sanitize_text_field', wp_unslash( $_POST['post_expiration_settings'] ) );
 
-                $user_pack['_post_expiration_time'] = post_expiration_settings['expiration_time_value'] . ' ' . post_expiration_settings['expiration_time_type'];
+                $user_pack['_post_expiration_time'] = $post_expiration_settings['expiration_time_value'] . ' ' . $post_expiration_settings['expiration_time_type'];
 
                 echo esc_html( $user_pack['_post_expiration_time'] );
             }


### PR DESCRIPTION
Missing $ when declaring 'post_expiration_settings' variable.

Fix https://github.com/weDevsOfficial/wp-user-frontend/issues/904 