### PR TITLE
Conflict with acf image field

### DIFF
--- a/includes/fields/class-field-image.php
+++ b/includes/fields/class-field-image.php
@@ -1,4 +1,3 @@
-
 <?php
 
 /**
@@ -23,13 +22,12 @@ class WPUF_Form_Field_Image extends WPUF_Field_Contract {
      * @return void
      */
     public function render( $field_settings, $form_id, $type = 'post', $post_id = null ) {
-        $has_images         = false;
+        $has_images = false;
 
-        if ( isset( $post_id ) && $post_id != '0' ) {
+        if ( isset( $post_id ) && $post_id !== 0 ) {
             $images = $this->get_meta( $post_id, $field_settings['name'], $type, false );
 
-            if ( $this->is_meta( $field_settings ) && ! empty( $images[0] ) ) {   
-                             
+            if ( $this->is_meta( $field_settings ) && ! empty( $images[0] ) ) {
                 if ( is_serialized( $images[0] ) ) {
                     $images = maybe_unserialize( $images[0] );
                 }
@@ -37,8 +35,8 @@ class WPUF_Form_Field_Image extends WPUF_Field_Contract {
                 if ( is_array( $images[0] ) ) {
                     $images = $images[0];
                 }
-                
-                $has_images         = true;
+
+                $has_images = true;
             }
         }
 
@@ -61,7 +59,8 @@ class WPUF_Form_Field_Image extends WPUF_Field_Contract {
                                 foreach ( $images as $attach_id ) {
                                     echo WPUF_Upload::attach_html( $attach_id, $field_settings['name'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
                                 }
-                            } ?>
+                            }
+                            ?>
                         </ul>
                     </div>
                 </div><!-- .container -->
@@ -80,7 +79,8 @@ class WPUF_Form_Field_Image extends WPUF_Field_Contract {
             </script>
 
 
-        <?php $this->after_field_print_label();
+        <?php
+        $this->after_field_print_label();
     }
 
     /**
@@ -89,7 +89,7 @@ class WPUF_Form_Field_Image extends WPUF_Field_Contract {
      * @return array
      */
     public function get_options_settings() {
-        $default_options      = $this->get_default_option_settings( true, ['dynamic', 'width'] ); // exclude dynamic
+        $default_options = $this->get_default_option_settings( true, [ 'dynamic', 'width' ] ); // exclude dynamic
 
         $settings = [
             [
@@ -157,6 +157,6 @@ class WPUF_Form_Field_Image extends WPUF_Field_Contract {
 
         $wpuf_files = isset( $_POST['wpuf_files'] ) ? array_map( 'sanitize_text_field', wp_unslash( $_POST['wpuf_files'] ) ) : [];
 
-        return isset( $wpuf_files[$field['name']] ) ? $wpuf_files[$field['name']] : [];
+        return isset( $wpuf_files[ $field['name'] ] ) ? $wpuf_files[ $field['name'] ] : [];
     }
 }

--- a/includes/fields/class-field-image.php
+++ b/includes/fields/class-field-image.php
@@ -1,3 +1,4 @@
+
 <?php
 
 /**
@@ -25,18 +26,18 @@ class WPUF_Form_Field_Image extends WPUF_Field_Contract {
         $has_images         = false;
 
         if ( isset( $post_id ) && $post_id != '0' ) {
-            if ( $this->is_meta( $field_settings ) ) {
-                $images = $this->get_meta( $post_id, $field_settings['name'], $type, false );
+            $images = $this->get_meta( $post_id, $field_settings['name'], $type, false );
 
-                if ( $images ) {
-                    if ( is_serialized( $images[0] ) ) {
-                        $images = maybe_unserialize( $images[0] );
-                    }
-
-                    if ( is_array( $images[0] ) ) {
-                        $images = $images[0];
-                    }
+            if ( $this->is_meta( $field_settings ) && ! empty( $images[0] ) ) {   
+                             
+                if ( is_serialized( $images[0] ) ) {
+                    $images = maybe_unserialize( $images[0] );
                 }
+
+                if ( is_array( $images[0] ) ) {
+                    $images = $images[0];
+                }
+                
                 $has_images         = true;
             }
         }


### PR DESCRIPTION
If make a compatible image field with acf image field, then update the post from backend keep empty the image field it shows a default image in frontend post edit form.

Fix: #945