### PR TITLE
Fix: Render HTML tags in help text instead of displaying as plain text

### DIFF
--- a/includes/Admin/views/support.php
+++ b/includes/Admin/views/support.php
@@ -442,7 +442,7 @@ function wpuf_help_related_articles( $articles ) {
                     printf(
                         wp_kses(
                             // translators: %1$s. Opening paragraph tag. %2$s Opening strong tag for "Frontend Dashboard". %3$s Closing strong tag. %4$s Opening strong tag for "My Account". %5$s Closing strong tag. %6$s Closing paragraph tag.
-                            __( '%1$sWP User Frontend generates %2$sFrontend Dashboard%3$s and %4$sMy Account%5$s page for all your users. Using these pages, they can get a list of their posts and subscriptions directly at frontend. They can also customize the details of their profile. You don’t need to give them access to the backend at all!%6$s', 'wp-user-frontend' ),
+                            __( '%1$sWP User Frontend generates %2$sFrontend Dashboard%3$s and %4$sMy Account%5$s page for all your users. Using these pages, they can get a list of their posts and subscriptions directly at frontend. They can also customize the details of their profile. You don\'t need to give them access to the backend at all!%6$s', 'wp-user-frontend' ),
                             array(
                                 'p'      => array(),
                                 'strong' => array()
@@ -582,7 +582,7 @@ function wpuf_help_related_articles( $articles ) {
                     printf(
                         // translators: %1$s and %2$s = <strong> tags
                         esc_html__(
-                            'We assume you’ve already created a registration form. If not, you can use the default form that was automatically created during plugin installation. To get the shortcode, go to %1$sUser Frontend%2$s → %3$sRegistration Forms%4$s in your dashboard. You’ll find the shortcodes listed on the right side of the screen.',
+                            'We assume you\'ve already created a registration form. If not, you can use the default form that was automatically created during plugin installation. To get the shortcode, go to %1$sUser Frontend%2$s → %3$sRegistration Forms%4$s in your dashboard. You\'ll find the shortcodes listed on the right side of the screen.',
                             'wp-user-frontend'
                         ),
                         '<strong>',
@@ -610,11 +610,11 @@ function wpuf_help_related_articles( $articles ) {
                     <li><?php esc_html_e( 'This will enable some new settings. You have to specify post expiration time and the post status after the post expires.', 'wp-user-frontend' ); ?></li>
                     <li><?php esc_html_e( 'You can also notify users when a post expires. To do so, check the Send Mail option.', 'wp-user-frontend' ); ?></li>
                     <li><?php esc_html_e( 'Now, enter the message you want to send the user in the Post Expiration Message field.', 'wp-user-frontend' ); ?></li>
-                    <li><?php esc_html_e( 'You can specify the number of posts you are giving away with this subscription pack. If you want to provide unlimited posts, enter ‘-1’ in the number of posts field.', 'wp-user-frontend' ); ?></li>
-                    <li><?php esc_html_e( 'You can also set the number of pages and custom CSS. For unlimited value, enter ‘-1’.', 'wp-user-frontend' ); ?></li>
+                    <li><?php esc_html_e( 'You can specify the number of posts you are giving away with this subscription pack. If you want to provide unlimited posts, enter -1 in the number of posts field.', 'wp-user-frontend' ); ?></li>
+                    <li><?php esc_html_e( 'You can also set the number of pages and custom CSS. For unlimited value, enter −1', 'wp-user-frontend' ); ?></li>
                     <li><?php esc_html_e( 'WPUF offers you recurring payment while creating a Subscription pack. Enable this option if you want to set recurring payment for this pack. It will provide you some new options for the recurring payment.', 'wp-user-frontend' ); ?></li>
                     <li><?php esc_html_e( 'Now, select the billing cycle.', 'wp-user-frontend' ); ?></li>
-                    <li><?php esc_html_e( 'You can also stop the billing cycle if you want. If you don’t want to stop the cycle select Never.', 'wp-user-frontend' ); ?></li>
+                    <li><?php esc_html_e( 'You can also stop the billing cycle if you want. If you don\'t want to stop the cycle select Never.', 'wp-user-frontend' ); ?></li>
                     <li><?php esc_html_e( 'To enable trial period, check the Trial box. You can set the trial amount to be paid by the user for trial period.', 'wp-user-frontend' ); ?></li>
                     <li><?php esc_html_e( 'Now, specify the trial period. Enter number of days, week, month or year.', 'wp-user-frontend' ); ?></li>
                     <li><?php esc_html_e( 'You can also enable post number rollback. If enabled, number of posts will be restored if the post is deleted.', 'wp-user-frontend' ); ?></li>
@@ -644,20 +644,20 @@ function wpuf_help_related_articles( $articles ) {
                 <h2><?php esc_html_e('Pay Per Post', 'wp-user-frontend'); ?></h2>
 
                 <p>
-                    <?php esc_html_e('With this you can introduce pay per post feature where users pay to publish their posts each post. When pay per post is enabled from “Settings → Payments → Charge for posting“, users see a notice right before the post creation form in frontend about payment. When the submits a post, the post status gets pending and he is redirected to the payment page (to setup the payment page, create a Page Payment and select the page at “Settings → Payments → Payment Page“. No shortcode is needed). Currently by default PayPal is only supported gateway. Upon selecting PayPal, he is redirected to PayPal for payment. After successful payment he is redirected back to the site and the post gets published.', 'wp-user-frontend'); ?>
+                    <?php esc_html_e('With this you can introduce pay per post feature where users pay to publish their posts each post. When pay per post is enabled from "Settings → Payments → Charge for posting", users see a notice right before the post creation form in frontend about payment. When the submits a post, the post status gets pending and he is redirected to the payment page (to setup the payment page, create a Page Payment and select the page at "Settings → Payments → Payment Page". No shortcode is needed). Currently by default PayPal is only supported gateway. Upon selecting PayPal, he is redirected to PayPal for payment. After successful payment he is redirected back to the site and the post gets published.', 'wp-user-frontend'); ?>
                 </p>
 
                 <h2><?php esc_html_e('Subscription Pack', 'wp-user-frontend'); ?></h2>
 
                 <p><?php esc_html_e('There is an another option for charged posting. With this feature, you can create unlimited subscription pack. In each pack, you can configure the number of posts, validity date and the cost.', 'wp-user-frontend'); ?></p>
-                <p><?php esc_html_e('When a user buys a subscription package, he gets to create some posts (e.g. 10) in X days (e.g: 30 days). If he crosses the number of posts or the validity date, he can’t post again. You can force the user to buy a pack before posting “Settings → Payments → Force pack purchase“.', 'wp-user-frontend'); ?></p>
+                <p><?php esc_html_e('When a user buys a subscription package, he gets to create some posts (e.g. 10) in X days (e.g: 30 days). If he crosses the number of posts or the validity date, he can\'t post again. You can force the user to buy a pack before posting "Settings → Payments → Force pack purchase".', 'wp-user-frontend'); ?></p>
                 <p></p>
                 <p>
                     <?php
                     printf(
                         // translators: %1$s and %2$s are HTML tags, %3$s and %4$s are HTML tags
                         esc_html__(
-                            'To show the subscription packs in a page, you can use the shortcode: %1$s[wpuf_sub_pack]%2$s. To show the user subscription info: %3$s[wpuf_sub_info]%4$s. The info will show the user about his pack’s remaining post count and expiration date of his pack.',
+                            'To show the subscription packs in a page, you can use the shortcode: %1$s[wpuf_sub_pack]%2$s. To show the user subscription info: %3$s[wpuf_sub_info]%4$s. The info will show the user about his pack\'s remaining post count and expiration date of his pack.',
                             'wp-user-frontend'
                         ),
                         '<code>',
@@ -695,9 +695,9 @@ function wpuf_help_related_articles( $articles ) {
 
                 <ol>
                     <li><?php esc_html_e( 'Now, select the page that has the shortcode of the selected form.', 'wp-user-frontend' ); ?></li>
-                    <li><?php esc_html_e( 'Scroll down and you will find the <strong>WPUF Content Restriction</strong> settings.', 'wp-user-frontend' ); ?></li>
-                    <li><?php esc_html_e( 'You can set the form visible to three types of people: <strong>Everyone</strong>, <strong>Logged in users only</strong> or <strong>Subscription users only</strong>', 'wp-user-frontend' ); ?></li>
-                    <li><?php esc_html_e( 'You can also set <strong>subscription plans</strong> for the form. For this, check the box of relevant subscription pack.', 'wp-user-frontend' ); ?></li>
+                    <li><?php echo wp_kses_post( __( 'Scroll down and you will find the <strong>WPUF Content Restriction</strong> settings.', 'wp-user-frontend' ) ); ?></li>
+                    <li><?php echo wp_kses_post( __( 'You can set the form visible to three types of people: <strong>Everyone</strong>, <strong>Logged in users only</strong> or <strong>Subscription users only</strong>', 'wp-user-frontend' ) ); ?></li>
+                    <li><?php echo wp_kses_post( __( 'You can also set <strong>subscription plans</strong> for the form. For this, check the box of relevant subscription pack.', 'wp-user-frontend' ) ); ?></li>
                     <li><?php esc_html_e( 'Finally, update the page.', 'wp-user-frontend' ); ?></li>
                 </ol>
 


### PR DESCRIPTION
Close #1559 

**Description of Changes**

- Fixed apostrophe (') code errors in translation strings by escaping them as \' within single-quoted PHP strings. This prevents syntax errors and ensures proper rendering of text containing apostrophes (e.g., "don't", "can't").

- Corrected HTML rendering in translation strings: For any help text that includes HTML tags (such as <strong>), replaced esc_html_e() with echo wp_kses_post( __( ... ) ) to allow safe HTML to be rendered in the output, instead of being displayed as plain text.

![image](https://github.com/user-attachments/assets/acc85e36-fdf6-4ae3-ae7a-a4711ffa6f07)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Standardized apostrophes and quotation marks in support page text for consistency.

- **Documentation**
  - Improved rendering of inline HTML tags in the support page content for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->