### PR TITLE
fix: subscription feature remaining bugs

### DIFF
--- a/includes/Admin/Subscription.php
+++ b/includes/Admin/Subscription.php
@@ -880,7 +880,7 @@ class Subscription {
             $user_id         = get_current_user_id();
             $payment_gateway = $wpdb->get_var( $wpdb->prepare( "SELECT payment_type FROM {$wpdb->prefix}wpuf_transaction WHERE user_id = %s AND status = 'completed' ORDER BY created DESC", $user_id ) );
 
-            $payment_gateway = strtolower( $payment_gateway );
+            $payment_gateway = $payment_gateway ? strtolower( $payment_gateway ) : '';
             ?>
 
             <?php echo wp_kses_post( __( '<p><i>You have a subscription pack activated. </i></p>', 'wp-user-frontend' ) ); ?>

--- a/includes/User_Subscription.php
+++ b/includes/User_Subscription.php
@@ -83,9 +83,9 @@ class User_Subscription {
 
         $expire_date = isset( $this->pack['expire'] ) ? $this->pack['expire'] : 0;
         $expired     = true;
-
+        
         // phpcs:disable
-        if ( strtolower( $expire_date ) == 'unlimited' || empty( $expire_date ) ) {
+        if ( strtolower( $expire_date ) == 'unlimited' || empty( $expire_date ) || $expire_date == '-1' ) {
             $expired = false;
         } elseif ( strtotime( date( 'Y-m-d', strtotime( $expire_date ) ) ) >= strtotime( date( 'Y-m-d', time() ) ) ) {
             $expired = false;
@@ -191,9 +191,7 @@ class User_Subscription {
                 'status'  => $status,
             ];
 
-            // $recurring = get_post_meta( $pack_id, '_recurring_pay', true );
-
-            if ( $recurring ) {
+            if ( $subscription->meta_value['recurring_pay'] == 'on') {
                 $totla_date              = date( 'd-m-Y', strtotime( '+' . $subscription->meta_value['billing_cycle_number'] . $subscription->meta_value['cycle_period'] . 's' ) ); // phpcs:ignore
                 $user_meta['expire']     = '';
                 $user_meta['profile_id'] = $profile_id;
@@ -202,7 +200,7 @@ class User_Subscription {
                 $period_type            = $subscription->meta_value['expiration_period'];
                 $period_number          = $subscription->meta_value['expiration_number'];
                 $date                   = date( 'd-m-Y', strtotime( '+' . $period_number . $period_type . 's' ) ); // phpcs:ignore
-                $expired                = ( empty( $period_number ) || ( $period_number == 0 ) ) ? 'unlimited' : wpuf_date2mysql( $date );
+                $expired                = ( empty( $period_number ) || ( $period_number == 0 || $period_number == '-1' ) ) ? 'unlimited' : wpuf_date2mysql( $date );
                 $user_meta['expire']    = $expired;
                 $user_meta['recurring'] = 'no';
             }

--- a/templates/dashboard/subscription.php
+++ b/templates/dashboard/subscription.php
@@ -20,27 +20,63 @@
                 <strong><?php esc_html_e( 'Remaining post: ', 'wp-user-frontend' ); ?></strong>
                 <?php
                 $i = 0;
+                $post_count = 0;
                 if ( ! empty( $user_sub['posts'] ) ) {
                     foreach ( $user_sub['posts'] as $key => $value ) {
                         $value = intval( $value );
-
                         if ( 0 === $value || -1 === $value ) {
                             continue;
                         }
-
                         $post_type_obj = get_post_type_object( $key );
-
                         if ( ! $post_type_obj ) {
                             continue;
                         }
-                        $value = ( $value == '-1' ) ? __( 'Unlimited', 'wp-user-frontend' ) : $value; ?>
-                        <div><?php echo esc_html( $post_type_obj->labels->name ) . ': ' . esc_html( $value ); ?></div>
+                        $post_count++;
+                    }
+                }
+                ?>
+                <div id="wpuf-remaining-posts-list">
+                <?php
+                $i = 0;
+                if ( ! empty( $user_sub['posts'] ) ) {
+                    foreach ( $user_sub['posts'] as $key => $value ) {
+                        $value = intval( $value );
+                        if ( 0 === $value || -1 === $value ) {
+                            continue;
+                        }
+                        $post_type_obj = get_post_type_object( $key );
+                        if ( ! $post_type_obj ) {
+                            continue;
+                        }
+                        $value = ( $value == '-1' ) ? __( 'Unlimited', 'wp-user-frontend' ) : $value;
+                        $hidden_class = ($i >= 3) ? 'wpuf-remaining-post-hidden' : '';
+                        ?>
+                        <div class="<?php echo esc_attr( $hidden_class ); ?>"><?php echo esc_html( $post_type_obj->labels->name ) . ': ' . esc_html( $value ); ?></div>
                         <?php
                         $i ++;
                     }
                 }
                 echo $i ? '' : esc_attr( $i );
                 ?>
+                </div>
+                <?php if ( $post_count > 3 ) : ?>
+                    <button type="button" id="wpuf-remaining-posts-toggle" class="btn btn-link" style="padding:0;"><?php esc_html_e( 'Show More', 'wp-user-frontend' ); ?></button>
+                    <script>
+                        (function(){
+                            var btn = document.getElementById('wpuf-remaining-posts-toggle');
+                            var hidden = document.querySelectorAll('.wpuf-remaining-post-hidden');
+                            var expanded = false;
+                            btn.addEventListener('click', function() {
+                                expanded = !expanded;
+                                hidden.forEach(function(el) {
+                                    el.style.display = expanded ? 'block' : 'none';
+                                });
+                                btn.textContent = expanded ? '<?php echo esc_js( __( 'Show Less', 'wp-user-frontend' ) ); ?>' : '<?php echo esc_js( __( 'Show More', 'wp-user-frontend' ) ); ?>';
+                            });
+                            hidden.forEach(function(el) { el.style.display = 'none'; });
+                        })();
+                    </script>
+                <?php endif; ?>
             </div>
             <?php
             if ( $user_sub['recurring'] != 'yes' ) {
@@ -53,23 +89,152 @@
                 }
             }
 
-            if ( $user_sub['recurring'] == 'yes' ) {
-                global $wpdb;
-
-                $user_id         = get_current_user_id();
-                $payment_gateway = $wpdb->get_var( $wpdb->prepare( "SELECT payment_type FROM {$wpdb->prefix}wpuf_transaction WHERE user_id = %d AND status = 'completed' ORDER BY created DESC", $user_id ) );
-
-                $payment_gateway = strtolower( $payment_gateway ); ?>
-                <br>
-                <p><i><?php esc_html_e( 'To cancel the pack, press the following cancel button.', 'wp-user-frontend' ); ?></i></p>
-                <form action="" method="post" style="text-align: center;">
-                    <?php wp_nonce_field( 'wpuf-sub-cancel' ); ?>
-                    <input type="hidden" name="gateway" value="<?php echo esc_attr( $payment_gateway ); ?>">
-                    <input type="submit" name="wpuf_cancel_subscription" class="btn btn-sm btn-danger" value="<?php esc_html_e( 'Cancel', 'wp-user-frontend' ); ?>">
-                </form>
-                <?php
+            if ( $user_sub['recurring'] === 'yes' ) {
+                $subscription_data = get_subscription_data( $user_sub );
+                display_subscription_details( $subscription_data );
             }
         }
         ?>
     </div>
 </div>
+
+<?php
+    /**
+     * Get subscription related data
+     *
+     * @param array $user_sub User subscription data
+     * @return array Subscription data
+     */
+    function get_subscription_data( $user_sub ) {
+        global $wpdb;
+        
+        $user_id = get_current_user_id();
+        $pack_id = $user_sub['pack_id'];
+        $subscription = wpuf()->subscription->get_subscription( $pack_id );
+        // Get payment gateway
+        $payment_gateway = $wpdb->get_var( $wpdb->prepare( 
+            "SELECT payment_type 
+            FROM {$wpdb->prefix}wpuf_transaction 
+            WHERE user_id = %d 
+            AND status = 'completed' 
+            ORDER BY created DESC", 
+            $user_id 
+        ) );
+        $payment_gateway = strtolower( $payment_gateway );
+
+        // Get last payment date
+        $last_payment_date = $wpdb->get_var( $wpdb->prepare(
+            "SELECT created 
+            FROM {$wpdb->prefix}wpuf_transaction 
+            WHERE user_id = %d 
+            AND status = 'completed' 
+            ORDER BY created DESC 
+            LIMIT 1",
+            $user_id
+        ) );
+
+        // Get billing cycle details
+        $cycle_number = intval( $subscription->meta_value['billing_cycle_number'] );
+        $cycle_period = $subscription->meta_value['cycle_period'];
+        
+        // Get trial details
+        $trial_status = $subscription->meta_value['trial_status'];
+        $trial_duration = $subscription->meta_value['trial_duration'];
+        $trial_duration_type = $subscription->meta_value['trial_duration_type'];
+
+        return [
+            'payment_gateway' => $payment_gateway,
+            'last_payment_date' => $last_payment_date,
+            'cycle_number' => $cycle_number,
+            'cycle_period' => $cycle_period,
+            'trial_status' => $trial_status,
+            'trial_duration' => $trial_duration,
+            'trial_duration_type' => $trial_duration_type
+        ];
+    }
+
+    /**
+     * Display subscription details
+     *
+     * @param array $subscription_data Subscription data
+     * @return void
+     */
+    function display_subscription_details( $subscription_data ) {
+        $trial_html = get_trial_expiration_html( $subscription_data );
+        $billing_html = get_next_billing_html( $subscription_data );
+        ?>
+        <br>
+        <?php if ( $subscription_data['trial_status'] == 'on' ): ?>
+            <?php echo wp_kses_post( $trial_html ); ?>
+        <?php elseif ( $subscription_data['trial_status'] === 'off' ): ?>
+            <div class="wpuf-recurring-info">
+                <?php echo wp_kses_post( $billing_html ); ?>
+            </div>
+        <?php endif; ?>
+        
+        <p><i><?php esc_html_e( 'To cancel the pack, press the following cancel button.', 'wp-user-frontend' ); ?></i></p>
+        <form action="" method="post" style="text-align: center;">
+            <?php wp_nonce_field( 'wpuf-sub-cancel' ); ?>
+            <input type="hidden" name="gateway" value="<?php echo esc_attr( $subscription_data['payment_gateway'] ); ?>">
+            <input type="submit" name="wpuf_cancel_subscription" class="btn btn-sm btn-danger" value="<?php esc_html_e( 'Cancel', 'wp-user-frontend' ); ?>">
+        </form>
+        <?php
+    }
+
+    /**
+     * Get trial expiration HTML
+     *
+     * @param array $subscription_data Subscription data
+     * @return string HTML for trial expiration
+     */
+    function get_trial_expiration_html( $subscription_data ) {
+        if ( $subscription_data['trial_status'] !== 'on' ) {
+            return '';
+        }
+
+        $trial_expiration_date = date(
+            'Y-m-d', 
+            strtotime(
+                "+{$subscription_data['trial_duration']} {$subscription_data['trial_duration_type']}", 
+                strtotime( $subscription_data['last_payment_date'] )
+            )
+        );
+
+        return sprintf(
+            '<div><strong>%s</strong> %s</div>',
+            esc_html__( 'Trial expiration date:', 'wp-user-frontend' ),
+            esc_html( $trial_expiration_date )
+        );
+    }
+
+    /**
+     * Get next billing HTML
+     *
+     * @param array $subscription_data Subscription data
+     * @return string HTML for next billing
+     */
+    function get_next_billing_html( $subscription_data ) {
+        if ( ! $subscription_data['last_payment_date'] || 
+             ! $subscription_data['cycle_number'] || 
+             ! $subscription_data['cycle_period'] ) {
+            return sprintf(
+                '<div><strong>%s</strong> %s</div>',
+                esc_html__( 'Next billing date:', 'wp-user-frontend' ),
+                esc_html__( 'N/A', 'wp-user-frontend' )
+            );
+        }
+
+        $next_billing_date = date(
+            'Y-m-d',
+            strtotime(
+                "+{$subscription_data['cycle_number']} {$subscription_data['cycle_period']}", 
+                strtotime( $subscription_data['last_payment_date'] )
+            )
+        );
+        return sprintf(
+            '<div><strong>%s</strong> %s</div>',
+            esc_html__( 'Next billing date:', 'wp-user-frontend' ),
+            esc_html( $next_billing_date )
+        );
+    }
+?>


### PR DESCRIPTION
### Subscription logic improvements:
* Updated the `expired()` method to handle a special case where the expiration date is `-1`, treating it as "unlimited" (`includes/User_Subscription.php`).
* Adjusted the `add_pack()` method to account for `-1` as a valid value for unlimited expiration and replaced a commented-out recurring logic check with a proper condition (`includes/User_Subscription.php`) [[1]](diffhunk://#diff-aca5e67137f8129a32bbccf5517bb457783ffdb20f59e98e239b185cb43be24dL194-R194) [[2]](diffhunk://#diff-aca5e67137f8129a32bbccf5517bb457783ffdb20f59e98e239b185cb43be24dL205-R203).

### User interface enhancements:
* Added a "Show More" button to the subscription dashboard to toggle the visibility of additional remaining post types when more than three are present (`templates/dashboard/subscription.php`).
* Refactored the subscription dashboard to display detailed subscription information, including trial expiration and next billing dates, using newly introduced helper functions (`templates/dashboard/subscription.php`).

### Code robustness and readability:
* Ensured safe handling of null values in payment gateway retrieval by adding a fallback to an empty string (`includes/Admin/Subscription.php`).
* Modularized subscription-related logic by introducing helper functions `get_subscription_data()`, `display_subscription_details()`, `get_trial_expiration_html()`, and `get_next_billing_html()` to improve code readability and reusability (`templates/dashboard/subscription.php`).

- solves [issue](https://github.com/weDevsOfficial/wpuf-pro/issues/742)