### PR TITLE
fix: Reset password message requesting from AJAX

### DIFF
--- a/assets/js/wpuf-login-widget.js
+++ b/assets/js/wpuf-login-widget.js
@@ -58,6 +58,7 @@ jQuery( function($) {
         })
         .done( function( response, textStatus, jqXHR ) {
             $('.wpuf-ajax-reset-password-form .wpuf-ajax-message p').html(response.data.message);
+            $('.wpuf-ajax-reset-password-form .wpuf-ajax-message').addClass('wpuf-message');
         } )
         .fail( function( jqXHR, textStatus, errorThrown ) {
             console.log( 'AJAX failed', errorThrown );

--- a/includes/free/class-login.php
+++ b/includes/free/class-login.php
@@ -614,6 +614,11 @@ class WPUF_Simple_Login {
             return;
         }
 
+        // request coming from ajax call, example: sidebar widget
+        if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+            return;
+        }
+
         // process lost password form
         if ( isset( $_POST['user_login'] ) && isset( $_POST['_wpnonce'] ) ) {
             $nonce = sanitize_key( wp_unslash( $_POST['_wpnonce'] ) );


### PR DESCRIPTION
Reset password message now showing when request coming from AJAX, such as sidebar widget.
fix #1244 