### PR TITLE
Fix/phpcs workflow deprecation

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Get Composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Setup cache
         uses: pat-s/always-upload-cache@v1.1.4
@@ -33,7 +33,7 @@ jobs:
         run: |
           URL="https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files"
           FILES=$(curl -s -X GET -G $URL | jq -r '.[] | .filename' | xargs)
-          echo "::set-output name=files::$FILES"
+          echo "files=$FILES" >> $GITHUB_OUTPUT
 
       - name: Detect coding standard violations
         run: vendor/bin/phpcs ${{ steps.changes.outputs.files }} -q --report=checkstyle | cs2pr --graceful-warnings

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -691,6 +691,10 @@ a.wpuf-button.button-upgrade-to-pro {
   border-radius: 5px;
   text-decoration: none;
   border: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  white-space: nowrap;
 }
 .pro-field-overlay a.wpuf-button.button-upgrade-to-pro {
   position: absolute;
@@ -703,8 +707,13 @@ a.wpuf-button.button-upgrade-to-pro {
 a.wpuf-button.button-upgrade-to-pro:hover {
   background: #d07805;
 }
+span.pro-icon {
+  display: inline-flex;
+  align-items: center;
+}
 span.pro-icon svg {
   height: 1em;
+  margin-left: 5px;
 }
 span.pro-icon.icon-white svg path {
   fill: #fff;

--- a/assets/less/admin.less
+++ b/assets/less/admin.less
@@ -895,6 +895,10 @@ a.wpuf-button.button-upgrade-to-pro {
     border-radius: 5px;
     text-decoration: none;
     border: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    white-space: nowrap;
 }
 
 .pro-field-overlay a.wpuf-button.button-upgrade-to-pro {
@@ -910,8 +914,14 @@ a.wpuf-button.button-upgrade-to-pro:hover {
     background: #d07805;
 }
 
+span.pro-icon {
+    display: inline-flex;
+    align-items: center;
+}
+
 span.pro-icon svg {
     height: 1em;
+    margin-left: 5px;
 }
 
 span.pro-icon.icon-white svg path {


### PR DESCRIPTION
Refactor: Use GITHUB_OUTPUT in PHPCS workflow

Updated the `.github/workflows/phpcs.yml` workflow to address the deprecation of the `set-output` command. The steps setting composer cache directory and changed files now use the `echo "key=value" >> $GITHUB_OUTPUT` method.

This aligns with GitHub's best practices and prevents potential workflow failures when `set-output` is fully disabled.

Link : [github-actions](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the layout and spacing of the upgrade button and its icon for better alignment and visual consistency in the admin interface.

- **Chores**
  - Updated GitHub Actions workflow to use the latest recommended syntax for setting output variables, ensuring compatibility with current GitHub standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->