### PR TITLE
enhance: inconsistent format in email templates

### DIFF
--- a/includes/Admin/Forms/Post/Templates/Post_Form_Template_Events_Calendar.php
+++ b/includes/Admin/Forms/Post/Templates/Post_Form_Template_Events_Calendar.php
@@ -192,7 +192,7 @@ class Post_Form_Template_Events_Calendar extends Form_Template{
                 'new_to'       => get_option( 'admin_email' ),
                 'new_subject'  => 'New event has been created',
                 'new_body'     => 'Hi,
-A new event has been created in your site %sitename% (%siteurl%).
+A new event has been created in your site {sitename} ({siteurl}).
 
 Here is the details:
 Event Title: {post_title}

--- a/includes/Admin/Forms/Post/Templates/Post_Form_Template_Events_Calendar.php
+++ b/includes/Admin/Forms/Post/Templates/Post_Form_Template_Events_Calendar.php
@@ -182,7 +182,7 @@ class Post_Form_Template_Events_Calendar extends Form_Template{
             'submit_text'      => __( 'Create Event', 'wp-user-frontend' ),
             'edit_post_status' => 'publish',
             'edit_redirect_to' => 'same',
-            'update_message'   => __( 'Event has been updated successfully. <a target="_blank" href="%link%">View event</a>',
+            'update_message'   => __( 'Event has been updated successfully. <a target="_blank" href="{link}">View event</a>',
                                       'wp-user-frontend' ),
             'edit_url'         => '',
             'update_text'      => __( 'Update Event', 'wp-user-frontend' ),
@@ -195,25 +195,25 @@ class Post_Form_Template_Events_Calendar extends Form_Template{
 A new event has been created in your site %sitename% (%siteurl%).
 
 Here is the details:
-Event Title: %post_title%
-Description: %post_content%
-Short Description: %post_excerpt%
-Author: %author%
-Post URL: %permalink%
-Edit URL: %editlink%',
+Event Title: {post_title}
+Description: {post_content}
+Short Description: {post_excerpt}
+Author: {author}
+Post URL: {permalink}
+Edit URL: {editlink}',
                 'edit'         => 'off',
                 'edit_to'      => get_option( 'admin_email' ),
                 'edit_subject' => 'Post has been edited',
                 'edit_body'    => 'Hi,
-The event "%post_title%" has been updated.
+The event "{post_title}" has been updated
 
 Here is the details:
-Event Title: %post_title%
-Description: %post_content%
-Short Description: %post_excerpt%
-Author: %author%
-Post URL: %permalink%
-Edit URL: %editlink%',
+Event Title: {post_title}
+Description: {post_content}
+Short Description: {post_excerpt}
+Author: {author}
+Post URL: {permalink}
+Edit URL: {editlink}'
             ],
         ];
     }

--- a/includes/Admin/Forms/Post/Templates/Post_Form_Template_Post.php
+++ b/includes/Admin/Forms/Post/Templates/Post_Form_Template_Post.php
@@ -157,7 +157,7 @@ class Post_Form_Template_Post extends Form_Template {
                 'new_to'                     => get_option( 'admin_email' ),
                 'new_subject'                => 'New post has been created',
                 'new_body'                   => 'Hi,
-                A new post has been created in your site %sitename% (%siteurl%).
+                A new post has been created in your site {sitename} ({siteurl}).
 
                 Here is the details:
                 Post Title: {post_title}

--- a/includes/Admin/Forms/Post/Templates/Post_Form_Template_Post.php
+++ b/includes/Admin/Forms/Post/Templates/Post_Form_Template_Post.php
@@ -148,7 +148,7 @@ class Post_Form_Template_Post extends Form_Template {
                 ],
                 'edit_post_status'           => 'publish',
                 'edit_redirect_to'           => 'same',
-                'update_message'             => __( 'Post has been updated successfully. <a target="_blank" href="%link%">View post</a>', 'wp-user-frontend' ),
+                'update_message'             => __( 'Post has been updated successfully. <a target="_blank" href="{link}">View post</a>', 'wp-user-frontend' ),
                 'edit_url'                   => '',
                 'update_text'                => __( 'Update Post', 'wp-user-frontend' ),
                 'form_template'              => 'post_form_template_post',
@@ -160,25 +160,25 @@ class Post_Form_Template_Post extends Form_Template {
                 A new post has been created in your site %sitename% (%siteurl%).
 
                 Here is the details:
-                Post Title: %post_title%
-                Description: %post_content%
-                Short Description: %post_excerpt%
-                Author: %author%
-                Post URL: %permalink%
-                Edit URL: %editlink%',
+                Post Title: {post_title}
+                Description: {post_content}
+                Short Description: {post_excerpt}
+                Author: {author}
+                Post URL: {permalink}
+                Edit URL: {editlink}',
                 'edit'                       => 'off',
                 'edit_to'                    => get_option( 'admin_email' ),
                 'edit_subject'               => 'Post has been edited',
                 'edit_body'                  => 'Hi,
-                The post "%post_title%" has been updated.
+                The post "{post_title}" has been updated
 
                 Here is the details:
-                Post Title: %post_title%
-                Description: %post_content%
-                Short Description: %post_excerpt%
-                Author: %author%
-                Post URL: %permalink%
-                Edit URL: %editlink%',
+                Post Title: {post_title}
+                Description: {post_content}
+                Short Description: {post_excerpt}
+                Author: {author}
+                Post URL: {permalink}
+                Edit URL: {editlink}'
                 ],
             ];
     }

