### PR TITLE
fix: default form template not selecting

### DIFF
--- a/includes/Admin/Forms/Post/Templates/Post_Form_Template_Events_Calendar.php
+++ b/includes/Admin/Forms/Post/Templates/Post_Form_Template_Events_Calendar.php
@@ -186,7 +186,7 @@ class Post_Form_Template_Events_Calendar extends Form_Template{
                                       'wp-user-frontend' ),
             'edit_url'         => '',
             'update_text'      => __( 'Update Event', 'wp-user-frontend' ),
-            'form_template'    => __CLASS__,
+            'form_template'    => 'post_form_template_events_calendar',
             'notification'     => [
                 'new'          => 'on',
                 'new_to'       => get_option( 'admin_email' ),

--- a/includes/Admin/Forms/Post/Templates/Post_Form_Template_Post.php
+++ b/includes/Admin/Forms/Post/Templates/Post_Form_Template_Post.php
@@ -151,7 +151,7 @@ class Post_Form_Template_Post extends Form_Template {
                 'update_message'             => __( 'Post has been updated successfully. <a target="_blank" href="%link%">View post</a>', 'wp-user-frontend' ),
                 'edit_url'                   => '',
                 'update_text'                => __( 'Update Post', 'wp-user-frontend' ),
-                'form_template'              => __CLASS__,
+                'form_template'              => 'post_form_template_post',
                 'notification'               => [
                 'new'                        => 'on',
                 'new_to'                     => get_option( 'admin_email' ),

--- a/includes/Admin/Forms/Post/Templates/Post_Form_Template_WooCommerce.php
+++ b/includes/Admin/Forms/Post/Templates/Post_Form_Template_WooCommerce.php
@@ -193,7 +193,7 @@ class Post_Form_Template_WooCommerce extends Form_Template {
             'update_message'   => 'Product has been updated successfully. <a target="_blank" href="%link%">View Product</a>',
             'edit_url'         => '',
             'update_text'      => 'Update Product',
-            'form_template'    => __CLASS__,
+            'form_template'    => 'post_form_template_woocommerce',
             'notification'     => [
                 'new'          => 'on',
                 'new_to'       => get_option( 'admin_email' ),


### PR DESCRIPTION
when selecting a registration form template, in form settings > General > Form Template not automatically selecting.

<img width="1286" alt="image" src="https://github.com/weDevsOfficial/wpuf-pro/assets/15567340/6bbc1939-c760-4dbe-ac97-24cd31c43e72">