### PR TITLE
fix: All label added for transactions page

### DIFF
--- a/assets/js/frontend-form.js
+++ b/assets/js/frontend-form.js
@@ -324,7 +324,7 @@
         removeField: function() {
             //check if it's the only item
             var $parent = $(this).closest('tr');
-            var items = $parent.siblings().andSelf().length;
+            var items = $parent.siblings().addBack().length;
 
             if( items > 1 ) {
                 $parent.remove();

--- a/class/transactions-list-table.php
+++ b/class/transactions-list-table.php
@@ -82,13 +82,33 @@ class WPUF_Transactions_List_Table extends WP_List_Table {
         $status_links = [];
         $base_link    = admin_url( 'admin.php?page=wpuf_transaction' );
 
-        $transactions_count         = wpuf_get_transactions( [ 'count' => true ] );
+        $transactions_completed_count = wpuf_get_completed_transactions( [ 'count' => true ] );
         $transactions_pending_count = wpuf_get_pending_transactions( [ 'count' => true ] );
+        $transactions_total_count = $transactions_completed_count + $transactions_pending_count;
 
         $status = isset( $_REQUEST['status'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['status'] ) ) : 'all';
 
-        $status_links['all']     = sprintf( '<a href="%s" class="%s">%s <span class="count">(%s)</span></a>', add_query_arg( [ 'status' => 'all' ], $base_link ), ( $status === 'all' ) ? 'current' : '', __( 'All', 'wp-user-frontend' ), $transactions_count );
-        $status_links['pending'] = sprintf( '<a href="%s" class="%s">%s <span class="count">(%s)</span></a>', add_query_arg( [ 'status' => 'pending' ], $base_link ), ( $status === 'pending' ) ? 'current' : '', __( 'Pending', 'wp-user-frontend' ), $transactions_pending_count );
+        $status_links['all'] = sprintf(
+            '<a href="%s" class="%s">%s <span class="count">(%s)</span></a>',
+            add_query_arg( [ 'status' => 'all' ], $base_link ),
+            ( 'all' === $status ) ? 'current' : '',
+            __( 'All', 'wp-user-frontend' ),
+            $transactions_total_count
+        );
+        $status_links['completed'] = sprintf(
+            '<a href="%s" class="%s">%s <span class="count">(%s)</span></a>',
+            add_query_arg( [ 'status' => 'completed' ], $base_link ),
+            ( 'completed' === $status ) ? 'current' : '',
+            __( 'Completed', 'wp-user-frontend' ),
+            $transactions_completed_count
+        );
+        $status_links['pending'] = sprintf(
+            '<a href="%s" class="%s">%s <span class="count">(%s)</span></a>',
+            add_query_arg( [ 'status' => 'pending' ], $base_link ),
+            ( 'pending' === $status ) ? 'current' : '',
+            __( 'Pending', 'wp-user-frontend' ),
+            $transactions_pending_count
+        );
 
         return $status_links;
     }
@@ -214,10 +234,12 @@ class WPUF_Transactions_List_Table extends WP_List_Table {
 
         $status = isset( $_REQUEST['status'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['status'] ) ) : 'all';
 
-        if ( $status === 'pending' ) {
+        if ( 'pending' === $status ) {
             $total_items = wpuf_get_pending_transactions( [ 'count' => true ] );
+        } elseif ( 'completed' === $status ) {
+            $total_items = wpuf_get_completed_transactions( [ 'count' => true ] );
         } else {
-            $total_items = wpuf_get_transactions( [ 'count' => true ] );
+            $total_items = wpuf_get_all_transactions( [ 'count' => true ] );
         }
 
         $this->set_pagination_args(
@@ -243,10 +265,12 @@ class WPUF_Transactions_List_Table extends WP_List_Table {
             $args['order']   = sanitize_text_field( wp_unslash( $_REQUEST['order'] ) );
         }
 
-        if ( $status === 'pending' ) {
+        if ( 'pending' === $status ) {
             $this->items = wpuf_get_pending_transactions( $args );
+        } elseif ( 'completed' === $status ) {
+            $this->items = wpuf_get_completed_transactions( $args );
         } else {
-            $this->items = wpuf_get_transactions( $args );
+            $this->items = wpuf_get_all_transactions( $args );
         }
     }
 

--- a/class/transactions-list-table.php
+++ b/class/transactions-list-table.php
@@ -126,10 +126,9 @@ class WPUF_Transactions_List_Table extends WP_List_Table {
         $delete_nonce = wp_create_nonce( 'wpuf-delete-transaction' );
         $title        = '<strong>#' . $id . '</strong>';
 
-        $status = isset( $_REQUEST['status'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['status'] ) ) : '';
         $page = isset( $_REQUEST['page'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['page'] ) ) : '';
 
-        if ( $status === 'pending' ) {
+        if ( 'pending' === $item->status ) {
             $accept_nonce = wp_create_nonce( 'wpuf-accept-transaction' );
             $reject_nonce = wp_create_nonce( 'wpuf-reject-transaction' );
 
@@ -208,16 +207,20 @@ class WPUF_Transactions_List_Table extends WP_List_Table {
      */
     public function get_bulk_actions() {
         $status = isset( $_REQUEST['status'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['status'] ) ) : '';
+        $completed_action = [
+            'bulk-delete' => __( 'Delete', 'wp-user-frontend' ),
+        ];
+        $pending_action = [
+            'bulk-accept' => __( 'Accept', 'wp-user-frontend' ),
+            'bulk-reject' => __( 'Reject', 'wp-user-frontend' ),
+        ];
 
-        if ( $status === 'pending' ) {
-            $actions = [
-                'bulk-accept' => __( 'Accept', 'wp-user-frontend' ),
-                'bulk-reject' => __( 'Reject', 'wp-user-frontend' ),
-            ];
+        if ( 'pending' === $status ) {
+            $actions = $pending_action;
+        } elseif ( 'completed' === $status ) {
+            $actions = $completed_action;
         } else {
-            $actions = [
-                'bulk-delete' => __( 'Delete', 'wp-user-frontend' ),
-            ];
+            $actions = array_merge( $completed_action, $pending_action );
         }
 
         return $actions;

--- a/wpuf-functions.php
+++ b/wpuf-functions.php
@@ -2190,6 +2190,8 @@ function wpuf_get_all_transactions( $args = [] ) {
         );
     }
 
+    // get all the completed transaction from transaction table
+    // and pending transaction from post table
     $transactions = $wpdb->get_results(
             "(SELECT id, user_id, status, tax, cost, post_id, pack_id, payer_first_name, payer_last_name, payer_email, payment_type, transaction_id, created FROM {$transaction_table})
             UNION ALL
@@ -2208,12 +2210,14 @@ function wpuf_get_all_transactions( $args = [] ) {
             continue;
         }
 
+        // get metadata for pending transactions
         $info = get_post_meta( $transaction->id, '_data', true );
         $payment_method = isset( $info['post_data']['wpuf_payment_method'] ) ? $info['post_data']['wpuf_payment_method'] : '';
 
         $type = isset( $info['type'] ) ? $info['type'] : '';
         $item_number = isset( $info['item_number'] ) ? $info['item_number'] : 0;
 
+        // attach data to pending transactions
         $transaction->user_id          = isset( $info['user_info']['id'] ) ? $info['user_info']['id'] : 0;
         $transaction->status           = 'pending';
         $transaction->cost             = isset( $info['price'] ) ? $info['price'] : 0;


### PR DESCRIPTION
In WP Dashboard > User Frontend > Transaction, new label added as 'All'.
A JS deprecated function is replaced (not related to this issue).
fix [#216](https://github.com/weDevsOfficial/wpuf-pro/issues/216) (in pro)