### PR TITLE
fix: unauthorized login and register dynamic url

### DIFF
--- a/includes/Frontend/Frontend_Form.php
+++ b/includes/Frontend/Frontend_Form.php
@@ -483,7 +483,7 @@ class Frontend_Form extends Frontend_Render_Form {
             $login        = wpuf()->frontend->simple_login->get_login_url();
             $register     = wpuf()->frontend->simple_login->get_registration_url();
             $replace      = [ "<a href='" . $login . "'>Login</a>", "<a href='" . $register . "'>Register</a>" ];
-            $placeholders = [ '%login%', '%register%' ];
+            $placeholders = [ '{login}', '{register}' ];
 
             $this->form_settings['message_restrict'] = str_replace( $placeholders, $replace, $this->form_settings['message_restrict'] );
         }

--- a/includes/Frontend_Render_Form.php
+++ b/includes/Frontend_Render_Form.php
@@ -202,7 +202,14 @@ class Frontend_Render_Form {
             wp_enqueue_style( 'wpuf-' . $layout );
         }
         if ( ! is_user_logged_in() && ( ! empty( $this->form_settings['post_permission'] ) && 'guest_post' !== $this->form_settings['post_permission'] ) ) {
-            echo wp_kses_post( '<div class="wpuf-message">' . $this->form_settings['message_restrict'] . '</div>' );
+            $login        = wpuf()->frontend->simple_login->get_login_url();
+            $register     = wpuf()->frontend->simple_login->get_registration_url();
+            $replace      = [ "<a href='" . $login . "'>Login</a>", "<a href='" . $register . "'>Register</a>" ];
+            $placeholders = [ '{login}', '{register}' ];
+
+            $message_restrict = str_replace( $placeholders, $replace, $this->form_settings['message_restrict'] );
+
+            echo wp_kses_post( '<div class="wpuf-message">' . $message_restrict . '</div>' );
 
             return;
         }


### PR DESCRIPTION
the `{login}` and `{register}` keyword should replace dynamically based on settings. fixed in this PR.

Step to reproduce:
1. go to WP Dashboard > User Frontend > Post Forms.
2. Open a form and go to Form Settings > General > set Post Permission to Role Based Post. Then select some role.

Now where this forms shortcode is placed, The visitor should see the `Unauthorized Message` with dynamic login and registration page link. But the link was not working

![image](https://github.com/user-attachments/assets/63d65036-7b02-488c-8ad0-5350530e09d1)
