### PR TITLE
Fixed new constructor error

### DIFF
--- a/assets/js/wpuf-form-builder-components.js
+++ b/assets/js/wpuf-form-builder-components.js
@@ -104,7 +104,7 @@ Vue.component('builder-stage', {
 
             // check if these are already inserted
             if ( this.isSingleInstance( field.template ) && this.containsField( field.template ) ) {
-                swal({
+                new swal({
                     title: "Oops...",
                     text: "You already have this field in the form"
                 });
@@ -117,7 +117,7 @@ Vue.component('builder-stage', {
         delete_field: function(index) {
             var self = this;
 
-            swal({
+            new swal({
                 text: self.i18n.delete_field_warn_msg,
                 type: 'warning',
                 showCancelButton: true,
@@ -945,7 +945,7 @@ Vue.component('form-column_field', {
             };
 
             if (this.isAllowedInClolumnField(data.field_template)) {
-                swal({
+                new swal({
                     title: "Oops...",
                     text: "You cannot add this field as inner column field"
                 });
@@ -954,7 +954,7 @@ Vue.component('form-column_field', {
 
             // check if these are already inserted
             if ( this.isSingleInstance( data.field_template ) && this.containsField( data.field_template ) ) {
-                swal({
+                new swal({
                     title: "Oops...",
                     text: "You already have this field in the form"
                 });
@@ -1022,7 +1022,7 @@ Vue.component('form-column_field', {
 
             // check if the field is allowed to duplicate
             if ( self.isSingleInstance( field.template ) ) {
-                swal({
+                new swal({
                     title: "Oops...",
                     text: "You already have this field in the form"
                 });
@@ -1040,7 +1040,7 @@ Vue.component('form-column_field', {
                     fromColumn: fromColumn
                 };
 
-            swal({
+            new swal({
                 text: self.i18n.delete_field_warn_msg,
                 type: 'warning',
                 showCancelButton: true,
@@ -1263,7 +1263,7 @@ Vue.component('form-fields', {
         alert_pro_feature: function (field) {
             var title = this.field_settings[field].title;
 
-            swal({
+            new swal({
                 title: '<i class="fa fa-lock"></i> ' + title + ' <br>' + this.i18n.is_a_pro_feature,
                 text: this.i18n.pro_feature_msg,
                 type: '',

--- a/assets/js/wpuf-form-builder.js
+++ b/assets/js/wpuf-form-builder.js
@@ -163,7 +163,7 @@
                             html      += '<img src="' + image_two + '" alt="custom field data">';
                             html      += '</div>';
                             html      += '</div>';
-                        swal({
+                        new swal({
                             title: __( 'Do you want to show custom field data inside your post ?', 'wp-user-frontend' ),
                             html: html,
                             showCancelButton: true,


### PR DESCRIPTION
This fixes an error in the Javascript where it will not allow you to call `swal` without `new`. This error was preventing any popups from showing. Adding the `new` keyword fixes this error.