### PR TITLE
Fix: Add missing phone field icon for blurred pro fields in free plugin

### DIFF
--- a/assets/images/phone.svg
+++ b/assets/images/phone.svg
@@ -1,0 +1,3 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8.75 1.25H6.875C5.83947 1.25 5 2.08947 5 3.125V16.875C5 17.9105 5.83947 18.75 6.875 18.75H13.125C14.1605 18.75 15 17.9105 15 16.875V3.125C15 2.08947 14.1605 1.25 13.125 1.25H11.25M8.75 1.25V2.5H11.25V1.25M8.75 1.25H11.25M8.75 16.875H11.25" stroke="#6B7280" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/includes/Pro_Upgrades.php
+++ b/includes/Pro_Upgrades.php
@@ -43,9 +43,11 @@ class Pro_Upgrades {
         $pro_fields = [
             'repeat_field',
             'date_field',
+            'time_field',
             'file_upload',
             'country_list_field',
             'numeric_text_field',
+            'phone_field',
             'address_field',
             'google_map',
             'step_start',


### PR DESCRIPTION
Close #1587 

### Summary
**Fix: Add missing phone field icon for blurred pro fields in free plugin**

### Changes Made

1. **Added missing phone.svg icon to free plugin assets**
   - **File**: `wp-content/plugins/wp-user-frontend/assets/images/phone.svg`
   - **Action**: Copied `device-phone-mobile.svg` from pro plugin to free plugin as `phone.svg`
   - **Reason**: The phone field in the free plugin was configured to use icon `'phone'` but the corresponding SVG file was missing, causing the icon not to display in the blurred pro field preview

2. **Added missing pro field definitions**
   - **File**: `wp-content/plugins/wp-user-frontend/includes/Pro_Upgrades.php`
   - **Action**: Added `'time_field'` and `'phone_field'` to the `$pro_fields` array in the `add_to_custom_fields()` method
   - **Reason**: These fields were missing from the pro fields list, causing them not to be properly blurred with pro badges in the free plugin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for "Time" and "Phone" field types as pro custom fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->