### PR TITLE
fix: required asterisk on password label

### DIFF
--- a/assets/css/frontend-forms.css
+++ b/assets/css/frontend-forms.css
@@ -1835,7 +1835,7 @@ body .wpuf-attachment-upload-filelist + .moxie-shim {
 }
 img.wpuf-eye {
   position: absolute;
-  right: 0;
+  right: 1rem;
   top: 50%;
   transform: translateY(-50%) translateX(-6%);
 }

--- a/assets/less/frontend-forms.less
+++ b/assets/less/frontend-forms.less
@@ -2124,7 +2124,7 @@ ul.wpuf-form{
 
 img.wpuf-eye {
     position: absolute;
-    right: 0;
+    right: 1rem;
     top: 50%;
     transform: translateY(-50%) translateX(-6%);
 }

--- a/includes/Admin/Forms/Form.php
+++ b/includes/Admin/Forms/Form.php
@@ -182,7 +182,9 @@ class Form {
             return [ $user_can_post, $info ];
         }
 
-        $has_post_count = $current_user->subscription()->has_post_count( $form_settings['post_type'] );
+        $post_type = ! empty( $form_settings['post_type'] ) ? $form_settings['post_type'] : 'post';
+
+        $has_post_count = $current_user->subscription()->has_post_count( $post_type );
 
         if ( $current_user->subscription()->current_pack_id() && ! $has_post_count ) {
             $user_can_post = 'no';

--- a/languages/wp-user-frontend.pot
+++ b/languages/wp-user-frontend.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: WP User Frontend 4.0.11\n"
 "Report-Msgid-Bugs-To: https://wedevs.com/contact/\n"
-"POT-Creation-Date: 2024-09-17 06:55:34+00:00\n"
+"POT-Creation-Date: 2024-09-17 09:28:09+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1332,7 +1332,7 @@ msgstr ""
 #: admin/template.php:185 includes/Admin/Forms/Admin_Template.php:212
 #: includes/Fields/Field_Contract.php:687
 #: includes/Fields/Form_Field_Textarea.php:12
-#: includes/Fields/Form_Field_Textarea.php:125
+#: includes/Fields/Form_Field_Textarea.php:132
 msgid "Textarea"
 msgstr ""
 
@@ -2596,19 +2596,19 @@ msgstr ""
 msgid "Others"
 msgstr ""
 
-#: includes/Admin/Forms/Form.php:189 includes/Admin/Forms/Form.php:239
+#: includes/Admin/Forms/Form.php:191 includes/Admin/Forms/Form.php:241
 msgid "Post Limit Exceeded for your purchased subscription pack."
 msgstr ""
 
-#: includes/Admin/Forms/Form.php:212
+#: includes/Admin/Forms/Form.php:214
 #. translators: %s: Pack page link
 msgid ""
 "You need to  <a href=\"%s\">purchase a subscription package</a> to post in "
 "this form"
 msgstr ""
 
-#: includes/Admin/Forms/Form.php:219 includes/Admin/Forms/Form.php:252
-#: includes/Admin/Forms/Form.php:259
+#: includes/Admin/Forms/Form.php:221 includes/Admin/Forms/Form.php:254
+#: includes/Admin/Forms/Form.php:261
 msgid "Payment type not selected for this form. Please contact admin."
 msgstr ""
 


### PR DESCRIPTION
fixes [#508 ](https://github.com/weDevsOfficial/wpuf-pro/issues/508)

related [PR](https://github.com/weDevsOfficial/wpuf-pro/pull/630)

What we have to do:

Add the asterisk for the required password and confirm the password (only missing on the form preview), live is okay.
Move the password view/eye icon inside the password field.

![image](https://github.com/user-attachments/assets/1e9aa63d-7398-4cb9-96a7-3ac7acba70bd)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced visual spacing for the `wpuf-eye` image element in forms.
- **Bug Fixes**
	- Improved robustness in the form submission logic by ensuring a valid post type is always used.
- **Chores**
	- Updated translation template with new timestamps and line references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->