### PR TITLE
70% width is affecting HTML content field's width

### DIFF
--- a/assets/css/frontend-forms.css
+++ b/assets/css/frontend-forms.css
@@ -244,7 +244,7 @@ ul.wpuf-form li.field-size-small .wpuf-fields {
 }
 ul.wpuf-form li .wpuf-fields {
   float: left;
-  width: 70%;
+  width: fit-content;
 }
 ul.wpuf-form li .wpuf-fields .wpuf-radio-inline,
 ul.wpuf-form li .wpuf-fields .wpuf-checkbox-inline {


### PR DESCRIPTION
Though there is no extra class or input type selector to select custom_html field, it's inheriting the initial width as 70% from [backend form builder](http://prntscr.com/vlors6) and [frontend preview/post page](http://prntscr.com/vlot1c). However, assigning width: 100%, fit-content, or auto; showing as it should be for the custom_html field.