### PR TITLE
tweak: for v4.1.1

### DIFF
--- a/Lib/WeDevs_Settings_API.php
+++ b/Lib/WeDevs_Settings_API.php
@@ -590,7 +590,29 @@ class WeDevs_Settings_API {
 
         $html .= '</h2>';
 
-        echo wp_kses_post( $html );
+        $allowed_html = [
+            'h2'    => [
+                'class' => true,
+            ],
+            'div'   => [
+                'id' => true,
+            ],
+            'input' => [
+                'type'        => true,
+                'id'          => true,
+                'placeholder' => true,
+            ],
+            'span'  => [
+                'class' => true,
+            ],
+            'a'     => [
+                'href'  => true,
+                'class' => true,
+                'id'    => true,
+            ],
+        ];
+
+        echo wp_kses( $html, $allowed_html );
     }
 
     /**

--- a/wpuf-functions.php
+++ b/wpuf-functions.php
@@ -4943,10 +4943,6 @@ function wpuf_get_post_form_builder_setting_menu_contents() {
             'label' => __( 'EDD Download Form', 'wp-user-frontend' ),
             'image' => WPUF_ASSET_URI . '/images/templates/edd.svg',
         ],
-        'post_form_template_events_calendar' => [
-            'label' => __( 'The Events Calendar Form', 'wp-user-frontend' ),
-            'image' => WPUF_ASSET_URI . '/images/templates/event.svg',
-        ],
     ];
 
     $registry = wpuf_get_post_form_templates();


### PR DESCRIPTION
some tweaks for `v4.1.1` release.

1. fix search on settings page. after PCP fixes it was broken
![CleanShot 2025-03-27 at 11 29 53](https://github.com/user-attachments/assets/5658a67c-9e44-4e7f-a0d7-945409b2a4c6)

2. remove events calendar template as we doesn't fully support Events Calendar integration fully after their breaking change on version 6