### PR TITLE
enhance: update dynamic properties use

### DIFF
--- a/Lib/invisible_recaptcha.php
+++ b/Lib/invisible_recaptcha.php
@@ -16,6 +16,9 @@
 *
 */
 
+// Use the fully-qualified AllowDynamicProperties, otherwise the #[AllowDynamicProperties] attribute WILL NOT WORK.
+use \AllowDynamicProperties;
+
 #[AllowDynamicProperties]
 class Invisible_Recaptcha{
 

--- a/admin/class-admin-settings.php
+++ b/admin/class-admin-settings.php
@@ -1,5 +1,8 @@
 <?php
 
+// Use the fully-qualified AllowDynamicProperties, otherwise the #[AllowDynamicProperties] attribute WILL NOT WORK.
+use \AllowDynamicProperties;
+
 /**
  * WPUF settings
  */

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -2,7 +2,8 @@
 
 namespace WeDevs\Wpuf;
 
-use AllowDynamicProperties;
+// Use the fully-qualified AllowDynamicProperties, otherwise the #[AllowDynamicProperties] attribute WILL NOT WORK.
+use \AllowDynamicProperties;
 use WeDevs\WpUtils\ContainerTrait;
 
 /**

--- a/includes/Admin/Forms/Admin_Form.php
+++ b/includes/Admin/Forms/Admin_Form.php
@@ -2,6 +2,8 @@
 
 namespace WeDevs\Wpuf\Admin\Forms;
 
+// Use the fully-qualified AllowDynamicProperties, otherwise the #[AllowDynamicProperties] attribute WILL NOT WORK.
+use \AllowDynamicProperties;
 use WeDevs\Wpuf\Admin\Subscription;
 use WeDevs\Wpuf\Traits\FieldableTrait;
 use WeDevs\WpUtils\ContainerTrait;

--- a/includes/Admin/Forms/Form.php
+++ b/includes/Admin/Forms/Form.php
@@ -2,6 +2,9 @@
 
 namespace WeDevs\Wpuf\Admin\Forms;
 
+// Use the fully-qualified AllowDynamicProperties, otherwise the #[AllowDynamicProperties] attribute WILL NOT WORK.
+use \AllowDynamicProperties;
+
 #[AllowDynamicProperties]
 class Form {
 

--- a/includes/Admin/Forms/Post/Templates/Pro_Form_Preview_EDD.php
+++ b/includes/Admin/Forms/Post/Templates/Pro_Form_Preview_EDD.php
@@ -1,7 +1,9 @@
 <?php
 
 namespace WeDevs\Wpuf\Admin\Forms\Post\Templates;
-use AllowDynamicProperties;
+
+// Use the fully-qualified AllowDynamicProperties, otherwise the #[AllowDynamicProperties] attribute WILL NOT WORK.
+use \AllowDynamicProperties;
 
 /**
  * Easy Digital Downloads post form template preview

--- a/includes/Ajax/Frontend_Form_Ajax.php
+++ b/includes/Ajax/Frontend_Form_Ajax.php
@@ -2,6 +2,8 @@
 
 namespace WeDevs\Wpuf\Ajax;
 
+// Use the fully-qualified AllowDynamicProperties, otherwise the #[AllowDynamicProperties] attribute WILL NOT WORK.
+use \AllowDynamicProperties;
 use DOMDocument;
 use WeDevs\Wpuf\Admin\Forms\Form;
 use WeDevs\Wpuf\Traits\FieldableTrait;

--- a/includes/Fields/Form_Field_Post_Taxonomy.php
+++ b/includes/Fields/Form_Field_Post_Taxonomy.php
@@ -7,6 +7,9 @@ namespace WeDevs\Wpuf\Fields;
 // require WPUF_INCLUDES . '/fields/class-abstract-fields.php';
 use WPUF_Walker_Category_Multi;
 
+// Use the fully-qualified AllowDynamicProperties, otherwise the #[AllowDynamicProperties] attribute WILL NOT WORK.
+use \AllowDynamicProperties;
+
 #[AllowDynamicProperties]
 class Form_Field_Post_Taxonomy extends Field_Contract {
     use Form_Field_Post_Trait;

--- a/includes/Frontend.php
+++ b/includes/Frontend.php
@@ -2,7 +2,8 @@
 
 namespace WeDevs\Wpuf;
 
-use AllowDynamicProperties;
+// Use the fully-qualified AllowDynamicProperties, otherwise the #[AllowDynamicProperties] attribute WILL NOT WORK.
+use \AllowDynamicProperties;
 use WeDevs\WpUtils\ContainerTrait;
 
 /**

--- a/wpuf-functions.php
+++ b/wpuf-functions.php
@@ -4153,7 +4153,7 @@ function wpuf_recursive_sanitize_text_field($arr){
  */
 function wpuf_payment_success_page( $data ){
     $gateway          = ! empty( $data['wpuf_payment_method'] ) ? $data['wpuf_payment_method'] : '';
-    $success_query    = "wpuf_${gateway}_success";
+    $success_query    = 'wpuf_' . $gateway . '_success';
     $redirect_page    = '';
     $redirect_page_id = 0;
     $payment_method   = ! empty( $data['post_data']['wpuf_payment_method'] ) ? $data['post_data']['wpuf_payment_method'] : '';

--- a/wpuf.php
+++ b/wpuf.php
@@ -35,6 +35,9 @@ define( 'WPUF_INCLUDES', WPUF_ROOT . '/includes' );
 use WeDevs\WpUtils\ContainerTrait;
 use WeDevs\WpUtils\SingletonTrait;
 
+// Use the fully-qualified AllowDynamicProperties, otherwise the #[AllowDynamicProperties] attribute WILL NOT WORK.
+use \AllowDynamicProperties;
+
 /**
  * Main bootstrap class for WP User Frontend
  */


### PR DESCRIPTION
The creation of dynamic properties is [deprecated](https://www.php.net/manual/en/migration82.deprecated.php) from PHP 8.x.x. fixed in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved issues with dynamic properties by ensuring the `#[AllowDynamicProperties]` attribute works correctly across various components of the application.

- **Code Quality**
  - Improved code consistency by updating string construction methods in the `wpuf_payment_success_page` function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->