### PR TITLE
fix: email body not respecting spaces

### DIFF
--- a/admin/form-builder/assets/js/form-builder.js
+++ b/admin/form-builder/assets/js/form-builder.js
@@ -553,6 +553,23 @@
                     return self.i18n.unsaved_changes;
                 }
             };
+
+            var mail_shortcodes = new window.Clipboard('.wpuf-long-help span[data-clipboard-text]');
+
+            mail_shortcodes.on('success', function(e) {
+                // Show copied tooltip
+                $(e.trigger)
+                    .attr('data-original-title', 'Copied!')
+                    .tooltip('show');
+
+                // Reset the copied tooltip
+                setTimeout(function() {
+                    $(e.trigger).tooltip('hide')
+                        .attr('data-original-title', self.i18n.copy_shortcode);
+                }, 1000);
+
+                e.clearSelection();
+            });
         },
 
         methods: {

--- a/admin/form-builder/views/post-form-settings.php
+++ b/admin/form-builder/views/post-form-settings.php
@@ -551,7 +551,7 @@ function wpuf_render_settings_field( $field_key, $field, $form_settings, $post_t
 
             if ( ! empty( $field['long_help'] ) ) {
                 ?>
-                <div class="wpuf-text-sm wpuf-mt-4">
+                <div class="wpuf-text-sm wpuf-mt-4 wpuf-long-help">
                     <?php echo wp_kses_post( $field['long_help'] ); ?>
                 </div>
                 <?php
@@ -634,7 +634,7 @@ function wpuf_render_settings_field( $field_key, $field, $form_settings, $post_t
 
             if ( ! empty( $field['long_help'] ) ) {
                 ?>
-            <div class="wpuf-text-sm wpuf-mt-4">
+            <div class="wpuf-text-sm wpuf-mt-4 wpuf-long-help">
                 <?php echo wp_kses_post( $field['long_help'] ); ?>
             </div>
                 <?php

--- a/assets/js/wpuf-form-builder.js
+++ b/assets/js/wpuf-form-builder.js
@@ -553,6 +553,23 @@
                     return self.i18n.unsaved_changes;
                 }
             };
+
+            var mail_shortcodes = new window.Clipboard('.wpuf-long-help span[data-clipboard-text]');
+
+            mail_shortcodes.on('success', function(e) {
+                // Show copied tooltip
+                $(e.trigger)
+                    .attr('data-original-title', 'Copied!')
+                    .tooltip('show');
+
+                // Reset the copied tooltip
+                setTimeout(function() {
+                    $(e.trigger).tooltip('hide')
+                        .attr('data-original-title', self.i18n.copy_shortcode);
+                }, 1000);
+
+                e.clearSelection();
+            });
         },
 
         methods: {

--- a/includes/Ajax/Frontend_Form_Ajax.php
+++ b/includes/Ajax/Frontend_Form_Ajax.php
@@ -678,6 +678,8 @@ class Frontend_Form_Ajax {
         }
 
         $content = str_replace( $post_field_search, $post_field_replace, $content );
+        // replace line breaks with proper html tags
+        $content = str_replace( [ "\r\n", "\n", "\r" ], '<br />', $content );
 
         // custom fields
         preg_match_all( '/{custom_([\w-]*)\b}/', $content, $matches );

--- a/wpuf-functions.php
+++ b/wpuf-functions.php
@@ -5019,7 +5019,7 @@ function wpuf_get_post_form_builder_setting_menu_contents() {
                             'type'      => 'select',
                             'options'   => [
                                 'draft'          => __( 'Draft', 'wp-user-frontend' ),
-                                'pending-review' => __( 'Pending Review', 'wp-user-frontend' ),
+                                'pending'        => __( 'Pending Review', 'wp-user-frontend' ),
                                 'private'        => __( 'Private', 'wp-user-frontend' ),
                                 'publish'        => __( 'Published', 'wp-user-frontend' ),
                             ],


### PR DESCRIPTION
fixes #1540 fixes #1538

**1.** The Email Body in _Posts Forms > Edit a form > Settings > Notification Settings_ is not respecting the line breaks/enter in emails.

You see the line breaks in the Email Body but once it hits our email system, it's all together with no spacing. It basically looks like this example:

```
Hi Admin, A new post has been created on your site Example Site (https://example.com/ ). Here are the details: Post Title: Title Here:

Content here which is long and spaced correctly.

Author: Author-name Post URL: https://example.com/?p=1 Edit URL: https://example.com/wp-admin/post.php?action=edit&post=1
```

**2.** Also, the below shortcodes that are under "You may use in to, subject & message" are clickable. Clicking on the code should copy it to your clipboard.

**3.** when setting the Post Forms > Before Post Settings > Post Submission Status to Pending Review, and then someone adds a post to our site, it doesn't show up in WordPress > Posts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added the ability to copy mail shortcodes directly from the help section with a "Copied!" tooltip for confirmation.

- **Style**
  - Enhanced help text containers with a new CSS class for improved styling and targeting.

- **Bug Fixes**
  - Ensured that line breaks in email content are correctly displayed as HTML line breaks in outgoing emails.

- **Improvements**
  - Updated the internal key for the "Pending Review" post status option to ensure better consistency in post form settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->