### PR TITLE
ignore all payment option if enable payments unchecked

### DIFF
--- a/admin/form-builder/assets/js/form-builder.js
+++ b/admin/form-builder/assets/js/form-builder.js
@@ -177,7 +177,7 @@
                             if (result) {
                                 state.show_custom_field_tooltip = false;
                             } else {
-                                
+
                             }
                         } );
                     }
@@ -672,10 +672,9 @@
             if ( $(this).is(':checked') ) {
                 table.find('tr.show-if-payment').show();
                 table.find('tr.show-if-force-pack').hide();
-
             } else {
                 table.find('tr.show-if-payment').hide();
-
+                table.find('input[type=checkbox]').removeAttr('checked');
             }
         },
 

--- a/assets/js/wpuf-form-builder.js
+++ b/assets/js/wpuf-form-builder.js
@@ -177,7 +177,7 @@
                             if (result) {
                                 state.show_custom_field_tooltip = false;
                             } else {
-                                
+
                             }
                         } );
                     }
@@ -672,10 +672,9 @@
             if ( $(this).is(':checked') ) {
                 table.find('tr.show-if-payment').show();
                 table.find('tr.show-if-force-pack').hide();
-
             } else {
                 table.find('tr.show-if-payment').hide();
-
+                table.find('input[type=checkbox]').removeAttr('checked');
             }
         },
 


### PR DESCRIPTION
Even though I had ‘Enable Payments’ unchecked, hidden below that I had ‘Enable Pay per post’ checked. Maybe it would be a good idea to ignore this setting if ‘Enable Payments’ is unchecked.