### PR TITLE
Add is_array validation on checkbox at class-frontend-render-form

### DIFF
--- a/includes/class-frontend-render-form.php
+++ b/includes/class-frontend-render-form.php
@@ -815,7 +815,7 @@ class WPUF_Frontend_Render_Form {
                     break;
 
                 case 'checkbox':
-                    if ( count( $value_name ) > 1 ) {
+                    if ( is_array( $value_name ) && count( $value_name ) > 1 ) {
                         $meta_key_value[ $value['name'] ] = implode( self::$separator, $value_name );
                     } else {
                         $meta_key_value[ $value['name'] ] = $value_name[0];


### PR DESCRIPTION
Hi,

I ran into an issue on a project of mine which I fixed with this pull request. It simply adds `is_array( $value_name )` to the if-condition, I'd suggest `is_countable()` but you would have to update your required PHP version to 7.3.0.

Hope I helped you with this and hopefully it will be merged soon.