### PR TITLE
fix: random number added on file name after uploading

### DIFF
--- a/class/upload.php
+++ b/class/upload.php
@@ -85,11 +85,9 @@ class WPUF_Upload {
 
         $file_name      = pathinfo( $wpuf_file['name'], PATHINFO_FILENAME );
         $file_extension = pathinfo( $wpuf_file['name'], PATHINFO_EXTENSION );
-        $hash           = wp_hash( time() );
-        $hash           = substr( $hash, 0, 8 );
 
         $upload = [
-            'name'     => $file_name . '-' . $hash . '.' . $file_extension,
+            'name'     => $file_name . '.' . $file_extension,
             'type'     => $wpuf_file['type'],
             'tmp_name' => $wpuf_file['tmp_name'],
             'error'    => $wpuf_file['error'],


### PR DESCRIPTION
A `time hash` was added for this [issue](https://github.com/weDevsOfficial/wp-user-frontend/issues/809) before. It was adding a `time hash` after the file name to prevent duplication. As there is already a check for duplicate files by `file name` and `file size`, the `time hash` is removed.

Now the scenarios are:

1. If uploaded files have the same name that exists in the WP media library, it will add an incrementing number like `-1` as per WordPress.
2. If the uploaded file name (with extension) and size match with a file with the WP media library, it won't upload the new file and link the previous file to this post.

fix [#485](https://github.com/weDevsOfficial/wpuf-pro/issues/485) in pro