### PR TITLE
fix: warning message not showing

### DIFF
--- a/assets/js/frontend-form.js
+++ b/assets/js/frontend-form.js
@@ -421,7 +421,7 @@
                 submitButton = form.find('input[type=submit]'),
                 form_data = WP_User_Frontend.validateForm(form);
 
-            if ( form_data == false ) {
+            if (!form_data) {
                 WP_User_Frontend.addErrorNotice( self, 'bottom' );
             }
             return form_data;
@@ -442,13 +442,11 @@
 
                 $.post(wpuf_frontend.ajaxurl, form_data, function(res) {
                     // var res = $.parseJSON(res);
-
                     if ( res.success) {
-
                         // enable external plugins to use events
                         $('body').trigger('wpuf:postform:success', res);
 
-                        if ( res.show_message == true) {
+                        if (res.show_message) {
                             form.before( '<div class="wpuf-success">' + res.message + '</div>');
                             form.slideUp( 'fast', function() {
                                 form.remove();
@@ -464,16 +462,23 @@
                         }
 
                     } else {
-
                         if ( typeof res.type !== 'undefined' && res.type === 'login' ) {
-
-                            if ( confirm(res.error) ) {
-                                window.location = res.redirect_to;
-                            } else {
-                                submitButton.removeAttr('disabled');
-                                submitButton.removeClass('button-primary-disabled');
-                                form.find('span.wpuf-loading').remove();
-                            }
+                            Swal.fire({
+                                text: res.error,
+                                icon: "warning",
+                                showCancelButton: true,
+                                confirmButtonColor: "#3085d6",
+                                cancelButtonColor: "#d33",
+                                confirmButtonText: "OK"
+                            }).then((result) => {
+                                if (result.isConfirmed) {
+                                    window.location = res.redirect_to;
+                                } else {
+                                    submitButton.removeAttr('disabled');
+                                    submitButton.removeClass('button-primary-disabled');
+                                    form.find('span.wpuf-loading').remove();
+                                }
+                            });
 
                             return;
                         } else {
@@ -481,8 +486,10 @@
                                 grecaptcha.reset();
                             }
 
+                            const errorMsg = res.error ? res.error : res.data.error;
+
                             Swal.fire({
-                                html: res.error,
+                                html: errorMsg,
                                 icon: 'warning',
                                 showCancelButton: false,
                                 confirmButtonColor: '#d54e21',


### PR DESCRIPTION
fixes [#696](https://github.com/weDevsOfficial/wpuf-pro/issues/696) 

Description: No warning message is showing for duplicate email or username or email. Only the pop-up modal appears with an exclamatory sign.

Steps: try to register with any existing username or email
![CleanShot 2025-04-08 at 09 44 47](https://github.com/user-attachments/assets/36d945f7-667e-4ce1-a8eb-7d70c8f358e8)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced form error notifications with a modern alert modal, replacing the older confirm dialog. Users now receive clear error messages during form submissions along with intuitive options to confirm and redirect or cancel, resulting in a smoother and more user-friendly experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->