### PR TITLE
fix: [wpuf-registration] short-code encryption update

### DIFF
--- a/class/encryption-helper.php
+++ b/class/encryption-helper.php
@@ -1,0 +1,45 @@
+<?php
+
+class WPUF_Encryption_Helper {
+
+    public static function get_encryption_method() {
+        return 'AES-256-CBC';
+    }
+
+    public static function get_encryption_nonce_length() {
+        return function_exists( 'sodium_crypto_secretbox' ) ? SODIUM_CRYPTO_SECRETBOX_NONCEBYTES : openssl_cipher_iv_length( self::get_encryption_method() );
+    }
+
+    public static function get_encryption_key_length() {
+        return function_exists( 'sodium_crypto_secretbox' ) ? SODIUM_CRYPTO_SECRETBOX_KEYBYTES : 32;
+    }
+
+    /**
+     * @return array
+     * @throws Exception
+     */
+    public static function get_encryption_auth_keys() {
+        $defaults = [
+            'auth_key'          => '',
+            'auth_salt'         => '',
+        ];
+        $auth_keys = get_option( 'wpuf_auth_keys', $defaults );
+
+        if ( empty( $auth_keys['auth_key'] ) || empty( $auth_keys['auth_salt'] ) ) {
+            // check for saved key
+            $key = random_bytes( self::get_encryption_key_length() );
+            $auth_keys['auth_key'] = base64_encode( $key );
+
+            // check for saved nonce
+            $nonce = random_bytes( self::get_encryption_nonce_length() );
+            $auth_keys['auth_salt'] = base64_encode( $nonce );
+
+            update_option( 'wpuf_auth_keys', $auth_keys );
+        }
+
+        return [
+            'auth_key'  => base64_decode( $auth_keys['auth_key'] ),
+            'auth_salt' => base64_decode( $auth_keys['auth_salt'] )
+        ];
+    }
+}

--- a/class/encryption-helper.php
+++ b/class/encryption-helper.php
@@ -58,18 +58,18 @@ class WPUF_Encryption_Helper {
         if ( empty( $auth_keys['auth_key'] ) || empty( $auth_keys['auth_salt'] ) ) {
             // check for saved key
             $key                   = random_bytes( self::get_encryption_key_length() );
-            $auth_keys['auth_key'] = base64_encode( $key );
+            $auth_keys['auth_key'] = base64_encode( $key );    // phpcs:ignore
 
             // check for saved nonce
             $nonce                  = random_bytes( self::get_encryption_nonce_length() );
-            $auth_keys['auth_salt'] = base64_encode( $nonce );
+            $auth_keys['auth_salt'] = base64_encode( $nonce );    // phpcs:ignore
 
             update_option( 'wpuf_auth_keys', $auth_keys );
         }
 
         return [
-            'auth_key'  => base64_decode( $auth_keys['auth_key'] ),
-            'auth_salt' => base64_decode( $auth_keys['auth_salt'] ),
+            'auth_key'  => base64_decode( $auth_keys['auth_key'] ),    // phpcs:ignore
+            'auth_salt' => base64_decode( $auth_keys['auth_salt'] ),    // phpcs:ignore
         ];
     }
 }

--- a/class/encryption-helper.php
+++ b/class/encryption-helper.php
@@ -1,37 +1,67 @@
 <?php
