### PR TITLE
fix: nonce validation for ajax actions

### DIFF
--- a/assets/js/wpuf-login-widget.js
+++ b/assets/js/wpuf-login-widget.js
@@ -75,6 +75,7 @@ jQuery( function($) {
             dataType: 'json',
             data: {
                 action: 'wpuf_ajax_logout',
+                nonce: '<?php echo esc_attr( wp_create_nonce( "wpuf_acf_compatibility" ) ); ?>'
             },
             success: function(data) {
                 $('.wpuf-ajax-logout .wpuf-ajax-errors').html(data.message);

--- a/class/render-form.php
+++ b/class/render-form.php
@@ -982,11 +982,14 @@ class WPUF_Render_Form {
             <span class="wpuf-wordlimit-message wpuf-help"></span>
             <?php $this->help_text( $attr ); ?>
 
-            <?php if ( $taxonomy ) { ?>
+            <?php if ( $taxonomy ) {
+                $query_string = '?action=wpuf-ajax-tag-search&tax=post_tag';
+                $query_string .= '&nonce=' . wp_create_nonce( 'wpuf_ajax_tag_search' );
+                ?>
             <script type="text/javascript">
                 ;(function($) {
                     $(document).ready( function(){
-                        $('li.tags input[name=tags]').suggest( wpuf_frontend.ajaxurl + '?action=wpuf-ajax-tag-search&tax=post_tag', { delay: 500, minchars: 2, multiple: true, multipleSep: ', ' } );
+                        $('li.tags input[name=tags]').suggest( wpuf_frontend.ajaxurl + '<?php echo $query_string; ?>', { delay: 500, minchars: 2, multiple: true, multipleSep: ', ' } );
                     });
                 })(jQuery);
             </script>
@@ -1579,6 +1582,9 @@ class WPUF_Render_Form {
                         break;
 
                     case 'text':
+                        $query_string = '?action=wpuf-ajax-tag-search&tax=' . esc_attr( $attr['name'] );
+                        $query_string .= '&nonce=' . wp_create_nonce( 'wpuf_ajax_tag_search' );
+
                         ?>
 
                         <input class="textfield<?php echo esc_attr( $this->required_class( $attr ) ); ?>" id="<?php echo esc_attr( $attr['name'] ); ?>" type="text" data-required="<?php echo esc_attr( $attr['required'] ); ?>" data-type="text"<?php esc_attr( $this->required_html5( $attr ) ); ?> name="<?php echo esc_attr( $attr['name'] ); ?>" value="<?php echo esc_attr( implode( ', ', $terms ) ); ?>" size="40" />
@@ -1586,7 +1592,7 @@ class WPUF_Render_Form {
                         <script type="text/javascript">
                             ;(function($) {
                                 $(document).ready( function(){
-                                        $('#<?php echo esc_attr( $attr['name'] ); ?>').suggest( wpuf_frontend.ajaxurl + '?action=wpuf-ajax-tag-search&tax=<?php echo esc_attr( $attr['name'] ); ?>', { delay: 500, minchars: 2, multiple: true, multipleSep: ', ' } );
+                                        $('#<?php echo esc_attr( $attr['name'] ); ?>').suggest( wpuf_frontend.ajaxurl + '<?php echo $query_string; ?>', { delay: 500, minchars: 2, multiple: true, multipleSep: ', ' } );
                                 });
                             })(jQuery);
                         </script>

--- a/includes/class-acf.php
+++ b/includes/class-acf.php
@@ -70,6 +70,10 @@ class WPUF_ACF_Compatibility {
      *@return void
      */
     public function maybe_compatible() {
+        if ( empty( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_key( wp_unslash( $_POST['nonce'] ) ), 'wpuf_acf_compatibility' ) ) {
+            wp_send_json_error( __( 'Permission denied', 'wp-user-frontend' ) );
+        }
+
         wpuf_update_option( 'wpuf_compatibility_' . $this->id, 'wpuf_general', 'yes' );
 
         wp_send_json_success();
@@ -81,6 +85,10 @@ class WPUF_ACF_Compatibility {
      *@return void
      */
     public function migrate_cf_data() {
+        if ( empty( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_key( wp_unslash( $_POST['nonce'] ) ), 'wpuf_acf_migration' ) ) {
+            wp_send_json_error( __( 'Permission denied', 'wp-user-frontend' ) );
+        }
+
         $forms = $this->get_post_forms();
 
         if ( ! empty( $forms ) ) {
@@ -148,6 +156,10 @@ class WPUF_ACF_Compatibility {
      * @return void
      */
     public function dismiss_notice() {
+        if ( empty( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_key( wp_unslash( $_POST['nonce'] ) ), 'wpuf_dismiss_acf_notice' ) ) {
+            wp_send_json_error( __( 'Permission denied', 'wp-user-frontend' ) );
+        }
+
         $this->dismiss_prompt();
 
         wp_send_json_success();
@@ -187,6 +199,9 @@ class WPUF_ACF_Compatibility {
                     var self = $(this);
                     self.addClass('updating-message');
                     wp.ajax.send('wpuf_compatibility_<?php echo esc_attr( $this->id ); ?>', {
+                        data: {
+                            nonce: '<?php echo esc_attr( wp_create_nonce( 'wpuf_acf_compatibility' ) ); ?>'
+                        },
                         success: function() {
                             var html = '<p><strong>Compatible Option Updated</strong></p>';
 
@@ -211,6 +226,9 @@ class WPUF_ACF_Compatibility {
                     var self = $(this);
                     self.addClass('updating-message');
                     wp.ajax.send('wpuf_migrate_<?php echo esc_attr( $this->id ); ?>', {
+                        data: {
+                            nonce: '<?php echo esc_attr( wp_create_nonce( 'wpuf_acf_migration' ) ); ?>'
+                        },
                         success: function() {
                             var html  = '<p><strong>Compatible option and existing custom fields data updated</strong></p>';
 
@@ -233,7 +251,11 @@ class WPUF_ACF_Compatibility {
                     e.preventDefault();
 
                     $(this).closest('.notice').remove();
-                    wp.ajax.send('wpuf_dismiss_notice_<?php echo esc_attr( $this->id ); ?>');
+                    wp.ajax.send('wpuf_dismiss_notice_<?php echo esc_attr( $this->id ); ?>', {
+                        data: {
+                            nonce: '<?php echo esc_attr( wp_create_nonce( 'wpuf_dismiss_acf_notice' ) ); ?>'
+                        },
+                    });
                 });
 
             });

--- a/includes/class-billing-address.php
+++ b/includes/class-billing-address.php
@@ -7,8 +7,8 @@ class WPUF_Ajax_Address_Form {
 
     public function __construct() {
         add_action( 'wp_enqueue_scripts', [ $this, 'register_plugin_scripts' ] );
-        add_action( 'wp_ajax_wpuf_address_ajax_action', [ $this, 'ajax_form_action' ], 10, 1 );
-        add_action( 'wp_ajax_nopriv_wpuf_address_ajax_action', [ $this, 'ajax_form_action' ], 10, 1 );
+        add_action( 'wp_ajax_wpuf_address_ajax_action', [ $this, 'ajax_form_action' ] );
+        add_action( 'wp_ajax_nopriv_wpuf_address_ajax_action', [ $this, 'ajax_form_action' ] );
     }
 
     /**

--- a/includes/class-field-manager.php
+++ b/includes/class-field-manager.php
@@ -48,7 +48,7 @@ class WPUF_Field_Manager {
     public function get_field( $field_type ) {
         $fields = $this->get_fields();
 
-        if ( isset( $field_type, $fields ) ) {
+        if ( isset( $field_type, $fields, $fields[ $field_type ] ) ) {
             return $fields[ $field_type ];
         }
     }

--- a/includes/class-login-widget.php
+++ b/includes/class-login-widget.php
@@ -30,8 +30,8 @@ class WPUF_Login_Widget extends WP_Widget {
         $rememberme     = isset( $_POST['rememberme'] ) ? sanitize_text_field( wp_unslash( $_POST['rememberme'] ) ) : false;
         $nonce = isset( $_REQUEST['_wpnonce'] ) ? sanitize_key( wp_unslash( $_REQUEST['_wpnonce'] ) ) : '';
 
-        if ( isset( $nonce ) && ! wp_verify_nonce( $nonce , 'wpuf_lost_pass' ) ) {
-
+        if ( empty( $nonce ) || ! wp_verify_nonce( $nonce , 'wpuf_lost_pass' ) ) {
+            wp_send_json_error( __( 'Permission denied', 'wp-user-frontend' ) );
         }
 
         if ( empty( $user_login ) || empty( $user_pass ) ) {
@@ -54,6 +54,12 @@ class WPUF_Login_Widget extends WP_Widget {
      * @return void
      */
     public function ajax_logout() {
+        $nonce = isset( $_REQUEST['nonce'] ) ? sanitize_key( wp_unslash( $_REQUEST['nonce'] ) ) : '';
+
+        if ( empty( $nonce ) || ! wp_verify_nonce( $nonce, 'wpuf_lost_pass' ) ) {
+            wp_send_json_error( __( 'Permission denied', 'wp-user-frontend' ) );
+        }
+
         wp_logout();
         wp_send_json_success( [ 'message'=> __( 'Logout successful!', 'wp-user-frontend' ) ] );
     }
@@ -67,8 +73,8 @@ class WPUF_Login_Widget extends WP_Widget {
         $username_or_email = isset( $_POST['user_login'] ) ? sanitize_text_field( wp_unslash( $_POST['user_login'] ) ) : '';
         $nonce = isset( $_REQUEST['_wpnonce'] ) ? sanitize_key( wp_unslash( $_REQUEST['_wpnonce'] ) ) : '';
 
-        if ( isset( $nonce ) && ! wp_verify_nonce( $nonce, 'wpuf_lost_pass' ) ) {
-
+        if ( empty( $nonce ) || ! wp_verify_nonce( $nonce, 'wpuf_lost_pass' ) ) {
+            wp_send_json_error( __( 'Permission denied', 'wp-user-frontend' ) );
         }
 
         // Check if input variables are empty

--- a/includes/class-whats-new.php
+++ b/includes/class-whats-new.php
@@ -139,11 +139,7 @@ class WPUF_Whats_New {
      * @return void
      */
     public function dismiss_notice() {
-        if ( ! current_user_can( 'manage_options' ) ) {
-            wp_send_json_error( __( 'You have no permission to do that', 'wp-user-frontend' ) );
-        }
-
-        if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_key( wp_unslash( $_POST['nonce'] ) ), 'wpuf_whats_new_nonce' ) ) {
+        if ( empty( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_key( wp_unslash( $_POST['nonce'] ) ), 'wpuf_whats_new_nonce' ) ) {
             wp_send_json_error( __( 'Permission denied', 'wp-user-frontend' ) );
         }
 

--- a/includes/fields/class-field-post-tags.php
+++ b/includes/fields/class-field-post-tags.php
@@ -29,7 +29,11 @@ class WPUF_Form_Field_Post_Tags extends WPUF_Field_Contract {
             $value = implode( ', ', $tagsarray );
         } else {
             $value = $field_settings['default'];
-        } ?>
+        }
+
+        $query_string = '?action=wpuf-ajax-tag-search&tax=post_tag';
+        $query_string .= '&nonce=' . wp_create_nonce( 'wpuf_ajax_tag_search' );
+        ?>
 
 
         <li <?php $this->print_list_attributes( $field_settings ); ?>>
@@ -54,7 +58,7 @@ class WPUF_Form_Field_Post_Tags extends WPUF_Field_Contract {
               <script type="text/javascript">
                 ;(function($) {
                     $(document).ready( function(){
-                        $('li.tags input[name=tags]').suggest( wpuf_frontend.ajaxurl + '?action=wpuf-ajax-tag-search&tax=post_tag', { delay: 500, minchars: 2, multiple: true, multipleSep: ', ' } );
+                        $('li.tags input[name=tags]').suggest( wpuf_frontend.ajaxurl + '<?php echo $query_string; ?>', { delay: 500, minchars: 2, multiple: true, multipleSep: ', ' } );
                     });
                 })(jQuery);
             </script>

--- a/wpuf-functions.php
+++ b/wpuf-functions.php
@@ -1524,6 +1524,10 @@ function wpuf_get_attachment_id_from_url( $attachment_url = '' ) {
  * @global object $wpdb
  */
 function wpufe_ajax_tag_search() {
+    if ( ! isset( $_REQUEST['nonce'] ) || ! wp_verify_nonce( sanitize_key( wp_unslash( $_REQUEST['nonce'] ) ), 'wpuf_ajax_tag_search' ) ) {
+        wp_send_json_error( __( 'Permission denied', 'wp-user-frontend' ) );
+    }
+
     global $wpdb;
 
     $taxonomy = isset( $_GET['tax'] ) ? sanitize_text_field( wp_unslash( $_GET['tax'] ) ) : '';
@@ -1775,7 +1779,9 @@ function wpuf_get_child_cats() {
     $parent_cat  = isset( $_POST['catID'] ) ? sanitize_text_field( wp_unslash( $_POST['catID'] ) ) : '';
     $field_attr = isset( $_POST['field_attr'] ) ? array_map( 'sanitize_text_field', wp_unslash( $_POST['field_attr'] ) ) : [];
 
-    wp_verify_nonce( $nonce, 'wpuf_nonce' );
+    if ( wp_verify_nonce( $nonce, 'wpuf_nonce' ) ) {
+        wp_send_json_error( __( 'Permission denied', 'wp-user-frontend' ) );
+    }
 
     $allowed_tags = wp_kses_allowed_html( 'post' );
 


### PR DESCRIPTION
add missing nonce validation for ajax actions.

**Things to test:**
- whats new notice dismiss
- ajax tag search
- ACF compatibility buttons
- Login/Logout widget

Related [discussion](https://wedevs.slack.com/archives/G17RY7NVB/p1692275546518139)