### PR TITLE
fix: show recurring and trial info on subscription

### DIFF
--- a/class/subscription.php
+++ b/class/subscription.php
@@ -391,7 +391,7 @@ class WPUF_Subscription {
         $cycle_period         = ! empty( $post_data['cycle_period'] ) ? sanitize_text_field( wp_unslash( $post_data['cycle_period'] ) ) : '';
         $billing_limit        = ! empty( $post_data['billing_limit'] ) ? sanitize_text_field( wp_unslash( $post_data['billing_limit'] ) ) : '';
         $trial_duration       = ! empty( $post_data['trial_duration'] ) ? sanitize_text_field( wp_unslash( $post_data['trial_duration'] ) ) : '';
-        $trial_duration_type  = ! empty( $post_data['trial_duration_type'] ) ? sanitize_text_field( wp_unslash( $post_data['trial_duration_type'] ) ) : '';
+        $trial_duration_type  = ! empty( $post_data['_trial_duration_type'] ) ? sanitize_text_field( wp_unslash( $post_data['_trial_duration_type'] ) ) : '';
 
         if ( isset( $post_data['post_expiration_settings'] ) ) {
             if ( isset( $post_data['post_expiration_settings']['expiration_time_value'] ) && isset( $post_data['post_expiration_settings']['expiration_time_type'] ) ) {
@@ -955,7 +955,7 @@ class WPUF_Subscription {
         }
 
         if ( $billing_amount && $pack->meta_value['recurring_pay'] === 'yes' ) {
-            $recurring_des = sprintf( __( 'Every', 'wp-user-frontend' ) . ' %s %s', $pack->meta_value['billing_cycle_number'], self::get_cycle_label( $pack->meta_value['cycle_period'], $pack->meta_value['billing_cycle_number'] ), $pack->meta_value['trial_duration_type'] );
+            $recurring_des = sprintf( __( 'Every', 'wp-user-frontend' ) . ' %s %s', $pack->meta_value['billing_cycle_number'], self::get_cycle_label( $pack->meta_value['cycle_period'], $pack->meta_value['billing_cycle_number'] ), $pack->meta_value['_trial_duration_type'] );
             $recurring_des .= ! empty( $pack->meta_value['billing_limit'] ) ? sprintf( ', ' . __( 'for', 'wp-user-frontend' ) . ' %s ' . __( 'installments', 'wp-user-frontend' ), $pack->meta_value['billing_limit'] ) : '';
             $recurring_des = '<div class="wpuf-pack-cycle wpuf-nullamount-hide">' . $recurring_des . '</div>';
         }

--- a/includes/Admin/Subscription.php
+++ b/includes/Admin/Subscription.php
@@ -974,9 +974,12 @@ class Subscription {
         }
 
         if ( $billing_amount && wpuf_is_checkbox_or_toggle_on( $pack->meta_value['recurring_pay'] ) ) {
-            $recurring_des = sprintf( __( 'Every', 'wp-user-frontend' ) . ' %s %s', $pack->meta_value['billing_cycle_number'], self::get_cycle_label( $pack->meta_value['cycle_period'], $pack->meta_value['billing_cycle_number'] ), $pack->meta_value['_trial_duration_type'] );
+            $cycle_number = ! empty( $pack->meta_value['billing_cycle_number'] ) && '1' !== $pack->meta_value['billing_cycle_number'] ? $pack->meta_value['billing_cycle_number'] : '';
 
-            if ( ! empty( $pack->meta_value['billing_limit'] ) && '-1' !== $pack->meta_value['billing_limit'] ) {
+            $recurring_des = sprintf( __( 'Every', 'wp-user-frontend' ) . ' %s %s', $cycle_number, self::get_cycle_label( $pack->meta_value['cycle_period'], $pack->meta_value['billing_cycle_number'] ), $pack->meta_value['_trial_duration_type'] );
+
+
+            if ( wpuf_is_checkbox_or_toggle_on( $pack->meta_value['enable_billing_limit'] ) && ! empty( $pack->meta_value['billing_limit'] ) && '-1' !== $pack->meta_value['billing_limit'] ) {
                 $recurring_des .= ! empty( $pack->meta_value['billing_limit'] ) ? sprintf( ', ' . __( 'for', 'wp-user-frontend' ) . ' %s ' . __( 'installments', 'wp-user-frontend' ), $pack->meta_value['billing_limit'] ) : '';
             }
 

--- a/includes/Admin/Subscription.php
+++ b/includes/Admin/Subscription.php
@@ -974,7 +974,7 @@ class Subscription {
         }
 
         if ( $billing_amount && wpuf_is_checkbox_or_toggle_on( $pack->meta_value['recurring_pay'] ) ) {
-            $recurring_des = sprintf( __( 'Every', 'wp-user-frontend' ) . ' %s %s', $pack->meta_value['billing_cycle_number'], self::get_cycle_label( $pack->meta_value['cycle_period'], $pack->meta_value['billing_cycle_number'] ), $pack->meta_value['trial_duration_type'] );
+            $recurring_des = sprintf( __( 'Every', 'wp-user-frontend' ) . ' %s %s', $pack->meta_value['billing_cycle_number'], self::get_cycle_label( $pack->meta_value['cycle_period'], $pack->meta_value['billing_cycle_number'] ), $pack->meta_value['_trial_duration_type'] );
 
             if ( ! empty( $pack->meta_value['billing_limit'] ) && '-1' !== $pack->meta_value['billing_limit'] ) {
                 $recurring_des .= ! empty( $pack->meta_value['billing_limit'] ) ? sprintf( ', ' . __( 'for', 'wp-user-frontend' ) . ' %s ' . __( 'installments', 'wp-user-frontend' ), $pack->meta_value['billing_limit'] ) : '';
@@ -983,11 +983,11 @@ class Subscription {
             $recurring_des = '<div class="wpuf-pack-cycle wpuf-nullamount-hide">' . $recurring_des . '</div>';
         }
 
-        if ( $billing_amount && wpuf_is_checkbox_or_toggle_on( $pack->meta_value['recurring_pay']  ) && wpuf_is_checkbox_or_toggle_on( $pack->meta_value['trial_status'] ) ) {
+        if ( $billing_amount && wpuf_is_checkbox_or_toggle_on( $pack->meta_value['recurring_pay']  ) && wpuf_is_checkbox_or_toggle_on( $pack->meta_value['_trial_status'] ) ) {
             //phpcs:ignore
-            $duration = _n( $pack->meta_value['trial_duration_type'], $pack->meta_value['trial_duration_type'] . 's', $pack->meta_value['trial_duration'], 'wp-user-frontend' );
+            $duration = _n( $pack->meta_value['_trial_duration_type'], $pack->meta_value['_trial_duration_type'] . 's', $pack->meta_value['_trial_duration'], 'wp-user-frontend' );
             /* translators: %s: trial days */
-            $trial_des = sprintf( __( 'Trial available for first %1$s %2$s', 'wp-user-frontend' ), $pack->meta_value['trial_duration'], $duration );
+            $trial_des = sprintf( __( 'Trial available for first %1$s %2$s', 'wp-user-frontend' ), $pack->meta_value['_trial_duration'], $duration );
         }
 
         $label       = wpuf_get_option( 'logged_in_label', 'wpuf_subscription_settings', false );

--- a/includes/Frontend/Frontend_Account.php
+++ b/includes/Frontend/Frontend_Account.php
@@ -227,15 +227,16 @@ class Frontend_Account {
         $recurring_des = '';
         $billing_amount = ( intval( $pack->meta_value['billing_amount'] ) > 0 ) ? $details_meta['symbol'] . $pack->meta_value['billing_amount'] : __( 'Free',
                                                                                                                                                       'wp-user-frontend' );
-        if ( $pack->meta_value['recurring_pay'] === 'yes' ) {
+        if ( wpuf_is_checkbox_or_toggle_on( $pack->meta_value['recurring_pay'] ) ) {
+            error_log( print_r( $pack->meta_value, true ) );
             /* translators: %s: billing cycle number, %s: billing cycle period */
             $recurring_des = sprintf( __( 'For each', 'wp-user-frontend' ) . ' %s %s',
                                       $pack->meta_value['billing_cycle_number'],
                                       Subscription::get_cycle_label( $pack->meta_value['cycle_period'],
                                                                           $pack->meta_value['billing_cycle_number'] ),
-                                      $pack->meta_value['trial_duration_type'] );
+                                      $pack->meta_value['_trial_duration_type'] );
             /* translators: %s: number of installments */
-            $recurring_des .= ! empty( $pack->meta_value['billing_limit'] ) ? sprintf( __( ', for %s installments',
+            $recurring_des .= ! empty( $pack->meta_value['billing_limit'] ) && -1 ===  $pack->meta_value['billing_limit'] ? sprintf( __( ', for %s installments',
                                                                                            'wp-user-frontend' ),
                                                                                        $pack->meta_value['billing_limit'] ) : '';
         }

--- a/templates/dashboard/subscription.php
+++ b/templates/dashboard/subscription.php
@@ -13,7 +13,7 @@
             <?php esc_html_e( 'Subscription Expired!', 'wp-user-frontend' ); ?>
         </div>
         <?php } else {
-             if ( ! empty( $user_sub['total_feature_item'] ) ) { ?>
+             if ( ! empty( $user_sub['total_feature_item'] ) && -1 === $user_sub['total_feature_item'] ) { ?>
                 <div><strong><?php esc_html_e( 'Number of featured item: ', 'wp-user-frontend' ); ?></strong><?php echo esc_html( $user_sub['total_feature_item'] ); ?></div>
             <?php } ?>
             <div>
@@ -24,7 +24,7 @@
                     foreach ( $user_sub['posts'] as $key => $value ) {
                         $value = intval( $value );
 
-                        if ( $value === 0 ) {
+                        if ( 0 === $value || -1 === $value ) {
                             continue;
                         }
 

--- a/templates/subscriptions/pack-details.php
+++ b/templates/subscriptions/pack-details.php
@@ -15,7 +15,7 @@
  */
 ?>
 <div class="wpuf-pricing-wrap">
-    <h3><?php echo wp_kses_post( $pack->post_title ); ?> </h3>
+    <h3><?php echo wp_kses_post( $pack->post_title ); ?></h3>
     <div class="wpuf-sub-amount">
 
         <?php if ( $billing_amount != '0.00' ) { ?>
@@ -28,7 +28,7 @@
 
     </div>
     <?php
-    if ( $pack->meta_value['recurring_pay'] == 'yes' ) {
+    if ( wpuf_is_checkbox_or_toggle_on( $pack->meta_value['recurring_pay'] ) ) {
         ?>
         <div class="wpuf-sub-body wpuf-nullamount-hide">
             <div class="wpuf-sub-terms"><?php echo esc_html( $trial_des ); ?></div>


### PR DESCRIPTION
fixes [#724](https://github.com/weDevsOfficial/wpuf-pro/issues/724) fixes [#723](https://github.com/weDevsOfficial/wpuf-pro/issues/723)

![image](https://github.com/user-attachments/assets/9f3e9946-c49a-4ac8-a8e3-3541319dd776)
![image](https://github.com/user-attachments/assets/4819b55c-477d-4dd4-b588-43ee649b379c)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability in displaying trial duration and status information for subscription packs.
	- Refined logic for displaying featured item counts and post counts in subscription dashboards.
	- Enhanced recurring payment checks for subscription packs for more accurate display and processing.
	- Updated trial and billing limit data handling for consistent subscription information display.
- **Style**
	- Removed unnecessary trailing space in subscription pack titles for cleaner presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->