### PR TITLE
fix: fix/form builder missing infotips 814

### DIFF
--- a/includes/Fields/Field_Contract.php
+++ b/includes/Fields/Field_Contract.php
@@ -48,6 +48,7 @@ abstract class Field_Contract {
                 'priority' => 15,
                 'inline' => true,
                 'default' => 'max',
+                'help_text' => __( 'Choose whether to enforce a minimum or maximum content limit', 'wp-user-frontend' ),
             ],
 
             [
@@ -62,6 +63,7 @@ abstract class Field_Contract {
                 'priority' => 15,
                 'inline' => true,
                 'default' => 'character',
+                'help_text' => __( 'Select whether the content restriction applies by character count or word count', 'wp-user-frontend' ),
             ],
 
             [
@@ -320,6 +322,7 @@ abstract class Field_Contract {
                 'priority'  => 21,
                 'default'   => 'large',
                 'inline'    => true,
+                'help_text' => __( 'Adjust the visual width of the input field on the front-end', 'wp-user-frontend' ),
             ],
 
             [


### PR DESCRIPTION
Close [814](https://github.com/weDevsOfficial/wpuf-pro/issues/814)

Description : Added missing help text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added descriptive help text to several field options to provide clearer guidance for users when configuring content restrictions and input field width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->