### PR TITLE
fix: validate orderby and order input params

### DIFF
--- a/wpuf-functions.php
+++ b/wpuf-functions.php
@@ -2115,10 +2115,13 @@ function wpuf_get_account_sections_list( $post_type = 'page' ) {
  *
  * @since 2.4.2
  *
- * @return array
+ * @return array|string
  */
 function wpuf_get_completed_transactions( $args = [] ) {
     global $wpdb;
+
+    $orderby = [ 'id', 'status', 'created' ];
+    $order   = [ 'asc', 'desc' ];
 
     $defaults = [
         'number'  => 20,
@@ -2130,10 +2133,18 @@ function wpuf_get_completed_transactions( $args = [] ) {
 
     $args = wp_parse_args( $args, $defaults );
 
+    if ( ! in_array( $args['orderby'], $orderby ) ) {
+        $args['orderby'] = 'id';
+    }
+
+    if ( ! in_array( $args['order'], $order ) ) {
+        $args['order'] = 'DESC';
+    }
+
     if ( $args['count'] ) {
         return $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}wpuf_transaction" );
     }
-    //phpcs:ignore
+
     $result = $wpdb->get_results( "SELECT * FROM {$wpdb->prefix}wpuf_transaction ORDER BY `{$args['orderby']}` {$args['order']} LIMIT {$args['offset']}, {$args['number']}", OBJECT );
 
     return $result;
@@ -2149,6 +2160,9 @@ function wpuf_get_completed_transactions( $args = [] ) {
 function wpuf_get_pending_transactions( $args = [] ) {
     global $wpdb;
 
+    $orderby = [ 'id', 'status', 'created' ];
+    $order   = [ 'asc', 'desc' ];
+
     $defaults = [
         'number'  => 20,
         'offset'  => 0,
@@ -2158,6 +2172,14 @@ function wpuf_get_pending_transactions( $args = [] ) {
     ];
 
     $args = wp_parse_args( $args, $defaults );
+
+    if ( ! in_array( $args['orderby'], $orderby ) ) {
+        $args['orderby'] = 'id';
+    }
+
+    if ( ! in_array( $args['order'], $order ) ) {
+        $args['order'] = 'DESC';
+    }
 
     $pending_args = [
         'post_type'      => 'wpuf_order',
@@ -2218,7 +2240,7 @@ function wpuf_get_pending_transactions( $args = [] ) {
  *
  * @param $args
  *
- * @return array
+ * @return array|int|void
  */
 function wpuf_get_all_transactions( $args = [] ) {
     global $wpdb;


### PR DESCRIPTION
validate orderby and order input params for sorting a WP list table. details [here](https://github.com/weDevsOfficial/wpuf-pro/issues/609).

for testers: please check the Transactions are showing, sorting properly in WP dashboard > WPUF > Transections menu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation for `orderby` and `order` parameters in transaction functions to prevent invalid values.
  
- **Enhancements**
  - Default sorting options introduced for completed and pending transactions.
  - Improved return types for transaction fetching functions to handle more scenarios.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->