### PR TITLE
Fix post preview missing field

### DIFF
--- a/includes/class-field-manager.php
+++ b/includes/class-field-manager.php
@@ -104,6 +104,10 @@ class WPUF_Field_Manager {
      */
     private function register_field_types() {
         require_once __DIR__ . '/fields/class-abstract-fields.php';
+        require_once __DIR__ . '/fields/class-field-post-title.php';
+        require_once __DIR__ . '/fields/class-field-post-tags.php';
+        require_once __DIR__ . '/fields/class-field-post-taxonomy.php';
+        require_once __DIR__ . '/fields/class-field-post-content.php';
         require_once __DIR__ . '/fields/class-field-text.php';
         require_once __DIR__ . '/fields/class-field-email.php';
         require_once __DIR__ . '/fields/class-field-textarea.php';
@@ -120,6 +124,10 @@ class WPUF_Field_Manager {
         require_once __DIR__ . '/fields/class-field-recaptcha.php';
 
         $fields = [
+            'post_title'          => new WPUF_Form_Field_Post_Title(),
+            'post_content'        => new WPUF_Form_Field_Post_Content(),
+            'post_tags'           => new WPUF_Form_Field_Post_Tags(),
+            'taxonomy'            => new WPUF_Form_Field_Post_Taxonomy( 'category', 'category' ),
             'text_field'          => new WPUF_Form_Field_Text(),
             'email_address'       => new WPUF_Form_Field_Email(),
             'textarea_field'      => new WPUF_Form_Field_Textarea(),


### PR DESCRIPTION
When reviewing post post title, post content, post tags and categories fields are missing.

Fix https://github.com/weDevsOfficial/wp-user-frontend/issues/895