### PR TITLE
fix: different languages breaking design

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -906,42 +906,42 @@ span.pro-icon:hover .wpuf-pro-field-tooltip {
 .headway-header ul li a:hover {
   text-decoration: underline;
 }
-.user-frontend_page_wpuf-post-forms .wrap h2.with-headway-icon,
-.user-frontend_page_wpuf-profile-forms .wrap h2.with-headway-icon,
-.user-frontend_page_wpuf-settings .wrap h2.with-headway-icon {
+.wrap h2.with-headway-icon,
+.wrap h2.with-headway-icon,
+.wrap h2.with-headway-icon {
   display: flex;
   justify-content: space-between;
 }
-.user-frontend_page_wpuf-post-forms .wrap h2.with-headway-icon .flex-end,
-.user-frontend_page_wpuf-profile-forms .wrap h2.with-headway-icon .flex-end,
-.user-frontend_page_wpuf-settings .wrap h2.with-headway-icon .flex-end {
+.wrap h2.with-headway-icon .flex-end,
+.wrap h2.with-headway-icon .flex-end,
+.wrap h2.with-headway-icon .flex-end {
   display: flex;
   align-items: center;
 }
-.user-frontend_page_wpuf-post-forms .wrap h2.with-headway-icon .flex-end .HW_badge.HW_softHidden,
-.user-frontend_page_wpuf-profile-forms .wrap h2.with-headway-icon .flex-end .HW_badge.HW_softHidden,
-.user-frontend_page_wpuf-settings .wrap h2.with-headway-icon .flex-end .HW_badge.HW_softHidden {
+.wrap h2.with-headway-icon .flex-end .HW_badge.HW_softHidden,
+.wrap h2.with-headway-icon .flex-end .HW_badge.HW_softHidden,
+.wrap h2.with-headway-icon .flex-end .HW_badge.HW_softHidden {
   background: #eea6d0 !important;
 }
-.user-frontend_page_wpuf-post-forms .wrap h2.with-headway-icon .flex-end .flex-end .headway-icon:hover .HW_badge.HW_softHidden,
-.user-frontend_page_wpuf-profile-forms .wrap h2.with-headway-icon .flex-end .flex-end .headway-icon:hover .HW_badge.HW_softHidden,
-.user-frontend_page_wpuf-settings .wrap h2.with-headway-icon .flex-end .flex-end .headway-icon:hover .HW_badge.HW_softHidden {
+.wrap h2.with-headway-icon .flex-end .flex-end .headway-icon:hover .HW_badge.HW_softHidden,
+.wrap h2.with-headway-icon .flex-end .flex-end .headway-icon:hover .HW_badge.HW_softHidden,
+.wrap h2.with-headway-icon .flex-end .flex-end .headway-icon:hover .HW_badge.HW_softHidden {
   background: #ee62b4 !important;
 }
-.user-frontend_page_wpuf-post-forms .wrap h2.with-headway-icon .flex-end a.canny-link,
-.user-frontend_page_wpuf-profile-forms .wrap h2.with-headway-icon .flex-end a.canny-link,
-.user-frontend_page_wpuf-settings .wrap h2.with-headway-icon .flex-end a.canny-link {
+.wrap h2.with-headway-icon .flex-end a.canny-link,
+.wrap h2.with-headway-icon .flex-end a.canny-link,
+.wrap h2.with-headway-icon .flex-end a.canny-link {
   font-size: 1rem;
   text-decoration: none;
 }
-.user-frontend_page_wpuf-post-forms .wrap h2.with-headway-icon .flex-end a.canny-link:hover,
-.user-frontend_page_wpuf-profile-forms .wrap h2.with-headway-icon .flex-end a.canny-link:hover,
-.user-frontend_page_wpuf-settings .wrap h2.with-headway-icon .flex-end a.canny-link:hover {
+.wrap h2.with-headway-icon .flex-end a.canny-link:hover,
+.wrap h2.with-headway-icon .flex-end a.canny-link:hover,
+.wrap h2.with-headway-icon .flex-end a.canny-link:hover {
   text-decoration: underline;
 }
-.user-frontend_page_wpuf-post-forms .wrap h2.with-headway-icon #HW_frame_cont,
-.user-frontend_page_wpuf-profile-forms .wrap h2.with-headway-icon #HW_frame_cont,
-.user-frontend_page_wpuf-settings .wrap h2.with-headway-icon #HW_frame_cont {
+.wrap h2.with-headway-icon #HW_frame_cont,
+.wrap h2.with-headway-icon #HW_frame_cont,
+.wrap h2.with-headway-icon #HW_frame_cont {
   top: 78px !important;
 }
 @media only screen and (max-width: 1399px) {

--- a/assets/less/admin.less
+++ b/assets/less/admin.less
@@ -1136,9 +1136,9 @@ span.pro-icon:hover .wpuf-pro-field-tooltip {
     }
 }
 
-.user-frontend_page_wpuf-post-forms .wrap h2.with-headway-icon,
-.user-frontend_page_wpuf-profile-forms .wrap h2.with-headway-icon,
-.user-frontend_page_wpuf-settings .wrap h2.with-headway-icon {
+.wrap h2.with-headway-icon,
+.wrap h2.with-headway-icon,
+.wrap h2.with-headway-icon {
     display: flex;
     justify-content: space-between;
 

--- a/includes/Admin/Menu.php
+++ b/includes/Admin/Menu.php
@@ -308,8 +308,6 @@ class Menu {
      * @return void
      */
     public function enqueue_settings_page_scripts() {
-        wp_enqueue_style( 'wpuf-admin' );
-        wp_enqueue_script( 'wpuf-admin' );
         wp_enqueue_script( 'wpuf-subscriptions' );
         wp_enqueue_script( 'wpuf-settings' );
 


### PR DESCRIPTION
Issue:
Change language to Spanish -> Go to Post-forms-page/Registration-forms-page/Settings-page --> The headway and Canny design are broken

fixes [#576](https://github.com/weDevsOfficial/wpuf-pro/issues/576)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style Improvements**
	- Simplified CSS selectors for headers with the class `.with-headway-icon`, enhancing maintainability and consistency across user frontend pages.
  
- **Functionality Adjustments**
	- Removed unnecessary loading of admin styles and scripts from the settings page, streamlining resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->