--- a/includes/Admin/Forms/Post/Templates/Post_Form_Template_WooCommerce.php
+++ b/includes/Admin/Forms/Post/Templates/Post_Form_Template_WooCommerce.php
@@ -199,7 +199,7 @@ class Post_Form_Template_WooCommerce extends Form_Template {
                 'new_to'       => get_option( 'admin_email' ),
                 'new_subject'  => 'New product has been created',
                 'new_body'     => 'Hi,
-A new product has been created in your site %sitename% (%siteurl%).
+A new product has been created in your site {sitename} ({siteurl}).
 
 Here is the details:
 Product Title: {post_title}

--- a/includes/Admin/Forms/Post/Templates/Post_Form_Template_WooCommerce.php
+++ b/includes/Admin/Forms/Post/Templates/Post_Form_Template_WooCommerce.php
@@ -190,7 +190,7 @@ class Post_Form_Template_WooCommerce extends Form_Template {
             'submit_text'      => 'Create Product',
             'edit_post_status' => 'publish',
             'edit_redirect_to' => 'same',
-            'update_message'   => 'Product has been updated successfully. <a target="_blank" href="%link%">View Product</a>',
+            'update_message'   => 'Product has been updated successfully. <a target="_blank" href="{link}">View Product</a>',
             'edit_url'         => '',
             'update_text'      => 'Update Product',
             'form_template'    => 'post_form_template_woocommerce',
@@ -202,25 +202,25 @@ class Post_Form_Template_WooCommerce extends Form_Template {
 A new product has been created in your site %sitename% (%siteurl%).
 
 Here is the details:
-Product Title: %post_title%
-Description: %post_content%
-Short Description: %post_excerpt%
-Author: %author%
-Post URL: %permalink%
-Edit URL: %editlink%',
+Product Title: {post_title}
+Description: {post_content}
+Short Description: {post_excerpt}
+Author: {author}
+Post URL: {permalink}
+Edit URL: {editlink}',
                 'edit'         => 'off',
                 'edit_to'      => get_option( 'admin_email' ),
                 'edit_subject' => 'Product has been edited',
                 'edit_body'    => 'Hi,
-The product "%post_title%" has been updated.
+The product "{post_title}" has been updated
 
 Here is the details:
-Product Title: %post_title%
-Description: %post_content%
-Short Description: %post_excerpt%
-Author: %author%
-Post URL: %permalink%
-Edit URL: %editlink%',
+Product Title: {post_title}
+Description: {post_content}
+Short Description: {post_excerpt}
+Author: {author}
+Post URL: {permalink}
+Edit URL: {editlink}'
             ],
         ];
     }

