### PR TITLE
fix: draft button does not appear

### DIFF
--- a/includes/Frontend_Render_Form.php
+++ b/includes/Frontend_Render_Form.php
@@ -75,8 +75,8 @@ class Frontend_Render_Form {
                 <input type="submit" class="wpuf-submit-button wpuf_submit_<?php echo esc_attr( $form_id ); ?>" name="submit" value="<?php echo esc_attr( $form_settings['submit_text'] ); ?>" />
             <?php } ?>
 
-            <?php if ( isset( $form_settings['draft_post'] ) && $form_settings['draft_post'] == 'true' ) { ?>
-                <a href="#" class="btn" id="wpuf-post-draft"><?php esc_html_e( 'Save Draft', 'wp-user-frontend' ); ?></a>
+            <?php if ( isset( $form_settings['draft_post'] ) && wpuf_is_checkbox_or_toggle_on( $form_settings['draft_post'] ) ) { ?>
+                <a href="#" class="btn" style="margin-left: 0.5rem;" id="wpuf-post-draft"><?php esc_html_e( 'Save Draft', 'wp-user-frontend' ); ?></a>
             <?php } ?>
         </li>
 


### PR DESCRIPTION
fixes #1551 

**Description:** Draft button does not appear in post form, though draft button is enabled in post form settings

**Steps:**
Create post form and go to form settings
Enable drat button from settings and save the form
Preview the form and observe that draft button does not appears

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the logic for displaying the "Save Draft" button to better handle different truthy states of the draft setting.

- **Style**
  - Added spacing to the "Save Draft" button for improved visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->