### PR TITLE
tweaking for v3.6.1

### DIFF
--- a/admin/class-admin-subscription.php
+++ b/admin/class-admin-subscription.php
@@ -489,7 +489,7 @@ class WPUF_Admin_Subscription {
                                 </th>
                                 <td>
                                     <label>
-                                        <input disabled type="checkbox" name="post_expiration_settings[enable_mail_after_expired]" value="on" <?php echo esc_attr( $is_enable_mail_after_expired ); ?> />
+                                        <input type="checkbox" name="post_expiration_settings[enable_mail_after_expired]" value="on" <?php echo esc_attr( $is_enable_mail_after_expired ); ?> />
                                         <?php esc_html_e( 'Send Expiration Email to Post Author', 'wp-user-frontend' ); ?>
                                     </label>
 

--- a/assets/js/subscriptions.js
+++ b/assets/js/subscriptions.js
@@ -33,7 +33,7 @@
                 if ( document.activeElement.value === 'Update' ) {
                     event.preventDefault();
                     Swal.fire({
-                        title: 'Are you sure to update the Subscription?',
+                        title: 'Are you sure to update the subscription?',
                         text: 'The changes you made will be applied only to the new subscriptions and pending recurring payments.',
                         icon: 'warning',
                         showCancelButton: true,


### PR DESCRIPTION
- enable the `Expiration Mail` option in the subscription settings
- change the wording for updating subscription alert