### PR TITLE
fix: post description image for block theme

### DIFF
--- a/includes/Fields/Form_Field_Post_Content.php
+++ b/includes/Fields/Form_Field_Post_Content.php
@@ -11,6 +11,27 @@ class Form_Field_Post_Content extends Field_Contract {
         $this->name       = __( 'Post Content', 'wp-user-frontend' );
         $this->input_type = 'post_content';
         $this->icon       = 'text-width';
+
+        // check if block theme is active
+        if ( function_exists( 'wp_is_block_theme' ) && wp_is_block_theme() ) {
+            add_filter( 'format_for_editor', [ $this, 'format_for_editor' ], 10, 2 );
+        }
+    }
+
+    /**
+     * Format the content for editor. Need to do this for block theme support
+     *
+     * @param string $content
+     * @param string $default_editor
+     *
+     * @return string
+     */
+    public function format_for_editor( $content, $default_editor ) {
+        if ( 'tinymce' !== $default_editor ) {
+            return $content;
+        }
+
+        return htmlspecialchars_decode( $content, ENT_NOQUOTES );
     }
 
     /**

--- a/includes/Frontend/Frontend_Form.php
+++ b/includes/Frontend/Frontend_Form.php
@@ -33,8 +33,8 @@ class Frontend_Form extends Frontend_Render_Form {
      *
      * @param array $atts
      *
-     * @return
-     **/
+     * @return false|string
+     */
     public function edit_post_shortcode( $atts ) {
         add_filter( 'wpuf_form_fields', [ $this, 'add_field_settings' ] );
         // @codingStandardsIgnoreStart
@@ -52,7 +52,13 @@ class Frontend_Form extends Frontend_Render_Form {
 
             wp_login_form();
 
-            return;
+            return '';
+        }
+
+        $nonce = isset( $_GET['_wpnonce'] ) ? sanitize_key( wp_unslash( $_GET['_wpnonce'] ) ) : '';
+
+        if ( ! wp_verify_nonce( $nonce, 'wpuf_edit' ) ) {
+            return '<div class="wpuf-info">' . __( 'Please re-open the post', 'wp-user-frontend' ) . '</div>';
         }
 
         $post_id = isset( $_GET['pid'] ) ? intval( wp_unslash( $_GET['pid'] ) ) : 0;
@@ -110,7 +116,6 @@ class Frontend_Form extends Frontend_Render_Form {
         $form = new Form( $form_id );
 
         $this->form_fields = $form->get_fields();
-        // $form_settings = wpuf_get_form_settings( $form_id );
         $this->form_settings = $form->get_settings();
 
         $disable_pending_edit = wpuf_get_option( 'disable_pending_edit', 'wpuf_dashboard', 'on' );

--- a/includes/Frontend_Render_Form.php
+++ b/includes/Frontend_Render_Form.php
@@ -183,7 +183,7 @@ class Frontend_Render_Form {
             return;
         }
 
-        if ( $form_status != 'publish' ) {
+        if ( 'publish' !== $form_status ) {
             echo wp_kses_post( '<div class="wpuf-message">' . __( "Please make sure you've published your form.", 'wp-user-frontend' ) . '</div>' );
 
             return;
@@ -222,9 +222,9 @@ class Frontend_Render_Form {
         if ( $this->form_fields ) {
             ?>
 
-                <form class="wpuf-form-add wpuf-form-<?php echo esc_attr( $layout ); ?> <?php echo ( $layout == 'layout1' ) ? esc_html( $theme_css ) : 'wpuf-style'; ?>" action="" method="post">
+                <form class="wpuf-form-add wpuf-form-<?php echo esc_attr( $layout ); ?> <?php echo ( 'layout1' === $layout ) ? esc_html( $theme_css ) : 'wpuf-style'; ?>" action="" method="post">
 
-                   <script type="text/javascript">
+                    <script type="text/javascript">
                         if ( typeof wpuf_conditional_items === 'undefined' ) {
                             wpuf_conditional_items = [];
                         }


### PR DESCRIPTION
fixes [#524](https://github.com/weDevsOfficial/wpuf-pro/issues/524)

Testing-flow:

1. Activate a block theme
2. Go to Post Forms
3. Create New Post Form with `Post Description-image enabled`
4. Goto Frontend > Form Page 
5. Enter Details > Add Image to Post description field 
6. Submit Form
7. Edit Submitted Form > Issue Found - Post Description Image added is distorted

Actual Result: Image added in Post Description field is distorted

Expected Result: Image should display as it was uploaded when submitting form

--------------------------------------------

Screenshot for reference:
![image](https://github.com/weDevsOfficial/wpuf-pro/assets/95366111/79d6fff2-a77d-42a4-a61b-f5725b743a82)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced support for block themes in the content editor.
	- Improved error handling and feedback for editing posts, including nonce verification and user login status checks.

- **Bug Fixes**
	- Streamlined logic for handling post publication status and guest submissions.
	- Improved clarity of conditional checks to ensure type safety.

- **Refactor**
	- Adjusted control flow and conditional checks for better maintainability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->