### PR TITLE
Popup has a chance to get off-focus with a few 3rd party themes due to lower z-index

### DIFF
--- a/assets/vendor/sweetalert2/dist/sweetalert2.css
+++ b/assets/vendor/sweetalert2/dist/sweetalert2.css
@@ -20,7 +20,7 @@ body.swal2-iosfix {
   right: 0;
   padding: 10px;
   background-color: transparent;
-  z-index: 1060; }
+  z-index: 999; }
   .swal2-container.swal2-fade {
     -webkit-transition: background-color .1s;
     transition: background-color .1s; }


### PR DESCRIPTION
If there are no consequences, can we increase the z-index? As I found, the popup message is not showing with a third-party theme of a user.