### PR TITLE
Fix: style conflict with LearnPress

### DIFF
--- a/admin/form-builder/assets/less/form-builder.less
+++ b/admin/form-builder/assets/less/form-builder.less
@@ -867,6 +867,12 @@
                 }
             }
         }
+
+        /* fix for conflict with LearnPress */
+        ul li.clearfix{
+            opacity: initial;
+            height: initial;
+        }
     }
 }
 

--- a/admin/form-builder/assets/less/form-builder.less
+++ b/admin/form-builder/assets/less/form-builder.less
@@ -867,12 +867,6 @@
                 }
             }
         }
-
-        /* fix for conflict with LearnPress */
-        ul li.clearfix{
-            opacity: initial;
-            height: initial;
-        }
     }
 }
 

--- a/admin/form-builder/class-wpuf-admin-form-builder.php
+++ b/admin/form-builder/class-wpuf-admin-form-builder.php
@@ -88,8 +88,6 @@ class WPUF_Admin_Form_Builder {
             'wpuf-css', 'wpuf-font-awesome', 'wpuf-sweetalert2', 'wpuf-selectize', 'wpuf-toastr', 'wpuf-tooltip',
         ] );
 
-        wp_enqueue_style( 'wpuf-form-builder', WPUF_ASSET_URI . '/css/wpuf-form-builder.css', $form_builder_css_deps, WPUF_VERSION );
-
         wp_enqueue_style( 'jquery-ui', WPUF_ASSET_URI . '/css/jquery-ui-1.9.1.custom.css' );
 
         do_action( 'wpuf-form-builder-enqueue-style' );

--- a/admin/form-template.php
+++ b/admin/form-template.php
@@ -11,6 +11,7 @@ class WPUF_Admin_Form_Template {
 
     public function __construct() {
         add_action( 'admin_enqueue_scripts', [$this, 'enqueue_scripts'] );
+        add_action( 'admin_enqueue_scripts', [ $this, 'deregister_scripts' ], 99 );
 
         // post form templates
         add_action( 'admin_footer', [ $this, 'render_post_form_templates' ] );
@@ -22,6 +23,32 @@ class WPUF_Admin_Form_Template {
         // frontend insert/update
         add_action( 'wpuf_add_post_after_insert', [ $this, 'post_form_submission' ], 10, 3 );
         add_action( 'wpuf_edit_post_after_update', [ $this, 'post_form_submission' ], 10, 3 );
+    }
+
+    /**
+     * Deregister conflicting JS and CSS files of other plugins
+     *
+     * @since WPUF_SINCE
+     *
+     * @return void
+     */
+    public function deregister_scripts() {
+        global $wp_styles;
+
+        $current_screen = get_current_screen();
+
+        if ( ! in_array( $current_screen->id, [ 'user-frontend_page_wpuf-post-forms' ] ) ) {
+            return;
+        }
+
+        $sources = wp_list_pluck( $wp_styles->registered, 'src' );
+
+        // Look for any pre-existing learn-press style
+        $result = array_key_exists( 'learn-press-admin', $sources );
+
+        if ( $result ) {
+            wp_deregister_style( 'learn-press-admin' );
+        }
     }
 
     /**

--- a/assets/less/frontend-forms.less
+++ b/assets/less/frontend-forms.less
@@ -5,7 +5,6 @@
 @mediaMD: 1200px;
 /* DivTable.com */
 body {
-    font-family: 'Open Sans', sans-serif;
 #wpfooter {
     position: fixed  !important
 }
@@ -1375,7 +1374,6 @@ body.rtl{
     }
 }
 .wpuf-dashboard-container {
-    font-family: 'Open Sans', sans-serif;
     max-width: 85rem !important;
     .clearfix();
     .wpuf-dashboard-navigation {
@@ -1385,7 +1383,6 @@ body.rtl{
         a {
             text-decoration: none;
             box-shadow: none;
-            font-family: 'Open Sans', sans-serif;
             font-size: 16px;
             font-weight: bold;
             color: #000;
@@ -1450,7 +1447,6 @@ body.rtl{
         width: 100%;
         margin-top: 0px;
         border: 1.0218px solid #DAE1F5;
-        font-family: 'Open Sans', sans-serif !important;
         color: #000 !important;
         font-size: 16px !important;
         font-weight: 400 !important;
@@ -1659,7 +1655,6 @@ input[type="text"].wpuf-google-map-search {
     background-color: #fff !important;
     text-overflow: ellipsis !important;
     width: 170px !important;
-    font-family: Roboto !important;
     font-size: 15px !important;
     font-weight: 300 !important;
     padding: 0 11px 0 13px !important;


### PR DESCRIPTION
1. Dropdown item options were not showing when LearnPress is installed.
2. `wpuf-form-builder.css` was loading multiple times
3. removed `font-family` assigning style from WPUF. font-family should come from the theme or WP core.

**How to reproduce:**
1. Install & Activate WP User Frontend free plugin
2. Install & Activate the Learnpress LMS plugin: https://wordpress.org/plugins/learnpress/
3. Add a dropdown field on the post form > Edit dropdown field > Field options > Item Options not appearing

Necessary [Screenshot](https://prnt.sc/tsFeCc9judL_)