### PR TITLE
fix: pro-button-icon-alignment

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -691,6 +691,10 @@ a.wpuf-button.button-upgrade-to-pro {
   border-radius: 5px;
   text-decoration: none;
   border: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  white-space: nowrap;
 }
 .pro-field-overlay a.wpuf-button.button-upgrade-to-pro {
   position: absolute;
@@ -703,8 +707,13 @@ a.wpuf-button.button-upgrade-to-pro {
 a.wpuf-button.button-upgrade-to-pro:hover {
   background: #d07805;
 }
+span.pro-icon {
+  display: inline-flex;
+  align-items: center;
+}
 span.pro-icon svg {
   height: 1em;
+  margin-left: 5px;
 }
 span.pro-icon.icon-white svg path {
   fill: #fff;

--- a/assets/less/admin.less
+++ b/assets/less/admin.less
@@ -895,6 +895,10 @@ a.wpuf-button.button-upgrade-to-pro {
     border-radius: 5px;
     text-decoration: none;
     border: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    white-space: nowrap;
 }
 
 .pro-field-overlay a.wpuf-button.button-upgrade-to-pro {
@@ -910,8 +914,14 @@ a.wpuf-button.button-upgrade-to-pro:hover {
     background: #d07805;
 }
 
+span.pro-icon {
+    display: inline-flex;
+    align-items: center;
+}
+
 span.pro-icon svg {
     height: 1em;
+    margin-left: 5px;
 }
 
 span.pro-icon.icon-white svg path {


### PR DESCRIPTION
Fix: Upgrade to PRO button icon alignment [https://github.com/weDevsOfficial/wpuf-pro/issues/725](https://github.com/weDevsOfficial/wpuf-pro/issues/725)

The PRO icon in the "Upgrade to PRO" button was breaking into a new line. This update fixes the alignment by:

- Changed button display to inline-flex for better layout control
- Added align-items: center to vertically center text and icon
- Added proper spacing between text and icon using gap property
- Ensured icon stays inline using white-space: nowrap
- Improved icon alignment with inline-flex display

These CSS improvements ensure the crown icon stays on the same line as the text and maintains proper vertical alignment within the button.

![image](https://github.com/user-attachments/assets/91319b47-777b-400a-bf70-e4dff536d0a1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the layout and alignment of upgrade buttons and their icons for a more visually appealing and consistent appearance. Buttons now have better spacing, centered alignment, and icons are properly positioned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->