### PR TITLE
Fix: Add missing closing div in Post Content form field

### DIFF
--- a/includes/Fields/Form_Field_Post_Content.php
+++ b/includes/Fields/Form_Field_Post_Content.php
@@ -147,6 +147,7 @@ class Form_Field_Post_Content extends Field_Contract {
             );
         }
         ?>
+        </div>
         </li>
         <?php
     }


### PR DESCRIPTION
Close #1469 

1. Fixed HTML structure to ensure proper rendering of form fields by adding a missing closing tag. (div)