### PR TITLE
Fix/module name overlap

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Get Composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Setup cache
         uses: pat-s/always-upload-cache@v1.1.4
@@ -33,7 +33,7 @@ jobs:
         run: |
           URL="https://api.github.com/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files"
           FILES=$(curl -s -X GET -G $URL | jq -r '.[] | .filename' | xargs)
-          echo "::set-output name=files::$FILES"
+          echo "files=$FILES" >> $GITHUB_OUTPUT
 
       - name: Detect coding standard violations
         run: vendor/bin/phpcs ${{ steps.changes.outputs.files }} -q --report=checkstyle | cs2pr --graceful-warnings

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -691,6 +691,10 @@ a.wpuf-button.button-upgrade-to-pro {
   border-radius: 5px;
   text-decoration: none;
   border: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  white-space: nowrap;
 }
 .pro-field-overlay a.wpuf-button.button-upgrade-to-pro {
   position: absolute;
@@ -703,8 +707,13 @@ a.wpuf-button.button-upgrade-to-pro {
 a.wpuf-button.button-upgrade-to-pro:hover {
   background: #d07805;
 }
+span.pro-icon {
+  display: inline-flex;
+  align-items: center;
+}
 span.pro-icon svg {
   height: 1em;
+  margin-left: 5px;
 }
 span.pro-icon.icon-white svg path {
   fill: #fff;

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1350,3 +1350,7 @@ span.pro-icon:hover .wpuf-pro-field-tooltip {
 .wpuf-subscription-pack-settings .subscription-nav-content section .form-table td {
   padding: 15px 0;
 }
+
+.plugin-card .desc>p, .plugin-card .name {
+  margin-left: 148px !important;
+}

--- a/assets/less/admin.less
+++ b/assets/less/admin.less
@@ -1231,6 +1231,10 @@ span.pro-icon:hover .wpuf-pro-field-tooltip {
     }
 }
 
+.plugin-card .desc>p, .plugin-card .name {
+    margin-left: 148px !important;
+}
+
 @import "help.less";
 @import "whats-new.less";
 @import "metabox-tabs.less";

--- a/assets/less/admin.less
+++ b/assets/less/admin.less
@@ -895,6 +895,10 @@ a.wpuf-button.button-upgrade-to-pro {
     border-radius: 5px;
     text-decoration: none;
     border: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    white-space: nowrap;
 }
 
 .pro-field-overlay a.wpuf-button.button-upgrade-to-pro {
@@ -910,8 +914,14 @@ a.wpuf-button.button-upgrade-to-pro:hover {
     background: #d07805;
 }
 
+span.pro-icon {
+    display: inline-flex;
+    align-items: center;
+}
+
 span.pro-icon svg {
     height: 1em;
+    margin-left: 5px;
 }
 
 span.pro-icon.icon-white svg path {


### PR DESCRIPTION
close #1555 

**Fix: Adjust plugin card text alignment**

- Increased the margin-left for the .name and .desc > p elements within .plugin-card components to 148px. 
- This adjustment ensures proper alignment of the plugin name and description text, likely preventing overlap with the plugin icon or thumbnail and improving the overall layout readability in the plugin listing sections.

Screenshot:
![image](https://github.com/user-attachments/assets/9ebafd54-1e22-4831-bc91-7b7a5553a15d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved alignment and spacing for upgrade buttons and icons in the admin interface.
  - Enhanced layout of plugin card descriptions and names for better readability.

- **Chores**
  - Updated GitHub Actions workflow to use the latest method for setting output variables, ensuring compatibility with current standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->