### PR TITLE
fix: error on multi select form custom taxonomy

### DIFF
--- a/assets/css/frontend-forms.css
+++ b/assets/css/frontend-forms.css
@@ -1319,6 +1319,9 @@ body .wpuf-dashboard-container .wpuf-dashboard-content .wpuf-fields textarea:not
 body .wpuf-dashboard-container .wpuf-dashboard-content .wpuf-fields input:not([type="reset"]) {
   width: 100%;
 }
+body .wpuf-dashboard-container .wpuf-dashboard-content .wpuf-fields input[type="radio"] {
+  width: initial;
+}
 body .wpuf-dashboard-container .items-table-container,
 body .wpuf-dashboard-container .wpuf-dashboard-content.invoices {
   max-width: 100%;

--- a/assets/less/frontend-forms.less
+++ b/assets/less/frontend-forms.less
@@ -1460,6 +1460,12 @@ body.rtl{
             }
         }
 
+        .wpuf-fields {
+            input[type="radio"] {
+                    width: initial;
+            }
+        }
+
     }
 
     .items-table-container,

--- a/includes/Fields/Form_Field_Post_Taxonomy.php
+++ b/includes/Fields/Form_Field_Post_Taxonomy.php
@@ -379,7 +379,7 @@ class Form_Field_Post_Taxonomy extends Field_Contract {
 
         $required = sprintf( 'data-required="%s" data-type="multiselect"', $attr['required'] );
 
-        $walker = new WPUF_Walker_Category_Multi();
+        $walker = new \WPUF_Walker_Category_Multi();
 
         $exclude = wpuf_get_field_settings_excludes( $this->field_settings, $this->exclude_type );
 


### PR DESCRIPTION
An error occurs when the user switches a taxonomy field to “multi-select”.
issue [details](https://wedevs.slack.com/archives/G17RY7NVB/p1705263230677249)