### PR TITLE
Redundant CSS with the default T&C field's meta causing the checkbox invisible

### DIFF
--- a/assets/css/frontend-forms.css
+++ b/assets/css/frontend-forms.css
@@ -1809,6 +1809,3 @@ body .wpuf-attachment-upload-filelist + .moxie-shim {
   margin-top: 10px;
   cursor: pointer;
 }
-.wpuf-el.terms_and_conditions label > input[type=checkbox] {
-  width: 0 !important;
-}

--- a/assets/less/frontend-forms.less
+++ b/assets/less/frontend-forms.less
@@ -2096,6 +2096,3 @@ ul.wpuf-form{
 #wpuf-delete-msg span{
     margin-top: 10px;cursor: pointer
 }
-.wpuf-el.terms_and_conditions  label > input[type=checkbox]{
-    width: 0 !important;
-}


### PR DESCRIPTION
Invalid predefined (!important) width causing the T&C checkbox invisible for default "terms_and_conditions" meta ([https://prnt.sc/22rav3a](https://prnt.sc/22rav3a)). You need to change the default meta_key of the T&C field to make the checkbox visible on the frontend.