### PR TITLE
feat: separate translation context for date range "To" in German

### DIFF
--- a/admin/html/form-submission-restriction.php
+++ b/admin/html/form-submission-restriction.php
@@ -141,7 +141,7 @@ $limit_message   = ! empty( $form_settings['limit_message'] ) ? $form_settings['
                 <input type="text" name="wpuf_settings[schedule_start]" id="schedule_start" value="<?php echo esc_attr( $schedule_start ); ?>" class="datepicker">
                 <!-- <datepicker name="wpuf_settings[schedule_start]"></datepicker> -->
 
-                <?php esc_html_e( 'To (date range)', 'wp-user-frontend' ); ?>
+                <?php echo esc_html_x( 'To', 'date range', 'wp-user-frontend' ); ?>
                 <input type="text" name="wpuf_settings[schedule_end]" id="schedule_end" value="<?php echo esc_attr( $schedule_end ); ?>" class="datepicker">
                 <!-- <datepicker name="wpuf_settings[schedule_end]"></datepicker> -->
             </td>

--- a/admin/html/form-submission-restriction.php
+++ b/admin/html/form-submission-restriction.php
@@ -141,7 +141,7 @@ $limit_message   = ! empty( $form_settings['limit_message'] ) ? $form_settings['
                 <input type="text" name="wpuf_settings[schedule_start]" id="schedule_start" value="<?php echo esc_attr( $schedule_start ); ?>" class="datepicker">
                 <!-- <datepicker name="wpuf_settings[schedule_start]"></datepicker> -->
 
-                <?php esc_html_e( 'To', 'wp-user-frontend' ); ?>
+                <?php esc_html_e( 'To (date range)', 'wp-user-frontend' ); ?>
                 <input type="text" name="wpuf_settings[schedule_end]" id="schedule_end" value="<?php echo esc_attr( $schedule_end ); ?>" class="datepicker">
                 <!-- <datepicker name="wpuf_settings[schedule_end]"></datepicker> -->
             </td>


### PR DESCRIPTION
close #1595 

- Change "To" to "To (date range)" in form scheduling period
- Allows German translators to use "bis" for date ranges vs "an" for email recipients
- Improves German UX by using contextually appropriate translations
- File: admin/html/form-submission-restriction.php line 144

Fixes translation ambiguity where "To" was used for both email recipients and date ranges, causing confusion in German interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Updated the label for the schedule form's end date input to clarify it as a date range in the form submission restriction settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->