### PR TITLE
Redirection added for bank payment success page

### DIFF
--- a/wpuf-functions.php
+++ b/wpuf-functions.php
@@ -4074,7 +4074,15 @@ function wpuf_payment_success_page( $data ){
     $gateway          = ! empty( $data['wpuf_payment_method'] ) ? $data['wpuf_payment_method'] : '';
     $success_query    = "wpuf_${gateway}_success";
     $redirect_page    = '';
-    $redirect_page_id = wpuf_get_option( 'payment_success', 'wpuf_payment' );
+    $redirect_page_id = 0;
+    $payment_method   = ! empty( $data['post_data']['wpuf_payment_method'] ) ? $data['post_data']['wpuf_payment_method'] : '';
+
+    if ( 'bank' === $payment_method ) {
+        $redirect_page_id = wpuf_get_option( 'bank_success', 'wpuf_payment' );
+    } else {
+        $redirect_page_id = wpuf_get_option( 'payment_success', 'wpuf_payment' );
+    }
+
     if ( 'post' === $data['type'] ){
         $post_id           = array_key_exists( 'item_number', $data ) && ! empty( $data['item_number'] ) ? $data['item_number'] : $_GET['post_id'];
         $form_id           = get_post_meta( $post_id, '_wpuf_form_id', true );


### PR DESCRIPTION
The `Bank Payment Success Page` redirection setting was not working as expected. It’s honoring the `Payment Success Page` redirection instead the `Bank Payment Success Page` redirection.

We have two success pages for the Payment procedure.
1. The `Payment Success Page` which is for the online payment gateways (Stripe and Credit cards)
2. The `Bank Payment Success Page` is for the `Bank Payment/Manual-Offline payment` method.

However, in both cases, it honors the first option `Payment Success Page.`

[Problem video here](https://somup.com/c31rFMtdNA)

**Expected behavior:**
If you select the `Bank Payment` option during the purchase of the subscription it should redirect you to the 2nd option called `Bank Payment Success Page`.

Now the redirection priority is as followed from the top priority:

1. Payment Success Page from form settings
2. Bank Payment Success Page from WPUF settings > Payment (if Bank Payment Success Page is defined in settings and user paid via bank)
3. Payment Success Page from WPUF settings > Payment

