### PR TITLE
fix readonly does not work for 'Teeny Rich textarea'

### DIFF
--- a/includes/Fields/Form_Field_Textarea.php
+++ b/includes/Fields/Form_Field_Textarea.php
@@ -33,12 +33,14 @@ class Form_Field_Textarea extends Field_Contract {
             $value = $field_settings['default'];
         }
 
-        $req_class   = ( $field_settings['required'] == 'yes' ) ? 'required' : 'rich-editor';
+        $req_class   = ( 'yes' === $field_settings['required'] ) ? 'required' : 'rich-editor';
         $textarea_id = $field_settings['name'] ? $field_settings['name'] . '_' . $form_id : 'textarea_';
 
         $this->field_print_label( $field_settings, $form_id ); ?>
 
-             <?php if ( in_array( $field_settings['rich'], [ 'yes', 'teeny' ] ) ) { ?>
+            <?php
+            if ( in_array( $field_settings['rich'], [ 'yes', 'teeny' ], true ) ) {
+                ?>
                 <div class="wpuf-fields wpuf-rich-validation <?php printf( 'wpuf_%s_%s', esc_attr( $field_settings['name'] ), esc_attr( $form_id ) ); ?>" data-type="rich" data-required="<?php echo esc_attr( $field_settings['required'] ); ?>" data-id="<?php echo esc_attr( $field_settings['name'] ) . '_' . esc_attr( $form_id ); ?>" data-name="<?php echo esc_attr( $field_settings['name'] ); ?>">
             <?php } else { ?>
                 <div class="wpuf-fields">
@@ -56,6 +58,10 @@ class Form_Field_Textarea extends Field_Contract {
                         'textarea_name' => $field_settings['name'],
                     ];
 
+                    if ( ! empty( $field_settings['read_only'] ) ) {
+                        $tinymce_settings['readonly'] = true;
+                    }
+
                     if ( ! empty( $tinymce_settings ) ) {
                         $editor_settings['tinymce'] = $tinymce_settings;
                     }
@@ -65,6 +71,7 @@ class Form_Field_Textarea extends Field_Contract {
                     }
 
                     $editor_settings = apply_filters( 'wpuf_textarea_editor_args', $editor_settings );
+
                     wp_editor( $value, $textarea_id, $editor_settings );
                 } else {
                     ?>


### PR DESCRIPTION
fixes [#482](https://github.com/weDevsOfficial/wpuf-pro/issues/482)

**Issue:**
Textarea > Read only does not work for 'Teeny Rich textarea' as field is still editable

**Scenario:**
New Post Form > Add Textarea > Edit Advanced > Select 'Teeny Rich textarea' > Also select "Read only" option > Save > Field is still editable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a read-only state for the textarea, enhancing user interaction control.
- **Improvements**
	- Enhanced logic for rendering the rich text editor with improved type safety.
	- Updated validation for rich text editor settings to ensure accurate configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->