### PR TITLE
fix: state field is not changing

### DIFF
--- a/includes/Ajax.php
+++ b/includes/Ajax.php
@@ -46,7 +46,7 @@ class Ajax {
         $this->register_ajax( 'wpuf_account_update_profile', [ new Frontend\Frontend_Account(), 'update_profile' ], $this->logged_in_only );
         $this->register_ajax( 'wpuf_import_forms', [ new Admin\Admin_Tools(), 'import_forms' ], $this->logged_in_only );
         $this->register_ajax( 'wpuf_get_child_cat', 'wpuf_get_child_cats' );
-        $this->register_ajax( 'wpuf_ajax_address', 'wpuf_get_child_cats' );
+        $this->register_ajax( 'wpuf_ajax_address', 'wpuf_ajax_get_states_field' );
         $this->register_ajax( 'wpuf_update_billing_address', 'wpuf_update_billing_address' );
         $this->register_ajax( 'wpuf_clear_schedule_lock', 'wpuf_clear_schedule_lock', $this->logged_in_only );
     }

--- a/includes/Frontend.php
+++ b/includes/Frontend.php
@@ -139,12 +139,19 @@ class Frontend {
                     ]
                 )
             );
-
             wp_localize_script(
                 'wpuf-frontend-form', 'error_str_obj', [
                     'required'   => __( 'is required', 'wp-user-frontend' ),
                     'mismatch'   => __( 'does not match', 'wp-user-frontend' ),
                     'validation' => __( 'is not valid', 'wp-user-frontend' ),
+                ]
+            );
+            wp_localize_script(
+                'wpuf-billing-address',
+                'ajax_object',
+                [
+                    'ajaxurl'     => admin_url( 'admin-ajax.php' ),
+                    'fill_notice' => __( 'Some Required Fields are not filled!', 'wp-user-frontend' ),
                 ]
             );
         }

--- a/includes/Frontend/Frontend_Account.php
+++ b/includes/Frontend/Frontend_Account.php
@@ -280,10 +280,13 @@ class Frontend_Account {
      * @return void
      */
     public function billing_address_section( $sections, $current_section ) {
-        wpuf_load_template( 'dashboard/billing-address.php', [
-            'sections'        => $sections,
-            'current_section' => $current_section,
-        ] );
+        wpuf_load_template(
+            'dashboard/billing-address.php',
+            [
+                'sections'        => $sections,
+                'current_section' => $current_section,
+            ]
+        );
     }
 
     /**

--- a/templates/dashboard/billing-address.php
+++ b/templates/dashboard/billing-address.php
@@ -8,7 +8,6 @@ $cs             = new WeDevs\Wpuf\Data\Country_State();
 
 
 if ( isset( $_POST['update_billing_address'] ) ) {
-
     if ( ! isset( $_POST['wpuf_save_address_nonce'] ) || ! wp_verify_nonce( sanitize_key( $_POST['wpuf_save_address_nonce'] ), 'wpuf_address_ajax_action' ) ) {
         return;
     }


### PR DESCRIPTION
Options in State field is not changing according to the selected Country while setting up billing address.

Issue:
In frontend, options in State field is not changing

Scenario:

Go to frontend as an logged-in user
Go to account page
Click on billing address
Set country from country field except USA
Observe State/Province/Region field
Expected behaviour: Should be able to set the state according to the selected country

fixes [#584](https://github.com/weDevsOfficial/wpuf-pro/issues/584)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated AJAX functionality for address handling to improve data retrieval related to states.
	- Enhanced billing address script with localized notifications for required fields, improving user feedback during form submission.
  
- **Style**
	- Reformatted code for improved readability in the billing address section of the account frontend.
	- Minor formatting adjustments in the billing address template for cleaner code structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->