### PR TITLE
Fix Image Deleted by Both Confirmation and Cancel Buttons

### DIFF
--- a/assets/js/upload.js
+++ b/assets/js/upload.js
@@ -213,22 +213,25 @@
                     confirmButton: 'btn btn-success',
                     cancelButton: 'btn btn-danger',
                 }
-            }).then(function () {
-                var data = {
-                    'attach_id' : el.data('attach-id'),
-                    'nonce' : wpuf_frontend_upload.nonce,
-                    'action' : 'wpuf_file_del'
-                };
-                self.removed_files.push(data);
-                jQuery('#del_attach').val(el.data('attach-id'));
-                jQuery.post(wpuf_frontend_upload.ajaxurl, data, function() {
-                    self.perFileCount--;
-                    el.parent().parent().remove();
+            }).then(function (result) {
+                if (result.isConfirmed) {
 
-                    self.count -= 1;
-                    self.showHide();
-                    self.uploader.refresh();
-                });
+                    var data = {
+                        'attach_id' : el.data('attach-id'),
+                        'nonce' : wpuf_frontend_upload.nonce,
+                        'action' : 'wpuf_file_del'
+                    };
+                    self.removed_files.push(data);
+                    jQuery('#del_attach').val(el.data('attach-id'));
+                    jQuery.post(wpuf_frontend_upload.ajaxurl, data, function() {
+                        self.perFileCount--;
+                        el.parent().parent().remove();
+
+                        self.count -= 1;
+                        self.showHide();
+                        self.uploader.refresh();
+                    });
+                }
             });
         },
 


### PR DESCRIPTION
 Image Deletion Issue in Confirmation Window: Deletion Occurs When Clicking Either the Confirmation or Delete Button

![WPUF](https://github.com/weDevsOfficial/wp-user-frontend/assets/135999698/1c755939-be7e-4bde-91dc-6e0e3e3071ac)
