### PR TITLE
fix: field overlapping in address field

### DIFF
--- a/assets/css/frontend-forms.css
+++ b/assets/css/frontend-forms.css
@@ -542,13 +542,6 @@ body ul.wpuf-form li .wpuf-address-field:after {
   display: table;
 }
 body ul.wpuf-form li .wpuf-address-field.city_name,
-body ul.wpuf-form li .wpuf-address-field.state,
-body ul.wpuf-form li .wpuf-address-field.zip,
-body ul.wpuf-form li .wpuf-address-field.country_select {
-  float: left;
-  width: 47%;
-}
-body ul.wpuf-form li .wpuf-address-field.city_name,
 body ul.wpuf-form li .wpuf-address-field.zip {
   margin-right: 4%;
 }

--- a/assets/less/frontend-forms.less
+++ b/assets/less/frontend-forms.less
@@ -604,14 +604,6 @@ ul.wpuf-form {
             margin-bottom: 10px;
 
             &.city_name,
-            &.state,
-            &.zip,
-            &.country_select {
-                float: left;
-                width: 47%;
-            }
-
-            &.city_name,
             &.zip {
                 margin-right: 4%;
             }


### PR DESCRIPTION
fixes [#533](https://github.com/weDevsOfficial/wpuf-pro/issues/533)

`Issue:`
The City input field is overlapping with the country field [UI-issue]

`Steps:`
1. Create Post Forms > Add Address field
2. Go to Frontend > Form
3. Navigate to Address-field options 
4. See error ---> City input field is getting overlapped by the Country selection field

`Screenshot for reference:`
![image](https://github.com/user-attachments/assets/402a7cf8-7185-4341-99e7-45f7372ad741)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated styling for address fields in forms to allow for a more flexible layout.
	- Adjusted alignment and spacing for fields such as state, zip, and country select.
  
- **Bug Fixes**
	- Removed restrictive styles that could hinder the display of address fields, improving overall form usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->