### PR TITLE
fix: frontend registration form is not showing

### DIFF
--- a/templates/registration-form.php
+++ b/templates/registration-form.php
@@ -20,8 +20,8 @@
     }
     ?>
 
-    <?php wpuf()->registration->show_errors(); ?>
-    <?php wpuf()->registration->show_messages(); ?>
+    <?php wpuf()->frontend->registration->show_errors(); ?>
+    <?php wpuf()->frontend->registration->show_messages(); ?>
 
     <form name="registrationform" class="wpuf-registration-form" id="registrationform" action="<?php echo esc_attr( $action_url ); ?>" method="post">
 
@@ -31,12 +31,12 @@
                 <div class="wpuf-fields">
                     <div class="wpuf-name-field-wrap format-first-last">
                         <div class="wpuf-name-field-first-name">
-                            <input type="text" name="reg_fname" id="wpuf-user_fname" class="input" value="<?php echo esc_attr( wpuf()->registration->get_posted_value( 'reg_fname' ) ); ?>" size="" />
+                            <input type="text" name="reg_fname" id="wpuf-user_fname" class="input" value="<?php echo esc_attr( wpuf()->frontend->registration->get_posted_value( 'reg_fname' ) ); ?>" size="" />
                             <label class="wpuf-form-sub-label"><?php esc_html_e( 'First', 'wp-user-frontend' ); ?></label>
                         </div>
 
                         <div class="wpuf-name-field-last-name">
-                            <input type="text" name="reg_lname" id="wpuf-user_lname" class="input" value="<?php echo esc_attr( wpuf()->registration->get_posted_value( 'reg_lname' ) ); ?>" size="16" />
+                            <input type="text" name="reg_lname" id="wpuf-user_lname" class="input" value="<?php echo esc_attr( wpuf()->frontend->registration->get_posted_value( 'reg_lname' ) ); ?>" size="16" />
                             <label class="wpuf-form-sub-label"><?php esc_html_e( 'Last', 'wp-user-frontend' ); ?></label>
                         </div>
                     </div>
@@ -46,14 +46,14 @@
             <li>
                 <div class="wpuf-label"><?php esc_html_e( 'Email', 'wp-user-frontend' ); ?> <span class="required">*</span></div>
                 <div class="wpuf-fields">
-                    <input type="text" name="reg_email" id="wpuf-user_email" class="input" value="<?php echo esc_attr( wpuf()->registration->get_posted_value( 'reg_email' ) ); ?>" size="40">
+                    <input type="text" name="reg_email" id="wpuf-user_email" class="input" value="<?php echo esc_attr( wpuf()->frontend->registration->get_posted_value( 'reg_email' ) ); ?>" size="40">
                 </div>
             </li>
 
             <li>
                 <div class="wpuf-label"><?php esc_html_e( 'Username', 'wp-user-frontend' ); ?> <span class="required">*</span></div>
                 <div class="wpuf-fields">
-                    <input type="text" name="log" id="wpuf-user_login" class="input" value="<?php echo esc_attr( wpuf()->registration->get_posted_value( 'log' ) ); ?>" size="40" />
+                    <input type="text" name="log" id="wpuf-user_login" class="input" value="<?php echo esc_attr( wpuf()->frontend->registration->get_posted_value( 'log' ) ); ?>" size="40" />
                 </div>
             </li>
 
@@ -75,7 +75,7 @@
                 <input type="submit" name="wp-submit" id="wp-submit" value="<?php echo esc_attr( 'Register', 'wp-user-frontend' ); ?>" />
                 <input type="hidden" name="urhidden" value="<?php echo esc_attr( $userrole ); ?>" />
                 <input type="hidden" name="user_nonce" value="<?php echo esc_attr( $user_nonce ); ?>" />
-                <input type="hidden" name="redirect_to" value="<?php echo esc_attr( wpuf()->registration->get_posted_value( 'redirect_to' ) ); ?>" />
+                <input type="hidden" name="redirect_to" value="<?php echo esc_attr( wpuf()->frontend->registration->get_posted_value( 'redirect_to' ) ); ?>" />
                 <input type="hidden" name="wpuf_registration" value="true" />
                 <input type="hidden" name="action" value="registration" />
 


### PR DESCRIPTION
Unregistered users visiting the page with shortcode: [wpuf-registration]

setting enabled to redirect to subscriptions before register. When an unregistered user clicks sign up on a pack, the page throws: There has been a critical error on this website.