### PR TITLE
Fix: image field conflict with acf image field

### DIFF
--- a/includes/fields/class-field-image.php
+++ b/includes/fields/class-field-image.php
@@ -25,18 +25,17 @@ class WPUF_Form_Field_Image extends WPUF_Field_Contract {
         $has_images         = false;
 
         if ( isset( $post_id ) && $post_id != '0' ) {
-            if ( $this->is_meta( $field_settings ) ) {
-                $images = $this->get_meta( $post_id, $field_settings['name'], $type, false );
+            $images = $this->get_meta( $post_id, $field_settings['name'], $type, false );
 
-                if ( $images ) {
-                    if ( is_serialized( $images[0] ) ) {
-                        $images = maybe_unserialize( $images[0] );
-                    }
-
-                    if ( is_array( $images[0] ) ) {
-                        $images = $images[0];
-                    }
+            if ( $this->is_meta( $field_settings ) && ! empty( $images[0] ) ) {
+                if ( is_serialized( $images[0] ) ) {
+                    $images = maybe_unserialize( $images[0] );
                 }
+
+                if ( is_array( $images[0] ) ) {
+                    $images = $images[0];
+                }
+                
                 $has_images         = true;
             }
         }


### PR DESCRIPTION
If make a compatible image field with acf image field, then update the post from backend keep empty the image field it shows a default image in frontend post edit form.


Fix: #945