--- a/includes/Admin/Upgrades.php
+++ b/includes/Admin/Upgrades.php
@@ -24,6 +24,7 @@ class Upgrades {
         '2.9.2'  => 'upgrades/upgrade-2.9.2.php',
         '3.6.0'  => 'upgrades/upgrade-3.6.0.php',
         '4.0.4'  => 'upgrades/upgrade-4.0.4.php',
+        '4.0.11' => 'upgrades/upgrade-4.0.11.php',
     ];
 
     /**
@@ -53,7 +54,6 @@ class Upgrades {
      * @return bool
      */
     public function needs_update() {
-
         // may be it's the first install
         if ( ! $this->get_version() ) {
             return false;
@@ -88,11 +88,10 @@ class Upgrades {
                 if ( file_exists( $path ) ) {
                     include_once $path;
                 }
-                update_option( 'wpuf_version', $version );
             }
         }
 
-        update_option( 'wpuf_version', WPUF_VERSION );
+        update_option( wpuf()->get_db_version_key(), WPUF_VERSION );
     }
 
     /**
@@ -118,8 +117,8 @@ class Upgrades {
             );
             ?>
             <div id="message" class="updated">
-                <p><?php printf( '<strong>%s</strong>', esc_attr__( 'WPUF Data Update Required', 'wp-user-frontend' ) ); ?></p>
-                <p class="submit"><a href="<?php echo esc_url( $link ); ?>" class="wpuf-update-btn button-primary"><?php esc_attr_e( 'Run the updater', 'wp-user-frontend' ); ?></a></p>
+                <p><?php printf( '<strong>%s</strong>', esc_html__( 'WPUF Data Update Required', 'wp-user-frontend' ) ); ?></p>
+                <p class="submit"><a href="<?php echo esc_url( $link ); ?>" class="wpuf-update-btn button-primary"><?php esc_html_e( 'Run the updater', 'wp-user-frontend' ); ?></a></p>
             </div>
 
             <script type="text/javascript">

--- a/includes/Ajax/Frontend_Form_Ajax.php
+++ b/includes/Ajax/Frontend_Form_Ajax.php
@@ -658,14 +658,14 @@ class Frontend_Form_Ajax {
         ];
 
         if ( class_exists( 'WooCommerce' ) ) {
-            $post_field_search[] = '%product_cat%';
+            $post_field_search[] = '{product_cat}';
             $post_field_replace[] = get_the_term_list( $post_id, 'product_cat', '', ', ' );
         }
 
         $content = str_replace( $post_field_search, $post_field_replace, $content );
 
         // custom fields
-        preg_match_all( '/%custom_([\w-]*)\b%/', $content, $matches );
+        preg_match_all( '/{custom_([\w-]*)\b}/', $content, $matches );
         [ $search, $replace ] = $matches;
 
         if ( $replace ) {

--- a/includes/Ajax/Frontend_Form_Ajax.php
+++ b/includes/Ajax/Frontend_Form_Ajax.php
@@ -624,18 +624,18 @@ class Frontend_Form_Ajax {
         $post = get_post( $post_id );
 
         $post_field_search = [
-            '%post_title%',
-            '%post_content%',
-            '%post_excerpt%',
-            '%tags%',
-            '%category%',
-            '%author%',
-            '%author_email%',
-            '%author_bio%',
-            '%sitename%',
-            '%siteurl%',
-            '%permalink%',
-            '%editlink%',
+            '{post_title}',
+            '{post_content}',
+            '{post_excerpt}',
+            '{tags}',
+            '{category}',
+            '{author}',
+            '{author_email}',
+            '{author_bio}',
+            '{sitename}',
+            '{siteurl}',
+            '{permalink}',
+            '{editlink}',
         ];
 
         $home_url = sprintf( '<a href="%s">%s</a>', home_url(), home_url() );

--- a/includes/Free/Form_Element.php
+++ b/includes/Free/Form_Element.php
@@ -191,7 +191,7 @@ class Form_Element extends Pro_Prompt {
         global $post;
 
         $new_mail_body  = "Hi Admin,\r\n";
-        $new_mail_body .= "A new post has been created in your site %sitename% (%siteurl%).\r\n\r\n";
+        $new_mail_body .= "A new post has been created in your site {sitename} ({siteurl}).\r\n\r\n";
 
         $edit_mail_body = "Hi Admin,\r\n";
         $edit_mail_body .= "The post \"{post_title}\" has been updated.\r\n\r\n";

--- a/includes/Free/Form_Element.php
+++ b/includes/Free/Form_Element.php
@@ -194,14 +194,14 @@ class Form_Element extends Pro_Prompt {
         $new_mail_body .= "A new post has been created in your site %sitename% (%siteurl%).\r\n\r\n";
 
         $edit_mail_body = "Hi Admin,\r\n";
-        $edit_mail_body .= "The post \"%post_title%\" has been updated.\r\n\r\n";
+        $edit_mail_body .= "The post \"{post_title}\" has been updated.\r\n\r\n";
 
         $mail_body      = "Here is the details:\r\n";
-        $mail_body .= "Post Title: %post_title%\r\n";
-        $mail_body .= "Content: %post_content%\r\n";
-        $mail_body .= "Author: %author%\r\n";
-        $mail_body .= "Post URL: %permalink%\r\n";
-        $mail_body .= 'Edit URL: %editlink%';
+        $mail_body .= "Post Title: {post_title}\r\n";
+        $mail_body .= "Content: {post_content}\r\n";
+        $mail_body .= "Author: {author}\r\n";
+        $mail_body .= "Post URL: {permalink}\r\n";
+        $mail_body .= 'Edit URL: {editlink}';
 
         $form_settings = wpuf_get_form_settings( $post->ID );
 
@@ -288,13 +288,13 @@ class Form_Element extends Pro_Prompt {
 
         <h3><?php esc_html_e( 'You may use in to, subject & message:', 'wp-user-frontend' ); ?></h3>
         <p>
-            <code>%post_title%</code>, <code>%post_content%</code>, <code>%post_excerpt%</code>, <code>%tags%</code>, <code>%category%</code>,
+            <code>{post_title}</code>, <code>{post_content}</code>, <code>{post_excerpt}</code>, <code>{tags}</code>, <code>{category}</code>,
             <?php
             if ( class_exists( 'WooCommerce' ) ) :
 				?>
-                 <code>%product_cat%</code> <?php endif ?>,
-            <code>%author%</code>, <code>%author_email%</code>, <code>%author_bio%</code>, <code>%sitename%</code>, <code>%siteurl%</code>, <code>%permalink%</code>, <code>%editlink%</code>
-            <br><code>%custom_{NAME_OF_CUSTOM_FIELD}%</code> e.g: <code>%custom_website_url%</code> for <code>website_url</code> meta field
+                <code>{product_cat}</code> <?php endif ?>,
+            <code>{author}</code>, <code>{author_email}</code>, <code>{author_bio}</code>, <code>{sitename}</code>, <code>{siteurl}</code>, <code>{permalink}</code>, <code>{editlink}</code>
+            <br><code>{custom_{NAME_OF_CUSTOM_FIELD}}</code> e.g: <code>{custom_website_url}</code> for <code>website_url</code> meta field
         </p>
 
 		<?php

--- a/includes/Frontend/Frontend_Form.php
+++ b/includes/Frontend/Frontend_Form.php
@@ -125,7 +125,7 @@ class Frontend_Form extends Frontend_Render_Form {
 
         if ( $msg === 'post_updated' ) {
             echo wp_kses_post( '<div class="wpuf-success">' );
-            echo wp_kses_post( str_replace( '%link%', get_permalink( $post_id ), $this->form_settings['update_message'] ) );
+            echo wp_kses_post( str_replace( '{link}', get_permalink( $post_id ), $this->form_settings['update_message'] ) );
             echo wp_kses_post( '</div>' );
         }
 

--- a/includes/upgrades/upgrade-4.0.11.php
+++ b/includes/upgrades/upgrade-4.0.11.php
@@ -55,8 +55,6 @@ function wpuf_upgrade_4_0_11_migration() {
         '{link}',
     ];
 
-    // error_log( print_r( $form_settings, true ) );
-
     foreach ( $form_settings as $form_setting ) {
         $unserilized = maybe_unserialize( $form_setting->meta_value );
 
@@ -64,7 +62,7 @@ function wpuf_upgrade_4_0_11_migration() {
             $new_body         = $unserilized['notification']['new_body'];
             $updated_new_body = str_replace( $search, $replace, $new_body );
 
-            $unserilized['notification']['email_body'] = $updated_new_body;
+            $unserilized['notification']['new_body'] = $updated_new_body;
         }
 
         if ( isset( $unserilized['notification']['edit_body'] ) ) {

--- a/includes/upgrades/upgrade-4.0.11.php
+++ b/includes/upgrades/upgrade-4.0.11.php
@@ -1,0 +1,81 @@
+<?php
+
+function wpuf_upgrade_4_0_11_migration() {
+    global $wpdb;
+
+    // get all the post meta from postmeta table where meta_key is 'wpuf_form_settings'
+    $form_settings = $wpdb->get_results( "SELECT * FROM {$wpdb->postmeta} WHERE meta_key = 'wpuf_form_settings'" );
+
+    if ( empty( $form_settings ) ) {
+        return;
+    }
+
+    $search  = [
+        '%username%',
+        '%user_email%',
+        '%display_name%',
+        '%user_status%',
+        '%pending_users%',
+        '%approved_users%',
+        '%denied_users%',
+        '%sitename%',
+        '%post_title%',
+        '%post_content%',
+        '%post_excerpt%',
+        '%tags%',
+        '%category%',
+        '%author%',
+        '%author_email%',
+        '%author_bio%',
+        '%siteurl%',
+        '%permalink%',
+        '%editlink%',
+        '%link%',
+    ];
+    $replace = [
+        '{username}',
+        '{user_email}',
+        '{display_name}',
+        '{user_status}',
+        '{pending_users}',
+        '{approved_users}',
+        '{denied_users}',
+        '{sitename}',
+        '{post_title}',
+        '{post_content}',
+        '{post_excerpt}',
+        '{tags}',
+        '{category}',
+        '{author}',
+        '{author_email}',
+        '{author_bio}',
+        '{siteurl}',
+        '{permalink}',
+        '{editlink}',
+        '{link}',
+    ];
+
+    // error_log( print_r( $form_settings, true ) );
+
+    foreach ( $form_settings as $form_setting ) {
+        $unserilized = maybe_unserialize( $form_setting->meta_value );
+
+        if ( isset( $unserilized['notification']['new_body'] ) ) {
+            $new_body         = $unserilized['notification']['new_body'];
+            $updated_new_body = str_replace( $search, $replace, $new_body );
+
+            $unserilized['notification']['email_body'] = $updated_new_body;
+        }
+
+        if ( isset( $unserilized['notification']['edit_body'] ) ) {
+            $edit_body         = $unserilized['notification']['edit_body'];
+            $updated_edit_body = str_replace( $search, $replace, $edit_body );
+
+            $unserilized['notification']['edit_body'] = $updated_edit_body;
+        }
+
+        update_post_meta( $form_setting->post_id, 'wpuf_form_settings', $unserilized );
+    }
+}
+
+wpuf_upgrade_4_0_11_migration();

--- a/languages/wp-user-frontend.pot
+++ b/languages/wp-user-frontend.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: WP User Frontend 4.0.10\n"
 "Report-Msgid-Bugs-To: https://wedevs.com/contact/\n"
-"POT-Creation-Date: 2024-08-08 09:32:14+00:00\n"
+"POT-Creation-Date: 2024-08-22 03:44:53+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -133,7 +133,7 @@ msgstr ""
 #: admin/class-admin-settings.php:119 admin/class-admin-settings.php:167
 #: admin/form-builder/views/form-builder.php:9
 #: includes/Admin/Admin_Settings.php:68 includes/Admin/Menu.php:81
-#: includes/Admin/Menu.php:329 includes/Setup_Wizard.php:154
+#: includes/Admin/Menu.php:327 includes/Setup_Wizard.php:154
 msgid "Settings"
 msgstr ""
 
@@ -649,8 +649,7 @@ msgid "Name"
 msgstr ""
 
 #: admin/html/form-submission-restriction.php:12
-#: includes/Admin/List_Table_Transactions.php:56
-#: includes/Admin/views/support.php:223 includes/WPUF_Privacy.php:363
+#: includes/Admin/List_Table_Transactions.php:56 includes/WPUF_Privacy.php:363
 #: includes/functions/user/edit-user.php:166 templates/registration-form.php:48
 msgid "Email"
 msgstr ""
@@ -1978,16 +1977,16 @@ msgstr ""
 #: includes/Admin/Customizer_Options.php:86
 #: includes/Ajax/Address_Form_Ajax.php:167 includes/Traits/TaxableTrait.php:81
 #: includes/Traits/TaxableTrait.php:190 includes/WPUF_Privacy.php:270
+#: templates/dashboard/billing-address.php:50
 #: templates/dashboard/billing-address.php:51
-#: templates/dashboard/billing-address.php:52
 msgid "Country"
 msgstr ""
 
 #: includes/Admin/Customizer_Options.php:46
 #: includes/Admin/Customizer_Options.php:87
 #: includes/Ajax/Address_Form_Ajax.php:210
+#: templates/dashboard/billing-address.php:89
 #: templates/dashboard/billing-address.php:90
-#: templates/dashboard/billing-address.php:91
 msgid "State/Province/Region"
 msgstr ""
 
@@ -2004,8 +2003,8 @@ msgstr ""
 #: includes/Admin/Customizer_Options.php:49
 #: includes/Admin/Customizer_Options.php:90
 #: includes/Ajax/Address_Form_Ajax.php:265 includes/WPUF_Privacy.php:258
+#: templates/dashboard/billing-address.php:147
 #: templates/dashboard/billing-address.php:148
-#: templates/dashboard/billing-address.php:149
 msgid "City"
 msgstr ""
 
@@ -2621,7 +2620,7 @@ msgstr ""
 msgid "No transactions found."
 msgstr ""
 
-#: includes/Admin/Menu.php:333
+#: includes/Admin/Menu.php:331
 #: includes/Admin/views/post-forms-list-table-view.php:16
 msgid "Submit Ideas"
 msgstr ""
@@ -3000,7 +2999,7 @@ msgstr ""
 msgid "View all Documentations"
 msgstr ""
 
-#: includes/Admin/views/support.php:210
+#: includes/Admin/views/support.php:209
 msgid "Subscribe to Our Newsletter"
 msgstr ""
 
@@ -3010,113 +3009,108 @@ msgid ""
 "<strong>offers</strong> and <strong>news updates</strong>."
 msgstr ""
 
-#: includes/Admin/views/support.php:218 includes/Free/Edit_Profile.php:108
-#: includes/WPUF_Privacy.php:355
-msgid "First Name"
-msgstr ""
-
-#: includes/Admin/views/support.php:229
+#: includes/Admin/views/support.php:252
 msgid "Subscribe"
 msgstr ""
 
-#: includes/Admin/views/support.php:240
+#: includes/Admin/views/support.php:265
 msgid "Plugin Setup"
 msgstr ""
 
-#: includes/Admin/views/support.php:246
+#: includes/Admin/views/support.php:271
 #: includes/functions/settings-options.php:19
 msgid "Frontend Posting"
 msgstr ""
 
-#: includes/Admin/views/support.php:252
+#: includes/Admin/views/support.php:277
 msgid "Frontend Dashboard"
 msgstr ""
 
-#: includes/Admin/views/support.php:258
+#: includes/Admin/views/support.php:283
 msgid "User Registration"
 msgstr ""
 
-#: includes/Admin/views/support.php:264
+#: includes/Admin/views/support.php:289
 msgid "User Login"
 msgstr ""
 
-#: includes/Admin/views/support.php:270
+#: includes/Admin/views/support.php:295
 msgid "Profile Editing"
 msgstr ""
 
-#: includes/Admin/views/support.php:276
+#: includes/Admin/views/support.php:301
 msgid "Subscription &amp; Payment"
 msgstr ""
 
-#: includes/Admin/views/support.php:282 includes/Fields/Field_Contract.php:69
+#: includes/Admin/views/support.php:307 includes/Fields/Field_Contract.php:69
 msgid "Content Restriction"
 msgstr ""
 
-#: includes/Admin/views/support.php:304
+#: includes/Admin/views/support.php:329
 msgid "Learn More About Installation"
 msgstr ""
 
-#: includes/Admin/views/support.php:315
+#: includes/Admin/views/support.php:340
 msgid "Learn More About Frontend Posting"
 msgstr ""
 
-#: includes/Admin/views/support.php:325
+#: includes/Admin/views/support.php:350
 msgid "Learn More About Frontend Dashboard"
 msgstr ""
 
-#: includes/Admin/views/support.php:355
+#: includes/Admin/views/support.php:380
 msgid "Learn More About Registration"
 msgstr ""
 
-#: includes/Admin/views/support.php:371
+#: includes/Admin/views/support.php:396
 msgid "Learn More About Login"
 msgstr ""
 
-#: includes/Admin/views/support.php:388
+#: includes/Admin/views/support.php:413
 msgid "Learn More About Profile Editing"
 msgstr ""
 
-#: includes/Admin/views/support.php:441
+#: includes/Admin/views/support.php:466
 msgid "Learn More About Payments"
 msgstr ""
 
-#: includes/Admin/views/support.php:458
+#: includes/Admin/views/support.php:483
 msgid "Learn More About Content Restriction"
 msgstr ""
 
-#: includes/Admin/views/support.php:467 includes/Admin/views/support.php:469
+#: includes/Admin/views/support.php:492 includes/Admin/views/support.php:494
 msgid "Like The Plugin?"
 msgstr ""
 
-#: includes/Admin/views/support.php:471
+#: includes/Admin/views/support.php:496
 msgid "Your Review is very important to us as it helps us to grow more."
 msgstr ""
 
-#: includes/Admin/views/support.php:473
+#: includes/Admin/views/support.php:498
 msgid "Review Us on WP.org"
 msgstr ""
 
-#: includes/Admin/views/support.php:477 includes/Admin/views/support.php:479
+#: includes/Admin/views/support.php:502 includes/Admin/views/support.php:504
 msgid "Found Any Bugs?"
 msgstr ""
 
-#: includes/Admin/views/support.php:481
+#: includes/Admin/views/support.php:506
 msgid "Report any Bug that you Discovered, Get Instant Solutions."
 msgstr ""
 
-#: includes/Admin/views/support.php:483
+#: includes/Admin/views/support.php:508
 msgid "Report to GitHub"
 msgstr ""
 
-#: includes/Admin/views/support.php:487 includes/Admin/views/support.php:489
+#: includes/Admin/views/support.php:512 includes/Admin/views/support.php:514
 msgid "Need Any Assistance?"
 msgstr ""
 
-#: includes/Admin/views/support.php:491
+#: includes/Admin/views/support.php:516
 msgid "Our EXPERT Support Team is always ready to Help you out."
 msgstr ""
 
-#: includes/Admin/views/support.php:493
+#: includes/Admin/views/support.php:518
 msgid "Contact Support"
 msgstr ""
 
@@ -3124,39 +3118,39 @@ msgstr ""
 msgid "Import"
 msgstr ""
 
-#: includes/Ajax/Address_Form_Ajax.php:40
+#: includes/Ajax/Address_Form_Ajax.php:40 includes/Frontend.php:154
 msgid "Some Required Fields are not filled!"
 msgstr ""
 
 #: includes/Ajax/Address_Form_Ajax.php:191 includes/Traits/TaxableTrait.php:109
 #: includes/Traits/TaxableTrait.php:212 includes/Traits/TaxableTrait.php:266
-#: templates/dashboard/billing-address.php:69
+#: templates/dashboard/billing-address.php:68
 msgid "Choose a country"
 msgstr ""
 
 #: includes/Ajax/Address_Form_Ajax.php:224 includes/Traits/TaxableTrait.php:126
 #: includes/Traits/TaxableTrait.php:161 includes/Traits/TaxableTrait.php:234
-#: templates/dashboard/billing-address.php:111
+#: templates/dashboard/billing-address.php:110
 msgid "Choose a state"
 msgstr ""
 
 #: includes/Ajax/Address_Form_Ajax.php:243
-#: templates/dashboard/billing-address.php:134
+#: templates/dashboard/billing-address.php:133
 msgid "Address Line 1 "
 msgstr ""
 
 #: includes/Ajax/Address_Form_Ajax.php:254
-#: templates/dashboard/billing-address.php:142
+#: templates/dashboard/billing-address.php:141
 msgid "Address Line 2 "
 msgstr ""
 
 #: includes/Ajax/Address_Form_Ajax.php:285
-#: templates/dashboard/billing-address.php:167
+#: templates/dashboard/billing-address.php:166
 msgid "Update Billing Address"
 msgstr ""
 
 #: includes/Ajax/Address_Form_Ajax.php:328
-#: templates/dashboard/billing-address.php:32
+#: templates/dashboard/billing-address.php:31
 msgid "Billing address is updated."
 msgstr ""
 
@@ -3620,6 +3614,10 @@ msgstr ""
 
 #: includes/Free/Edit_Profile.php:105
 msgid "Usernames cannot be changed."
+msgstr ""
+
+#: includes/Free/Edit_Profile.php:108 includes/WPUF_Privacy.php:355
+msgid "First Name"
 msgstr ""
 
 #: includes/Free/Edit_Profile.php:113 includes/WPUF_Privacy.php:359
@@ -4684,48 +4682,48 @@ msgstr ""
 msgid "For each"
 msgstr ""
 
-#: includes/Frontend/Frontend_Account.php:299
+#: includes/Frontend/Frontend_Account.php:302
 msgid "Nonce failure"
 msgstr ""
 
-#: includes/Frontend/Frontend_Account.php:310
+#: includes/Frontend/Frontend_Account.php:313
 msgid "First Name is a required field."
 msgstr ""
 
-#: includes/Frontend/Frontend_Account.php:313
+#: includes/Frontend/Frontend_Account.php:316
 msgid "Last Name is a required field."
 msgstr ""
 
-#: includes/Frontend/Frontend_Account.php:316
+#: includes/Frontend/Frontend_Account.php:319
 msgid "Email is a required field."
 msgstr ""
 
-#: includes/Frontend/Frontend_Account.php:325
+#: includes/Frontend/Frontend_Account.php:328
 msgid "Please provide a valid email address."
 msgstr ""
 
-#: includes/Frontend/Frontend_Account.php:327
+#: includes/Frontend/Frontend_Account.php:330
 msgid "This email address is already registered."
 msgstr ""
 
-#: includes/Frontend/Frontend_Account.php:332
+#: includes/Frontend/Frontend_Account.php:335
 msgid "Please fill out all password fields."
 msgstr ""
 
-#: includes/Frontend/Frontend_Account.php:335
+#: includes/Frontend/Frontend_Account.php:338
 msgid "Please enter your current password."
 msgstr ""
 
-#: includes/Frontend/Frontend_Account.php:338
+#: includes/Frontend/Frontend_Account.php:341
 msgid "Please re-enter your password."
 msgstr ""
 
-#: includes/Frontend/Frontend_Account.php:341
+#: includes/Frontend/Frontend_Account.php:344
 msgid "New passwords do not match."
 msgstr ""
 
-#: includes/Frontend/Frontend_Account.php:345
-#: includes/Frontend/Frontend_Account.php:353
+#: includes/Frontend/Frontend_Account.php:348
+#: includes/Frontend/Frontend_Account.php:356
 msgid "Your current password is incorrect."
 msgstr ""
 
@@ -4969,15 +4967,15 @@ msgstr ""
 msgid "Using %shortcode% is restricted"
 msgstr ""
 
-#: includes/Frontend.php:145
+#: includes/Frontend.php:144
 msgid "is required"
 msgstr ""
 
-#: includes/Frontend.php:146
+#: includes/Frontend.php:145
 msgid "does not match"
 msgstr ""
 
-#: includes/Frontend.php:147
+#: includes/Frontend.php:146
 msgid "is not valid"
 msgstr ""
 
@@ -6221,16 +6219,16 @@ msgid ""
 "<a href=\"mailto:%s\">webmaster</a> !"
 msgstr ""
 
-#: templates/dashboard/billing-address.php:133
+#: templates/dashboard/billing-address.php:132
 msgid "Address Line 1"
 msgstr ""
 
-#: templates/dashboard/billing-address.php:141
+#: templates/dashboard/billing-address.php:140
 msgid "Address Line 2"
 msgstr ""
 
-#: templates/dashboard/billing-address.php:156
-#: templates/dashboard/billing-address.php:158
+#: templates/dashboard/billing-address.php:155
+#: templates/dashboard/billing-address.php:157
 msgid "Postal/ZIP Code"
 msgstr ""
 

--- a/wpuf-functions.php
+++ b/wpuf-functions.php
@@ -2963,11 +2963,11 @@ function wpuf_create_sample_form( $post_title = 'Sample Form', $post_type = 'wpu
                 'new'          => 'on',
                 'new_to'       => get_option( 'admin_email' ),
                 'new_subject'  => 'New post created',
-                'new_body'     => "Hi Admin, \r\n\r\nA new post has been created in your site %sitename% (%siteurl%). \r\n\r\nHere is the details: \r\nPost Title: %post_title% \r\nContent: %post_content% \r\nAuthor: %author% \r\nPost URL: %permalink% \r\nEdit URL: %editlink%",
+                'new_body'     => "Hi Admin, \r\n\r\nA new post has been created in your site {sitename} ({siteurl}). \r\n\r\nHere is the details: \r\nPost Title: {post_title} \r\nContent: {post_content} \r\nAuthor: {author} \r\nPost URL: {permalink} \r\nEdit URL: {editlink}",
                 'edit'         => 'off',
                 'edit_to'      => get_option( 'admin_email' ),
                 'edit_subject' => 'A post has been edited',
-                'edit_body'    => "Hi Admin, \r\n\r\nThe post \"%post_title%\" has been updated. \r\n\r\nHere is the details: \r\nPost Title: %post_title% \r\nContent: %post_content% \r\nAuthor: %author% \r\nPost URL: %permalink% \r\nEdit URL: %editlink%",
+                'edit_body'    => "Hi Admin, \r\n\r\nThe post \"{post_title}\" has been updated. \r\n\r\nHere is the details: \r\nPost Title: {post_title} \r\nContent: {post_content} \r\nAuthor: {author} \r\nPost URL: {permalink} \r\nEdit URL: {editlink}",
             ],
         ];
     }

--- a/wpuf.php
+++ b/wpuf.php
@@ -23,7 +23,7 @@ if ( file_exists( $autoload ) ) {
     require_once $autoload;
 }
 
-define( 'WPUF_VERSION', '4.0.10' );
+define( 'WPUF_VERSION', '4.0.11' );
 define( 'WPUF_FILE', __FILE__ );
 define( 'WPUF_ROOT', __DIR__ );
 define( 'WPUF_ROOT_URI', plugins_url( '', __FILE__ ) );
@@ -370,6 +370,17 @@ final class WP_User_Frontend {
         if ( array_key_exists( $prop, $this->container ) ) {
             return $this->container[ $prop ];
         }
+    }
+
+    /**
+     * Get the DB version key
+     *
+     * @since WPUF_SINCE
+     *
+     * @return string
+     */
+    public function get_db_version_key() {
+        return 'wpuf_version';
     }
 }
 

--- a/wpuf.php
+++ b/wpuf.php
@@ -23,7 +23,7 @@ if ( file_exists( $autoload ) ) {
     require_once $autoload;
 }
 
-define( 'WPUF_VERSION', '4.0.11' );
+define( 'WPUF_VERSION', '4.0.10' );
 define( 'WPUF_FILE', __FILE__ );
 define( 'WPUF_ROOT', __DIR__ );
 define( 'WPUF_ROOT_URI', plugins_url( '', __FILE__ ) );


### PR DESCRIPTION
Description: In WP Dashboard > WPUF > Registration Form > Settings > Notification, the help text format are inconsistent. Some uses {placeholder_text} and some uses %placeholder_texts%

fixes [#589](https://github.com/weDevsOfficial/wpuf-pro/issues/589)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated placeholder syntax in message templates from percentage signs to curly braces, enhancing readability and consistency across notifications.
	- Introduced a migration function for form settings to standardize placeholder formats.

- **Bug Fixes**
	- Enhanced security in upgrade notices by properly escaping HTML entities.

- **Chores**
	- Incremented the plugin version to 4.0.11.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->