### PR TITLE
Fix role base permission for accessing a post form

### DIFF
--- a/includes/class-frontend-form-post.php
+++ b/includes/class-frontend-form-post.php
@@ -582,9 +582,7 @@ class WPUF_Frontend_Form extends WPUF_Frontend_Render_Form {
 
             // the user must be logged in already
         } elseif ( isset( $this->form_settings['role_base'] ) && $this->form_settings['role_base'] == 'true' ) {
-            $current_user = wp_get_current_user();
-
-            if ( !in_array( $current_user->roles[0], $this->form_settings['roles'] ) ) {
+            if ( ! wpuf_user_can_post( $this->form_settings['roles'] ) ) {
                 $this->send_error( __( 'You do not have sufficient permissions to access this form.', 'wp-user-frontend' ) );
             }
         } else {

--- a/includes/class-frontend-form-post.php
+++ b/includes/class-frontend-form-post.php
@@ -582,7 +582,7 @@ class WPUF_Frontend_Form extends WPUF_Frontend_Render_Form {
 
             // the user must be logged in already
         } elseif ( isset( $this->form_settings['role_base'] ) && $this->form_settings['role_base'] == 'true' ) {
-            if ( ! wpuf_user_can_post( $this->form_settings['roles'] ) ) {
+            if ( ! wpuf_user_has_roles( $this->form_settings['roles'] ) ) {
                 $this->send_error( __( 'You do not have sufficient permissions to access this form.', 'wp-user-frontend' ) );
             }
         } else {

--- a/includes/class-frontend-render-form.php
+++ b/includes/class-frontend-render-form.php
@@ -307,7 +307,7 @@ class WPUF_Frontend_Render_Form {
             return;
         }
 
-        if ( ! wpuf_user_can_post( $this->form_settings['roles'] ) ) {
+        if ( ! wpuf_user_has_roles( $this->form_settings['roles'] ) ) {
             echo wp_kses_post( '<div class="wpuf-message">' . __( 'You do not have sufficient permissions to access this form.', 'wp-user-frontend' ) . '</div>' );
 
             return;

--- a/includes/class-frontend-render-form.php
+++ b/includes/class-frontend-render-form.php
@@ -307,6 +307,12 @@ class WPUF_Frontend_Render_Form {
             return;
         }
 
+        if ( ! wpuf_user_can_post( $this->form_settings['roles'] ) ) {
+            echo wp_kses_post( '<div class="wpuf-message">' . __( 'You do not have sufficient permissions to access this form.', 'wp-user-frontend' ) . '</div>' );
+
+            return;
+        }
+
         if ( $this->form_fields ) { ?>
 
                 <form class="wpuf-form-add wpuf-form-<?php echo esc_attr( $layout ); ?> <?php echo ( $layout == 'layout1' ) ? esc_html( $theme_css ) : 'wpuf-style'; ?>" action="" method="post">

--- a/includes/class-frontend-render-form.php
+++ b/includes/class-frontend-render-form.php
@@ -308,7 +308,10 @@ class WPUF_Frontend_Render_Form {
         }
 
         if ( ! wpuf_user_has_roles( $this->form_settings['roles'] ) ) {
-            echo wp_kses_post( '<div class="wpuf-message">' . __( 'You do not have sufficient permissions to access this form.', 'wp-user-frontend' ) . '</div>' );
+            ?>
+            <div class="wpuf-message"><?php esc_html_e( 'You do not have sufficient permissions to access this form.', 'wp-user-frontend'  ); ?></div>
+            <?php
+
 
             return;
         }

--- a/wpuf-functions.php
+++ b/wpuf-functions.php
@@ -3545,3 +3545,29 @@ function wpuf_max_upload_size() {
 function wpuf_validate_boolean( $var ) {
     return filter_var( $var, FILTER_VALIDATE_BOOLEAN );
 }
+
+/**
+ * Check user permisson to submit a post
+ *
+ * @param  integer $user_id User id will submit post
+ * @param  array  $roles   Permitted user roles to submit a post
+ * @return bool          If user permitted to submit post
+ */
+function wpuf_user_can_post( array $roles, $user_id = null ) {
+
+    if ( empty( $roles ) ) {
+        return false;
+    }
+
+    $user = wp_get_current_user();
+
+    if ( $user_id ) {
+        $user = get_userdata( $user_id );
+    }
+
+    if ( in_array( $user->roles[0], $roles )  ) {
+        return true;
+    }
+
+    return false;
+}

--- a/wpuf-functions.php
+++ b/wpuf-functions.php
@@ -3547,25 +3547,23 @@ function wpuf_validate_boolean( $var ) {
 }
 
 /**
- * Check user permisson to submit a post
+ * Check user has certain roles
  *
- * @param  integer $user_id User id will submit post
+ * @since WPUF_SINCE
+ *
  * @param  array  $roles   Permitted user roles to submit a post
- * @return bool          If user permitted to submit post
+ * @param  int    $user_id User id will submit post
+ *
+ * @return bool
  */
-function wpuf_user_can_post( array $roles, $user_id = null ) {
-
+function wpuf_user_has_roles( $roles, $user_id = 0 ) {
     if ( empty( $roles ) ) {
         return false;
     }
 
-    $user = wp_get_current_user();
+    $user = $user_id ? get_userdata( $user_id ) : wp_get_current_user();
 
-    if ( $user_id ) {
-        $user = get_userdata( $user_id );
-    }
-
-    if ( in_array( $user->roles[0], $roles )  ) {
+    if ( ! empty( array_intersect( $user->roles, $roles ) ) ) {
         return true;
     }
 


### PR DESCRIPTION
If enabled is "Enable role base post" and the user role is not selected, the user can still view the post form.