+/**
+ * The WPUF_Encryption_Helper Class to handle the encryption
+ */
 
 class WPUF_Encryption_Helper {
 
+    /**
+     * Get the Advanced Encryption Standard we are using
+     *
+     * @since WPUF
+     *
+     * @return string
+     */
     public static function get_encryption_method() {
         return 'AES-256-CBC';
     }
 
+    /**
+     * Get the nonce length for the encryption
+     * Returns 24 If PHP version is 7.2 or above.
+     * For PHP version below 7.2 it will send the length as per the encryption method.
+     *
+     * @since WPUF
+     *
+     * @return int|bool
+     */
     public static function get_encryption_nonce_length() {
         return function_exists( 'sodium_crypto_secretbox' ) ? SODIUM_CRYPTO_SECRETBOX_NONCEBYTES : openssl_cipher_iv_length( self::get_encryption_method() );
     }
 
+    /**
+     * Get the encryption key length. Defaults to 32
+     *
+     * @since WPUF
+     *
+     * @return int
+     */
     public static function get_encryption_key_length() {
         return function_exists( 'sodium_crypto_secretbox' ) ? SODIUM_CRYPTO_SECRETBOX_KEYBYTES : 32;
     }
 
     /**
+     * Get the base64 encoded auth keys
+     *
+     * @since WPUF
+     *
      * @return array
      * @throws Exception
      */
     public static function get_encryption_auth_keys() {
         $defaults = [
-            'auth_key'          => '',
-            'auth_salt'         => '',
+            'auth_key'  => '',
+            'auth_salt' => '',
         ];
         $auth_keys = get_option( 'wpuf_auth_keys', $defaults );
 
         if ( empty( $auth_keys['auth_key'] ) || empty( $auth_keys['auth_salt'] ) ) {
             // check for saved key
-            $key = random_bytes( self::get_encryption_key_length() );
+            $key                   = random_bytes( self::get_encryption_key_length() );
             $auth_keys['auth_key'] = base64_encode( $key );
 
             // check for saved nonce
-            $nonce = random_bytes( self::get_encryption_nonce_length() );
+            $nonce                  = random_bytes( self::get_encryption_nonce_length() );
             $auth_keys['auth_salt'] = base64_encode( $nonce );
 
             update_option( 'wpuf_auth_keys', $auth_keys );
@@ -39,7 +69,7 @@ class WPUF_Encryption_Helper {
 
         return [
             'auth_key'  => base64_decode( $auth_keys['auth_key'] ),
-            'auth_salt' => base64_decode( $auth_keys['auth_salt'] )
+            'auth_salt' => base64_decode( $auth_keys['auth_salt'] ),
         ];
     }
 }

--- a/includes/free/class-registration.php
+++ b/includes/free/class-registration.php
@@ -131,6 +131,16 @@ class WPUF_Registration {
      * @return string
      */
     public function registration_form( $atts ) {
+        $atts = shortcode_atts(
+            [
+                'role' => '',
+            ], $atts
+        );
+        $userrole = $atts['role'];
+
+        $user_nonce  = base64_encode( random_bytes( WPUF_Encryption_Helper::get_encryption_nonce_length() ) );
+        $roleencoded = base64_encode( wpuf_encryption( $userrole, $user_nonce ) );
+
         $reg_page = $this->get_registration_url();
 
         if ( false === $reg_page ) {
@@ -156,6 +166,8 @@ class WPUF_Registration {
 
             $args = [
                 'action_url' => add_query_arg( $queries, $reg_page ),
+                'userrole'   => $roleencoded,
+                'user_nonce' => $user_nonce,
             ];
 
             wpuf_load_template( 'registration-form.php', $args );
@@ -172,6 +184,7 @@ class WPUF_Registration {
     public function process_registration() {
         if ( ! empty( $_POST['wpuf_registration'] ) && ! empty( $_POST['_wpnonce'] ) ) {
             $userdata = [];
+            $user     = '';
 
             if ( isset( $_POST['_wpnonce'] ) ) {
                 $nonce = sanitize_key( wp_unslash( $_POST['_wpnonce'] ) );
@@ -180,12 +193,14 @@ class WPUF_Registration {
 
             $validation_error = new WP_Error();
 
-            $reg_fname = isset( $_POST['reg_fname'] ) ? sanitize_text_field( wp_unslash( $_POST['reg_fname'] ) ) : '';
-            $reg_lname = isset( $_POST['reg_lname'] ) ? sanitize_text_field( wp_unslash( $_POST['reg_lname'] ) ) : '';
-            $reg_email = isset( $_POST['reg_email'] ) ? sanitize_email( wp_unslash( $_POST['reg_email'] ) ) : '';
-            $pwd1      = isset( $_POST['pwd1'] ) ? sanitize_text_field( wp_unslash( $_POST['pwd1'] ) ) : '';
-            $pwd2      = isset( $_POST['pwd2'] ) ? sanitize_text_field( wp_unslash( $_POST['pwd2'] ) ) : '';
-            $log       = isset( $_POST['log'] ) ? sanitize_text_field( wp_unslash( $_POST['log'] ) ) : '';
+            $reg_fname  = isset( $_POST['reg_fname'] ) ? sanitize_text_field( wp_unslash( $_POST['reg_fname'] ) ) : '';
+            $reg_lname  = isset( $_POST['reg_lname'] ) ? sanitize_text_field( wp_unslash( $_POST['reg_lname'] ) ) : '';
+            $reg_email  = isset( $_POST['reg_email'] ) ? sanitize_email( wp_unslash( $_POST['reg_email'] ) ) : '';
+            $pwd1       = isset( $_POST['pwd1'] ) ? sanitize_text_field( wp_unslash( $_POST['pwd1'] ) ) : '';
+            $pwd2       = isset( $_POST['pwd2'] ) ? sanitize_text_field( wp_unslash( $_POST['pwd2'] ) ) : '';
+            $log        = isset( $_POST['log'] ) ? sanitize_text_field( wp_unslash( $_POST['log'] ) ) : '';
+            $urhidden   = isset( $_POST['urhidden'] ) ? sanitize_text_field( wp_unslash( $_POST['urhidden'] ) ) : '';
+            $user_nonce = isset( $_POST['user_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['user_nonce'] ) ) : '';
 
             $validation_error = apply_filters( 'wpuf_process_registration_errors', $validation_error, $reg_fname, $reg_lname, $reg_email, $log, $pwd1, $pwd2 );
 
@@ -259,10 +274,16 @@ class WPUF_Registration {
                 $userdata['user_login'] = $log;
             }
 
+            $dec_role = base64_decode( wpuf_decryption( $urhidden, $user_nonce ) );
+
             $userdata['first_name'] = $reg_fname;
             $userdata['last_name']  = $reg_lname;
             $userdata['user_email'] = $reg_email;
             $userdata['user_pass']  = $pwd1;
+
+            if ( get_role( $dec_role ) ) {
+                $userdata['role'] = empty( $dec_role ) || 'administrator' === $dec_role ? get_option( 'default_role' ) : $dec_role;
+            }
 
             $user = wp_insert_user( $userdata );
 

--- a/includes/free/class-registration.php
+++ b/includes/free/class-registration.php
@@ -139,7 +139,7 @@ class WPUF_Registration {
         $userrole = $atts['role'];
 
         $user_nonce  = base64_encode( random_bytes( WPUF_Encryption_Helper::get_encryption_nonce_length() ) );
-        $roleencoded = base64_encode( wpuf_encryption( $userrole, $user_nonce ) );
+        $roleencoded = wpuf_encryption( $userrole, $user_nonce );
 
         $reg_page = $this->get_registration_url();
 
@@ -274,8 +274,7 @@ class WPUF_Registration {
                 $userdata['user_login'] = $log;
             }
 
-            $dec_role = base64_decode( wpuf_decryption( $urhidden, $user_nonce ) );
-
+            $dec_role               = wpuf_decryption( $urhidden, $user_nonce );
             $userdata['first_name'] = $reg_fname;
             $userdata['last_name']  = $reg_lname;
             $userdata['user_email'] = $reg_email;

--- a/includes/free/class-registration.php
+++ b/includes/free/class-registration.php
@@ -131,15 +131,6 @@ class WPUF_Registration {
      * @return string
      */
     public function registration_form( $atts ) {
-        $atts = shortcode_atts(
-            [
-                'role' => '',
-            ], $atts
-        );
-        $userrole = $atts['role'];
-
-        $roleencoded = wpuf_encryption( $userrole );
-
         $reg_page = $this->get_registration_url();
 
         if ( false === $reg_page ) {
@@ -165,7 +156,6 @@ class WPUF_Registration {
 
             $args = [
                 'action_url' => add_query_arg( $queries, $reg_page ),
-                'userrole'   => $roleencoded,
             ];
 
             wpuf_load_template( 'registration-form.php', $args );
@@ -196,7 +186,6 @@ class WPUF_Registration {
             $pwd1      = isset( $_POST['pwd1'] ) ? sanitize_text_field( wp_unslash( $_POST['pwd1'] ) ) : '';
             $pwd2      = isset( $_POST['pwd2'] ) ? sanitize_text_field( wp_unslash( $_POST['pwd2'] ) ) : '';
             $log       = isset( $_POST['log'] ) ? sanitize_text_field( wp_unslash( $_POST['log'] ) ) : '';
-            $urhidden  = isset( $_POST['urhidden'] ) ? sanitize_text_field( wp_unslash( $_POST['urhidden'] ) ) : '';
 
             $validation_error = apply_filters( 'wpuf_process_registration_errors', $validation_error, $reg_fname, $reg_lname, $reg_email, $log, $pwd1, $pwd2 );
 
@@ -270,16 +259,10 @@ class WPUF_Registration {
                 $userdata['user_login'] = $log;
             }
 
-            $dec_role = wpuf_decryption( $urhidden );
-
             $userdata['first_name'] = $reg_fname;
             $userdata['last_name']  = $reg_lname;
             $userdata['user_email'] = $reg_email;
             $userdata['user_pass']  = $pwd1;
-
-            if ( get_role( $dec_role ) ) {
-                $userdata['role'] = $dec_role;
-            }
 
             $user = wp_insert_user( $userdata );
 

--- a/templates/registration-form.php
+++ b/templates/registration-form.php
@@ -73,7 +73,6 @@
 
             <li class="wpuf-submit">
                 <input type="submit" name="wp-submit" id="wp-submit" value="<?php echo esc_attr( 'Register', 'wp-user-frontend' ); ?>" />
-                <input type="hidden" name="urhidden" value=" <?php echo esc_attr( $userrole ); ?>" />
                 <input type="hidden" name="redirect_to" value="<?php echo esc_attr( wpuf()->registration->get_posted_value( 'redirect_to' ) ); ?>" />
                 <input type="hidden" name="wpuf_registration" value="true" />
                 <input type="hidden" name="action" value="registration" />

--- a/templates/registration-form.php
+++ b/templates/registration-form.php
@@ -73,6 +73,8 @@
 
             <li class="wpuf-submit">
                 <input type="submit" name="wp-submit" id="wp-submit" value="<?php echo esc_attr( 'Register', 'wp-user-frontend' ); ?>" />
+                <input type="hidden" name="urhidden" value="<?php echo esc_attr( $userrole ); ?>" />
+                <input type="hidden" name="user_nonce" value="<?php echo esc_attr( $user_nonce ); ?>" />
                 <input type="hidden" name="redirect_to" value="<?php echo esc_attr( wpuf()->registration->get_posted_value( 'redirect_to' ) ); ?>" />
                 <input type="hidden" name="wpuf_registration" value="true" />
                 <input type="hidden" name="action" value="registration" />

--- a/wpuf-functions.php
+++ b/wpuf-functions.php
@@ -3114,10 +3114,12 @@ add_filter( 'display_post_states', 'wpuf_admin_page_states', 10, 2 );
  * Encryption function for various usage
  *
  * @since 2.5.8
+ * @since WPUF param $nonce added
  *
  * @param string $id
+ * @param string $nonce
  *
- * @return string $encoded_id
+ * @return string|bool encoded string or false if encryption failed
  */
 function wpuf_encryption( $id, $nonce = null ) {
     $auth_keys = WPUF_Encryption_Helper::get_encryption_auth_keys();
@@ -3126,7 +3128,7 @@ function wpuf_encryption( $id, $nonce = null ) {
 
     if ( function_exists( 'sodium_crypto_secretbox' ) ) {
         try {
-            return sodium_crypto_secretbox( $id, $secret_iv, $secret_key );
+            return base64_encode( sodium_crypto_secretbox( $id, $secret_iv, $secret_key ) );
         } catch ( Exception $e ) {
             delete_option( 'wpuf_auth_keys' );
             return false;
@@ -3143,8 +3145,10 @@ function wpuf_encryption( $id, $nonce = null ) {
  * Decryption function for various usage
  *
  * @since 2.5.8
+ * @since WPUF param $nonce added
  *
  * @param string $id
+ * @param string $nonce
  *
  * @return string|bool decrypted string or false if decryption failed
  */
@@ -3161,7 +3165,7 @@ function wpuf_decryption( $id, $nonce = null ) {
     // should we use sodium_crypto_secretbox_open
     if ( function_exists( 'sodium_crypto_secretbox_open') ) {
         try {
-            return sodium_crypto_secretbox_open( $id, $secret_iv, $secret_key );
+            return sodium_crypto_secretbox_open( base64_decode( $id ), $secret_iv, $secret_key );
         } catch ( Exception $e ) {
             delete_option( 'wpuf_auth_keys' );
             return false;

--- a/wpuf-functions.php
+++ b/wpuf-functions.php
@@ -3122,7 +3122,7 @@ add_filter( 'display_post_states', 'wpuf_admin_page_states', 10, 2 );
  * @return string|bool encoded string or false if encryption failed
  */
 function wpuf_encryption( $id, $nonce = null ) {
-    $auth_keys = WPUF_Encryption_Helper::get_encryption_auth_keys();
+    $auth_keys  = WPUF_Encryption_Helper::get_encryption_auth_keys();
     $secret_key = $auth_keys['auth_key'];
     $secret_iv  = ! empty( $nonce ) ? base64_decode( $nonce ) : $auth_keys['auth_salt'];
 
@@ -3136,7 +3136,7 @@ function wpuf_encryption( $id, $nonce = null ) {
     }
 
     $ciphertext_raw = openssl_encrypt( $id, WPUF_Encryption_Helper::get_encryption_method(), $secret_key, OPENSSL_RAW_DATA, $secret_iv );
-    $hmac = hash_hmac( 'sha256', $ciphertext_raw, $secret_key, true );
+    $hmac           = hash_hmac( 'sha256', $ciphertext_raw, $secret_key, true );
 
     return base64_encode( $secret_iv.$hmac.$ciphertext_raw );
 }

--- a/wpuf-functions.php
+++ b/wpuf-functions.php
@@ -3119,16 +3119,24 @@ add_filter( 'display_post_states', 'wpuf_admin_page_states', 10, 2 );
  *
  * @return string $encoded_id
  */
-function wpuf_encryption( $id ) {
-    $secret_key     = AUTH_KEY;
-    $secret_iv      = AUTH_SALT;
+function wpuf_encryption( $id, $nonce = null ) {
+    $auth_keys = WPUF_Encryption_Helper::get_encryption_auth_keys();
+    $secret_key = $auth_keys['auth_key'];
+    $secret_iv  = ! empty( $nonce ) ? base64_decode( $nonce ) : $auth_keys['auth_salt'];
 
-    $encrypt_method = 'AES-256-CBC';
-    $key            = hash( 'sha256', $secret_key );
-    $iv             = substr( hash( 'sha256', $secret_iv ), 0, 16 );
-    $encoded_id     = base64_encode( openssl_encrypt( $id, $encrypt_method, $key, 0, $iv ) );
+    if ( function_exists( 'sodium_crypto_secretbox' ) ) {
+        try {
+            return sodium_crypto_secretbox( $id, $secret_iv, $secret_key );
+        } catch ( Exception $e ) {
+            delete_option( 'wpuf_auth_keys' );
+            return false;
+        }
+    }
 
-    return $encoded_id;
+    $ciphertext_raw = openssl_encrypt( $id, WPUF_Encryption_Helper::get_encryption_method(), $secret_key, OPENSSL_RAW_DATA, $secret_iv );
+    $hmac = hash_hmac( 'sha256', $ciphertext_raw, $secret_key, true );
+
+    return base64_encode( $secret_iv.$hmac.$ciphertext_raw );
 }
 
 /**
@@ -3138,18 +3146,42 @@ function wpuf_encryption( $id ) {
  *
  * @param string $id
  *
- * @return string $encoded_id
+ * @return string|bool decrypted string or false if decryption failed
  */
-function wpuf_decryption( $id ) {
-    $secret_key     = AUTH_KEY;
-    $secret_iv      = AUTH_SALT;
+function wpuf_decryption( $id, $nonce = null ) {
+    // get auth keys
+    $auth_keys = WPUF_Encryption_Helper::get_encryption_auth_keys();
+    if ( empty( $auth_keys ) ) {
+        return false;
+    }
 
-    $encrypt_method = 'AES-256-CBC';
-    $key            = hash( 'sha256', $secret_key );
-    $iv             = substr( hash( 'sha256', $secret_iv ), 0, 16 );
-    $decoded_id     = openssl_decrypt( base64_decode( $id ), $encrypt_method, $key, 0, $iv );
+    $secret_key = $auth_keys['auth_key'];
+    $secret_iv  = ! empty( $nonce ) ? base64_decode( $nonce ) : $auth_keys['auth_salt'];
 
-    return $decoded_id;
+    // should we use sodium_crypto_secretbox_open
+    if ( function_exists( 'sodium_crypto_secretbox_open') ) {
+        try {
+            return sodium_crypto_secretbox_open( $id, $secret_iv, $secret_key );
+        } catch ( Exception $e ) {
+            delete_option( 'wpuf_auth_keys' );
+            return false;
+        }
+    }
+
+    $c              = base64_decode( $id );
+    $ivlen          = WPUF_Encryption_Helper::get_encryption_nonce_length();
+    $secret_iv      = substr( $c, 0, $ivlen );
+    $hmac           = substr( $c, $ivlen, 32 );
+    $ciphertext_raw = substr( $c, $ivlen + 32 );
+    $original_text  = openssl_decrypt( $ciphertext_raw, WPUF_Encryption_Helper::get_encryption_method(), $secret_key, OPENSSL_RAW_DATA, $secret_iv );
+    $calcmac        = hash_hmac( 'sha256', $ciphertext_raw, $secret_key, true );
+
+    // timing attack safe comparison
+    if ( hash_equals( $hmac, $calcmac ) ) {
+        return $original_text;
+    }
+
+    return false;
 }
 
 /**

--- a/wpuf.php
+++ b/wpuf.php
@@ -255,6 +255,7 @@ final class WP_User_Frontend {
      * @return void
      */
     public function includes() {
+        require_once __DIR__ . '/class/encryption-helper.php';
         require_once __DIR__ . '/wpuf-functions.php';
         require_once __DIR__ . '/lib/gateway/paypal.php';
         require_once __DIR__ . '/lib/gateway/bank.php';


### PR DESCRIPTION
Admin can set the short-code with `role` attribute. Example: `[wpuf-registration role='editor']`. Any role will work except `administration`. If admin set `[wpuf-registration role='administration']`, it will set the user role to the default user role from `Settings > General Settings > New User Default Role`

Another [testing scenario](https://wedevs.slack.com/archives/G17RY7NVB/p1662374469651519). Needs to test with PHP version 5.6 and PHP 8