### PR TITLE
fix: post submission when name email not required

### DIFF
--- a/admin/form-builder/assets/js/components/field-visibility/template.php
+++ b/admin/form-builder/assets/js/components/field-visibility/template.php
@@ -51,7 +51,35 @@
                     $output .= "<label class='wpuf-flex wpuf-items-center'><input :class=\"builder_class_names('checkbox')\" class=\"!wpuf-mr-2\" type=\"checkbox\" v-model=\"choices\" value=\"{$role}\"> {$role_name} </label>";
                     $output .= '</li>';
 
-                    echo wp_kses( $output, array( 'li' => array(), 'label' => array(), 'input' => array( 'type', 'value', 'v-model' ) ) );
+                    $allowed_html = [
+                        'li'    => [
+                            'class' => true,
+                        ],
+                        'label' => [
+                            'class' => true,
+                        ],
+                        'input' => [
+                            'class' => true,
+                            'type'  => true,
+                            'value' => true,
+                        ],
+                    ];
+
+                    // Apply standard wp_kses first
+                    $partially_filtered = wp_kses( $output, $allowed_html );
+
+                    // Then re-add Vue attributes with explicit pattern matching for safety
+                    $vue_attributes = array(
+                        ':class="builder_class_names(\'checkbox\')"',
+                        'v-model="choices"'
+                    );
+
+                    foreach ($vue_attributes as $attr) {
+                        // Safely insert the attribute back into the input tag
+                        $partially_filtered = preg_replace('/(<input[^>]+)/', '$1 ' . $attr, $partially_filtered, 1);
+                    }
+
+                    echo $partially_filtered;
                 }
             ?>
 	    </ul>
@@ -71,7 +99,35 @@
                             $output .= "<label class='wpuf-flex wpuf-items-center'><input  :class=\"builder_class_names('checkbox')\" class=\"!wpuf-mr-2\" type='checkbox' v-model='choices' value='{$pack->ID}' > {$pack->post_title} </label>";
                             $output .= '</li>';
 
-                            echo wp_kses( $output, array( 'li' => array(), 'label' => array(), 'input' => array( 'type', 'value', 'v-model' ) ) );
+                            $allowed_html = [
+                                'li'    => [
+                                    'class' => true,
+                                ],
+                                'label' => [
+                                    'class' => true,
+                                ],
+                                'input' => [
+                                    'class' => true,
+                                    'type'  => true,
+                                    'value' => true,
+                                ],
+                            ];
+
+                            // Apply standard wp_kses first
+                            $partially_filtered = wp_kses( $output, $allowed_html );
+
+                            // Then re-add Vue attributes with explicit pattern matching for safety
+                            $vue_attributes = array(
+                                ':class="builder_class_names(\'checkbox\')"',
+                                'v-model="choices"'
+                            );
+
+                            foreach ($vue_attributes as $attr) {
+                                // Safely insert the attribute back into the input tag
+                                $partially_filtered = preg_replace('/(<input[^>]+)/', '$1 ' . $attr, $partially_filtered, 1);
+                            }
+
+                            echo $partially_filtered;
                         }
                     } else {
                         esc_html_e( 'No subscription plan found.', 'wp-user-frontend' );

--- a/assets/js-templates/form-components.php
+++ b/assets/js-templates/form-components.php
@@ -690,7 +690,35 @@
                     $output .= "<label class='wpuf-flex wpuf-items-center'><input :class=\"builder_class_names('checkbox')\" class=\"!wpuf-mr-2\" type=\"checkbox\" v-model=\"choices\" value=\"{$role}\"> {$role_name} </label>";
                     $output .= '</li>';
 
-                    echo wp_kses( $output, array( 'li' => array(), 'label' => array(), 'input' => array( 'type', 'value', 'v-model' ) ) );
+                    $allowed_html = [
+                        'li'    => [
+                            'class' => true,
+                        ],
+                        'label' => [
+                            'class' => true,
+                        ],
+                        'input' => [
+                            'class' => true,
+                            'type'  => true,
+                            'value' => true,
+                        ],
+                    ];
+
+                    // Apply standard wp_kses first
+                    $partially_filtered = wp_kses( $output, $allowed_html );
+
+                    // Then re-add Vue attributes with explicit pattern matching for safety
+                    $vue_attributes = array(
+                        ':class="builder_class_names(\'checkbox\')"',
+                        'v-model="choices"'
+                    );
+
+                    foreach ($vue_attributes as $attr) {
+                        // Safely insert the attribute back into the input tag
+                        $partially_filtered = preg_replace('/(<input[^>]+)/', '$1 ' . $attr, $partially_filtered, 1);
+                    }
+
+                    echo $partially_filtered;
                 }
             ?>
 	    </ul>
