### PR TITLE
Fix mail body replace text bug

### DIFF
--- a/includes/Ajax/Frontend_Form_Ajax.php
+++ b/includes/Ajax/Frontend_Form_Ajax.php
@@ -669,8 +669,30 @@ class Frontend_Form_Ajax {
         preg_match_all( '/%custom_([\w-]*)\b%/', $content, $matches );
         [ $search, $replace ] = $matches;
 
+        $args = array(
+            'post_type' => 'wpuf_input',
+            'posts_per_page' => -1
+        );
+        $wpuf_posts = get_posts($args);
+
         if ( $replace ) {
             foreach ( $replace as $index => $meta_key ) {
+                $input_type = '';
+                foreach ($wpuf_posts as $post) {
+                    $post_content = $post->post_content;
+                    $data = unserialize($post_content);
+                    if ($data['name'] == $meta_key){
+                        $input_type = $data['input_type'];
+                        break;
+                    }
+                }
+
+                $use_attachment_url = false;
+                if ($input_type == "image_upload" || $input_type == "file_upload"){
+                    $use_attachment_url = true;
+                }
+                    
+
                 $value = get_post_meta( $post_id, $meta_key, false );
 
                 if ( isset( $value[0] ) && is_array( $value[0] ) ) {
@@ -687,21 +709,21 @@ class Frontend_Form_Ajax {
 
                     foreach ( $value as $val ) {
                         if ( $is_first ) {
-                            if ( get_post_mime_type( (int) $val ) ) {
+                            if ( $use_attachment_url ) {
                                 $meta_val = wp_get_attachment_url( $val );
                             } else {
                                 $meta_val = $val;
                             }
                             $is_first = false;
                         } else {
-                            if ( get_post_mime_type( (int) $val ) ) {
+                            if ( $use_attachment_url ) {
                                 $meta_val = $meta_val . ', ' . wp_get_attachment_url( $val );
                             } else {
                                 $meta_val = $meta_val . ', ' . $val;
                             }
                         }
 
-                        if ( get_post_mime_type( (int) $val ) ) {
+                        if ( $use_attachment_url ) {
                             $meta_val = $meta_val . ',' . wp_get_attachment_url( $val );
                         } else {
                             $meta_val = $meta_val . ',' . $val;
@@ -714,7 +736,7 @@ class Frontend_Form_Ajax {
                         $new_value = implode( ', ', $value );
                     }
 
-                    if ( get_post_mime_type( (int) $new_value ) ) {
+                    if ( $use_attachment_url ) {
                         $original_value = wp_get_attachment_url( $new_value );
                     } else {
                         $original_value = $new_value;


### PR DESCRIPTION
# Bug detail
When sending emails for creating or updating posts, the function prepare_mail_body() in the Frontend_Form_Ajax class sometimes causes the email body to display the output of wp_get_attachment_url() for related posts instead of showing the meta_value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of email body preparation to correctly manage attachment URLs based on input type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->