### PR TITLE
Custom hook used to load form builder

### DIFF
--- a/admin/class-admin-settings.php
+++ b/admin/class-admin-settings.php
@@ -137,6 +137,11 @@ class WPUF_Admin_Settings {
      * Fire when post form submenu registered
      */
     public function post_form_menu_action() {
+        /**
+         * Fires before a single post form page is loaded
+         *
+         * @since 3.5.27
+         */
         do_action( 'wpuf_load_post_forms' );
     }
 

--- a/admin/class-admin-settings.php
+++ b/admin/class-admin-settings.php
@@ -90,7 +90,7 @@ class WPUF_Admin_Settings {
         $this->menu_pages[] = $post_form_submenu;
 
         add_action( "load-$post_form_submenu", [ $this, 'post_form_menu_action' ] );
-	
+
 	remove_submenu_page( 'wp-user-frontend', 'wp-user-frontend' );
 
         /*
@@ -137,7 +137,7 @@ class WPUF_Admin_Settings {
      * Fire when post form submenu registered
      */
     public function post_form_menu_action() {
-        do_action('wpuf_load_post_forms');
+        do_action( 'wpuf_load_post_forms' );
     }
 
     /**

--- a/admin/form-handler.php
+++ b/admin/form-handler.php
@@ -4,8 +4,8 @@ class WPUF_Admin_Form_Handler {
 
     public function __construct() {
         // post forms list table
-        add_action( "wpuf_load_post_forms", [ $this, 'post_forms_actions' ] );
-        add_action( "wpuf_load_profile_forms", [ $this, 'profile_forms_actions' ] );
+        add_action( 'wpuf_load_post_forms', [ $this, 'post_forms_actions' ] );
+        add_action( 'wpuf_load_profile_forms', [ $this, 'profile_forms_actions' ] );
         add_action( 'admin_notices', [ $this, 'admin_notices' ] );
         add_action( 'removable_query_args', [ $this, 'removable_query_args' ] );
     }

--- a/admin/form.php
+++ b/admin/form.php
@@ -32,8 +32,7 @@ class WPUF_Admin_Form {
     public function __construct() {
         add_action( 'init', [$this, 'register_post_type'] );
 
-        $label = strtolower( preg_replace( '/\s/', '-$1', __( 'User Frontend', 'wp-user-frontend' ) ) );
-        add_action( "load-${label}_page_wpuf-post-forms", [ $this, 'post_forms_builder_init' ] );
+        add_action( 'wpuf_load_post_forms', [ $this, 'post_forms_builder_init' ] );
     }
 
     /**


### PR DESCRIPTION
We were using a dynamic hook depending on the menu title. If the title got translated, the hook doesn't work for some languages(Español, Türkçe, Arabic, etc.) and shows a blank post form.

We introduced 2 hooks `wpuf_load_post_forms` and `wpuf_load_profile_forms` earlier and now using those hooks to load our form builder