@@ -710,7 +738,35 @@
                             $output .= "<label class='wpuf-flex wpuf-items-center'><input  :class=\"builder_class_names('checkbox')\" class=\"!wpuf-mr-2\" type='checkbox' v-model='choices' value='{$pack->ID}' > {$pack->post_title} </label>";
                             $output .= '</li>';
 
-                            echo wp_kses( $output, array( 'li' => array(), 'label' => array(), 'input' => array( 'type', 'value', 'v-model' ) ) );
+                            $allowed_html = [
+                                'li'    => [
+                                    'class' => true,
+                                ],
+                                'label' => [
+                                    'class' => true,
+                                ],
+                                'input' => [
+                                    'class' => true,
+                                    'type'  => true,
+                                    'value' => true,
+                                ],
+                            ];
+
+                            // Apply standard wp_kses first
+                            $partially_filtered = wp_kses( $output, $allowed_html );
+
+                            // Then re-add Vue attributes with explicit pattern matching for safety
+                            $vue_attributes = array(
+                                ':class="builder_class_names(\'checkbox\')"',
+                                'v-model="choices"'
+                            );
+
+                            foreach ($vue_attributes as $attr) {
+                                // Safely insert the attribute back into the input tag
+                                $partially_filtered = preg_replace('/(<input[^>]+)/', '$1 ' . $attr, $partially_filtered, 1);
+                            }
+
+                            echo $partially_filtered;
                         }
                     } else {
                         esc_html_e( 'No subscription plan found.', 'wp-user-frontend' );

--- a/includes/Ajax/Frontend_Form_Ajax.php
+++ b/includes/Ajax/Frontend_Form_Ajax.php
@@ -483,11 +483,14 @@ class Frontend_Form_Ajax {
         $default_post_author = wpuf_get_option( 'default_post_owner', 'wpuf_frontend_posting', 1 );
 
         if ( ! is_user_logged_in() ) {
-            if ( isset( $this->form_settings['post_permission'] ) && 'guest_post' === $this->form_settings['post_permission'] ) {
+            if ( isset( $this->form_settings['post_permission'] ) && 'guest_post' === $this->form_settings['post_permission'] && ! empty( $this->form_settings['guest_details'] ) && wpuf_is_checkbox_or_toggle_on(
+                $this->form_settings['guest_details']
+            )) {
                 $guest_name = isset( $_POST['guest_name'] ) ? sanitize_text_field( wp_unslash( $_POST['guest_name'] ) ) : '';
-
-                $guest_email = isset( $_POST['guest_email'] ) ? sanitize_email( wp_unslash( $_POST['guest_email'] ) ) : '';
-                $page_id = isset( $_POST['page_id'] ) ? sanitize_text_field( wp_unslash( $_POST['page_id'] ) ) : '';
+                $guest_email = isset( $_POST['guest_email'] ) ? sanitize_email(
+                    wp_unslash( $_POST['guest_email'] )
+                ) : '';
+                $page_id     = isset( $_POST['page_id'] ) ? sanitize_text_field( wp_unslash( $_POST['page_id'] ) ) : '';
 
                 // is valid email?
                 if ( ! is_email( $guest_email ) ) {
@@ -499,17 +502,6 @@ class Frontend_Form_Ajax {
                     );
 
                     die();
-
-//                    $this->send_error( __( 'Invalid email address.', 'wp-user-frontend' ) );
-//                    wp_send_json(
-//                        [
-//                            'success'     => false,
-//                            'error'       => __( "You already have an account in our site. Please login to continue.\n\nClicking 'OK' will redirect you to the login page and you will lose the form data.\nClick 'Cancel' to stay at this page.", 'wp-user-frontend' ),
-//                            'type'        => 'login',
-//                            'redirect_to' => wp_login_url( get_permalink( $page_id ) ),
-//                        ]
-//                    );
-                    // wpuf()->ajax->send_error( __( 'Invalid email address.', 'wp-user-frontend' ) );
                 }
 
                 // check if the user email already exists

--- a/includes/Frontend_Render_Form.php
+++ b/includes/Frontend_Render_Form.php
@@ -248,8 +248,10 @@ class Frontend_Render_Form {
                     } else {
                         do_action( 'wpuf_edit_post_form_top', $form_id, $post_id, $this->form_settings );
                     }
-
-                    if ( ! is_user_logged_in() && ( ! empty( $this->form_settings['post_permission'] ) && 'guest_post' === $this->form_settings['post_permission'] ) && wpuf_is_checkbox_or_toggle_on( $this->form_settings['guest_details'] ) ) {
+                    if ( ! is_user_logged_in(
+                        ) && ( ! empty( $this->form_settings['post_permission'] ) && 'guest_post' === $this->form_settings['post_permission'] ) && ( ! empty( $this->form_settings['guest_details'] ) && wpuf_is_checkbox_or_toggle_on(
+                                $this->form_settings['guest_details']
+                            ) ) ) {
                         $this->guest_fields( $this->form_settings );
                     }
 

--- a/languages/wp-user-frontend.pot
+++ b/languages/wp-user-frontend.pot
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: WP User Frontend 4.1.2\n"
 "Report-Msgid-Bugs-To: https://wedevs.com/contact/\n"
-"POT-Creation-Date: 2025-04-16 10:22:46+00:00\n"
+"POT-Creation-Date: 2025-04-22 09:43:05+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -1109,12 +1109,12 @@ msgid "Unauthorized operation"
 msgstr ""
 
 #: admin/template-post.php:36 includes/Admin/Forms/Template_Post.php:39
-#: includes/Fields/Form_Field_Post_Content.php:166
+#: includes/Fields/Form_Field_Post_Content.php:167
 msgid "Enable Image Insertion"
 msgstr ""
 
 #: admin/template-post.php:42 includes/Admin/Forms/Template_Post.php:49
-#: includes/Fields/Form_Field_Post_Content.php:168
+#: includes/Fields/Form_Field_Post_Content.php:169
 msgid "Enable image upload in post area"
 msgstr ""
 
@@ -1750,7 +1750,7 @@ msgid ""
 "to add a new post."
 msgstr ""
 
-#: class/subscription.php:1106 includes/Admin/Subscription.php:1128
+#: class/subscription.php:1106 includes/Admin/Subscription.php:1155
 #. translators: %s: subscription link
 msgid "You must <a href=\"%s\">purchase a pack</a> before posting"
 msgstr ""
@@ -4251,15 +4251,15 @@ msgid ""
 "Please check your inbox!"
 msgstr ""
 
-#: includes/Ajax/Frontend_Form_Ajax.php:497
+#: includes/Ajax/Frontend_Form_Ajax.php:500
 msgid "Invalid email address."
 msgstr ""
 
-#: includes/Ajax/Frontend_Form_Ajax.php:522
+#: includes/Ajax/Frontend_Form_Ajax.php:514
 msgid "You already have an account in our site. Please login to continue."
 msgstr ""
 
-#: includes/Ajax/Frontend_Form_Ajax.php:577
+#: includes/Ajax/Frontend_Form_Ajax.php:569
 #: includes/Frontend_Render_Form.php:215
 #: includes/class-frontend-render-form.php:323
 msgid "You do not have sufficient permissions to access this form."
@@ -6300,13 +6300,13 @@ msgstr ""
 msgid "Please Cancel Your Currently Active Pack first!"
 msgstr ""
 
-#: includes/Frontend_Render_Form.php:298
+#: includes/Frontend_Render_Form.php:300
 #: includes/class-frontend-render-form.php:909
 #: templates/dashboard/posts.php:120
 msgid "Featured"
 msgstr ""
 
-#: includes/Frontend_Render_Form.php:305
+#: includes/Frontend_Render_Form.php:307
 #: includes/class-frontend-render-form.php:916
 #. translators: %1$s is Post type and %2$d is item
 #. translators: %1$s is Post type and %2$s is total feature item


### PR DESCRIPTION
when the `guest post` is open, and guest `Name and Email address` is not required, the form freezes without submitting the post.

Test scenario:
1. From WP Dashboard > Post Forms > Settings of a single post form > General > Post Permission > select Guest Post
2. Uncheck `Require Name and Email address` field
3. Submit the form without logging in

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved validation to ensure guest posting is only allowed when guest details are enabled and not empty.
	- Simplified and clarified error messages for invalid or duplicate guest email addresses.

- **Refactor**
	- Enhanced internal checks for guest posting permissions and guest field display conditions to provide more reliable behavior.
	- Updated sanitization approach to securely preserve Vue.js directives in form field and role/subscription plan checkboxes.

- **Chores**
	- Updated translation template metadata and source code references without changing any user-facing text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->