### PR TITLE
fix: image upload button condition

### DIFF
--- a/assets/js/upload.js
+++ b/assets/js/upload.js
@@ -161,14 +161,12 @@
                 this.UploadedFiles++;
                 var $container = $('#' + this.container).find('.wpuf-attachment-list');
                 $container.append(response.response);
-
                 if ( this.perFileCount > this.max ) {
                     var attach_id = $('.wpuf-image-wrap:last a.attachment-delete',$container).data('attach-id');
                     self.removeExtraAttachment(attach_id);
                     $('.wpuf-image-wrap',$container).last().remove();
                     this.perFileCount--;
                 }
-
             } else {
                 alert(res.data.replace( /(<([^>]+)>)/ig, ''));
 
@@ -180,6 +178,8 @@
 
             var uploaded        = this.UploadedFiles,
                 FileProgress    = up.files.length;
+
+            this.count = $('#' + this.container).find('.wpuf-attachment-list > li').length;
 
             if ( this.count >= this.max ) {
                 $('#' + this.container).find('.file-selector').hide();

--- a/includes/Ajax/Frontend_Form_Ajax.php
+++ b/includes/Ajax/Frontend_Form_Ajax.php
@@ -436,8 +436,12 @@ class Frontend_Form_Ajax {
             //now perform some post related actions
             do_action( 'wpuf_edit_post_after_update', $post_id, $form_id, $this->form_settings, $this->form_fields ); // plugin API to extend the functionality
 
-            //send mail notification
-            if ( isset( $this->form_settings['notification'] ) && $this->form_settings['notification']['edit'] === 'on' ) {
+            // send mail notification
+            if ( isset( $this->form_settings['notification'] ) && ( ( isset( $this->form_settings['notification']['edit'] ) && wpuf_is_checkbox_or_toggle_on(
+                            $this->form_settings['notification']['edit']
+                        ) ) || ( ! empty( $this->form_settings['notification_edit'] ) && wpuf_is_checkbox_or_toggle_on(
+                            $this->form_settings['notification_edit']
+                        ) ) ) ) {
                 $mail_body = $this->prepare_mail_body( $this->form_settings['notification']['edit_body'], $post_author, $post_id );
                 $to        = $this->prepare_mail_body( $this->form_settings['notification']['edit_to'], $post_author, $post_id );
                 $subject   = $this->prepare_mail_body( $this->form_settings['notification']['edit_subject'], $post_author, $post_id );


### PR DESCRIPTION
fixes #1532

Problem:
The **image upload** button does not disappear after reaching the maximum number of images while editing the post.

How to reproduce the issue:
1. Create a form with the image upload component and set the max files to 4 (for example).
2. Submit a new post using this form, and upload only 2 images.
3. Edit the post using the same form and try adding new images — the upload button remains active even if the total number of images exceeds 4, and it allows the user to upload additional images without any limit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file upload handling to ensure the file count is accurately updated after each upload.
  - Enhanced post update notifications to ensure email alerts are sent more reliably when edit notifications are enabled through various settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->