### PR TITLE
Custom taxonomy input text

### DIFF
--- a/includes/class-frontend-render-form.php
+++ b/includes/class-frontend-render-form.php
@@ -574,9 +574,14 @@ class WPUF_Frontend_Render_Form {
                     $terms = array_map( function ( $term_name ) use ( $taxonomy ) {
                         $term = get_term_by( 'name', $term_name, $taxonomy['name'] );
 
+                        if ( empty( $term_name ) ) {
+                            return null;
+                        }
+
                         if ( $term instanceof WP_Term  ) {
                             return $term->term_id;
-                        }
+
+                        } 
 
                         $new_term = wp_insert_term( $term_name, $taxonomy['name'] );
 

--- a/includes/class-frontend-render-form.php
+++ b/includes/class-frontend-render-form.php
@@ -578,7 +578,9 @@ class WPUF_Frontend_Render_Form {
                             return $term->term_id;
                         }
 
-                        return null;
+                        $new_term = wp_insert_term( $term_name, $taxonomy['name'] );
+
+                        return $new_term['term_id'];
 
                     }, $terms );
 


### PR DESCRIPTION
If custom taxonomy field type is text and not exist the term, it couldn't save the term.

Fix: https://github.com/weDevsOfficial/wp-user-frontend/issues/946