### PR TITLE
enhance: add custom note on plugin update page

### DIFF
--- a/admin/class-plugin-upgrade-notice.php
+++ b/admin/class-plugin-upgrade-notice.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * In WordPress Dashboard plugins page, show notice if needed
+ * The message is coming from wpuf-util
+ *
+ * @since WPUF_SINCE
+ */
+
+class Plugin_Upgrade_Notice {
+
+    /**
+     * The notice transient key
+     *
+     * @var string
+     */
+    const NOTICE_KEY = 'wpuf_upgrade_notice';
+
+    /**
+     * The plugin path as it is within the plugins directory, ie
+     * "some-plugin/main-file.php".
+     *
+     * @var string
+     */
+    protected $plugin_path = '';
+
+    /**
+     * The plugin upgrade notice (empty if none are available).
+     *
+     * @var string
+     */
+    protected $upgrade_notice = '';
+
+    /**
+     * The class constructor
+     *
+     * @since WPUF_SINCE
+     */
+    public function __construct() {
+        $plugin_file       = WPUF_FILE;
+        $this->plugin_path = trailingslashit( dirname( $plugin_file ) );
+        $plugin_dir        = trailingslashit( basename( $this->plugin_path ) );
+        $file              = $plugin_dir . basename( $plugin_file );
+
+        // WordPress dynamic hook
+        add_action( 'in_plugin_update_message-' . $file, [ $this, 'maybe_display_message' ] );
+    }
+
+    /**
+     * Display notice upon checking
+     *
+     * @since WPUF_SINCE
+     *
+     * @return void
+     */
+    public function maybe_display_message() {
+        $this->check_for_notice();
+
+        if ( $this->upgrade_notice ) {
+            $this->render_notice();
+        }
+    }
+
+    /**
+     * Tests to see if an upgrade notice is available.
+     *
+     * @since WPUF_SINCE
+     *
+     * @return void
+     */
+    protected function check_for_notice() {
+        $notice = get_transient( self::NOTICE_KEY );
+
+        if ( false === $notice ) {
+            $notice_url = 'https://raw.githubusercontent.com/weDevsOfficial/wpuf-util/master/upgrade-notice.json';
+            $response   = wp_remote_get( $notice_url, [ 'timeout' => 15 ] );
+            $notice     = wp_remote_retrieve_body( $response );
+
+            if ( is_wp_error( $response ) || ( 200 !== $response['response']['code'] ) ) {
+                $notice = '[]';
+            }
+
+            set_transient( self::NOTICE_KEY, $notice, DAY_IN_SECONDS );
+        }
+
+
+        $notice = json_decode( $notice, true );
+
+        if ( empty( $notice ) || ! is_array( $notice ) ) {
+            return;
+        }
+
+        $this->upgrade_notice = ! empty( $notice['message'] ) ? $notice['message'] : '';
+    }
+
+    /**
+     * Render the notice under new version available message
+     *
+     * @since WPUF_SINCE
+     *
+     * @return void
+     */
+    public function render_notice() {
+        $notice = wp_kses_post( $this->upgrade_notice );
+        echo "<div class='wpuf-update-message' style='color: #fff; background: #f54a20; padding: 10px;'> $notice </div>";
+    }
+}

--- a/wpuf.php
+++ b/wpuf.php
@@ -127,6 +127,7 @@ final class WP_User_Frontend {
         add_action( 'init', [ $this, 'load_textdomain' ] );
 
         add_action( 'admin_init', [ $this, 'block_admin_access' ] );
+        add_action( 'admin_init', [ $this, 'plugin_upgrade_notice' ] );
 
         add_filter( 'show_admin_bar', [ $this, 'show_admin_bar' ] );
 
@@ -319,6 +320,7 @@ final class WP_User_Frontend {
             include_once WPUF_ROOT . '/includes/class-acf.php';
             include_once WPUF_ROOT . '/includes/class-privacy.php';
             include_once WPUF_ROOT . '/admin/dashboard-metabox.php';
+            include_once WPUF_ROOT . '/admin/class-plugin-upgrade-notice.php';
         } else {
             require_once WPUF_ROOT . '/class/frontend-dashboard.php';
             require_once WPUF_ROOT . '/includes/free/class-registration.php';
@@ -800,6 +802,22 @@ final class WP_User_Frontend {
             // wp_die( __( 'Access Denied. Your site administrator has blocked your access to the WordPress back-office.', 'wpuf' ) );
             wp_redirect( home_url() );
             exit;
+        }
+    }
+
+    /**
+     * show plugin upgrade notice upon checking
+     *
+     * @since WPUF_SINCE
+     *
+     * @return void
+     */
+    public function plugin_upgrade_notice() {
+        global $pagenow;
+
+        // Show extra upgrade notices within the plugins.php screen only
+        if ( 'plugins.php' === $pagenow ) {
+            new Plugin_Upgrade_Notice();
         }
     }
 


### PR DESCRIPTION
We can now show notice/message to the user before updating WP User Frontend.
Image: 
<img width="1273" alt="image" src="https://github.com/weDevsOfficial/wp-user-frontend/assets/15567340/94506cec-9e73-47d9-97ec-ca3fcd27be88">
