### PR TITLE
Fix: Default post form is not showing on the frontend account

### DIFF
--- a/templates/submit-post.php
+++ b/templates/submit-post.php
@@ -1,7 +1,7 @@
 <?php
 
 $no_form_notice = __( 'No post form assigned yet by the administrator.', 'wp-user-frontend' );
-$selected_form  = wpuf_get_option( 'post_submission_form', 'wpuf_my_account' );
+$selected_form  = wpuf_get_option( 'default_post_form', 'wpuf_frontend_posting' );
 
 if ( empty( $selected_form ) ) {
     echo wp_kses_post( '<div class="wpuf-info">' . $no_form_notice . '</div>' );


### PR DESCRIPTION
When select a default post form from settings, it couldn't show as default post form from the frontend account page.


Fix #978