### PR TITLE
fix: QR data not showing when post is being draft

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -74,6 +74,16 @@ span.wpuf_help {
   float: right;
   display: none;
 }
+span.wpuf-loading {
+  height: 16px;
+  width: 16px;
+  background: url('../images/wpspin_light.gif') no-repeat;
+  padding: 0;
+  margin: 5px 10px;
+  right: -40px;
+  top: 0;
+  float: left;
+}
 #option-saved {
   -moz-border-radius: 5px 5px 5px 5px;
   background: none repeat scroll 0 0 orange;

--- a/assets/less/admin.less
+++ b/assets/less/admin.less
@@ -107,6 +107,16 @@ span {
         float: right;
         display: none;
     }
+    &.wpuf-loading {
+        height: 16px;
+        width: 16px;
+        background: url('../images/wpspin_light.gif') no-repeat;
+        padding: 0;
+        margin: 5px 10px;
+        right: -40px;
+        top: 0;
+        float: left;
+    }
 }
 
 #option-saved {

--- a/includes/Ajax/Frontend_Form_Ajax.php
+++ b/includes/Ajax/Frontend_Form_Ajax.php
@@ -451,10 +451,10 @@ class Frontend_Form_Ajax {
 
             //redirect the user
             $response = apply_filters( 'wpuf_add_post_redirect', $response, $post_id, $form_id, $this->form_settings );
-            //now perform some post related actions. it should done after other action.either count related problem emerge
-            do_action( 'wpuf_add_post_after_insert', $post_id, $form_id, $this->form_settings, $meta_vars ); // plugin API to extend the functionality
-
         }
+
+        // now perform some post related actions. it should be done after other action. either count related problem emerge
+        do_action( 'wpuf_add_post_after_insert', $post_id, $form_id, $this->form_settings, $meta_vars ); // plugin API to extend the functionality
 
         return $response;
     }


### PR DESCRIPTION
QR-Code data is not saving when posting as a guest user.
Related PR: [#590](https://github.com/weDevsOfficial/wpuf-pro/pull/590)

![image](https://github.com/weDevsOfficial/wp-user-frontend/assets/15567340/fdf8dbca-1115-4d27-9704-ef35f90c1a1b)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a loading spinner with new styles to enhance the admin interface.

- **Style**
  - Updated CSS and LESS files to include styling for the loading spinner element.

- **Documentation**
  - Improved comments in the `send_mail_for_guest` function for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->