### PR TITLE
Fix rolebase permission for post form

### DIFF
--- a/includes/class-frontend-render-form.php
+++ b/includes/class-frontend-render-form.php
@@ -307,7 +307,7 @@ class WPUF_Frontend_Render_Form {
             return;
         }
 
-        if ( ! wpuf_user_has_roles( $this->form_settings['roles'] ) ) {
+        if ( 'true' == $this->form_settings['role_base'] && ! wpuf_user_has_roles( $this->form_settings['roles'] ) ) {
             ?>
             <div class="wpuf-message"><?php esc_html_e( 'You do not have sufficient permissions to access this form.', 'wp-user-frontend'  ); ?></div>
             <?php

--- a/includes/class-frontend-render-form.php
+++ b/includes/class-frontend-render-form.php
@@ -307,7 +307,7 @@ class WPUF_Frontend_Render_Form {
             return;
         }
 
-        if ( 'true' == $this->form_settings['role_base'] && ! wpuf_user_has_roles( $this->form_settings['roles'] ) ) {
+        if ( wpuf_validate_boolean( $this->form_settings['role_base'] ) && ! wpuf_user_has_roles( $this->form_settings['roles'] ) ) {
             ?>
             <div class="wpuf-message"><?php esc_html_e( 'You do not have sufficient permissions to access this form.', 'wp-user-frontend'  ); ?></div>
             <?php


### PR DESCRIPTION
If any post doesn't turn on 'Enable role base post', the post form couldn't be rendered in frontend.