### PR TITLE
fix: Keep List & Builder Footer Color Consistent

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1,1359 +1,1521 @@
 h2.swal2-title {
-  line-height: 1.2em;
-  color: #000000 !important;
+    line-height: 1.2em;
+    color: #000000 !important;
 }
 .wpuf-admin fieldset {
-  border: 1px solid #E3E3E3;
-  margin: 20px 0 0px 0;
-  padding-bottom: 20px;
-  -moz-border-radius: 5px;
-  -webkit-border-radius: 5px;
-  background: #fff;
-  -moz-box-shadow: inset 0 0 5px #ccc;
-  -webkit-box-shadow: inset 0 0 5px #ccc;
-  box-shadow: inset 0 0 5px #ccc;
+    border: 1px solid #e3e3e3;
+    margin: 20px 0 0px 0;
+    padding-bottom: 20px;
+    -moz-border-radius: 5px;
+    -webkit-border-radius: 5px;
+    background: #fff;
+    -moz-box-shadow: inset 0 0 5px #ccc;
+    -webkit-box-shadow: inset 0 0 5px #ccc;
+    box-shadow: inset 0 0 5px #ccc;
 }
 .wpuf-admin legend {
-  -moz-border-radius: 5px 5px 5px 5px;
-  -webkit-border-radius: 5px;
-  background: #FFFFFF;
-  border: 1px solid #E3E3E3;
-  color: #2481C6;
-  font-size: 15px;
-  font-weight: bold;
-  margin-left: 20px;
-  padding: 5px 10px;
-  text-transform: capitalize;
-  -moz-box-shadow: inset 0 0 5px #ccc;
-  -webkit-box-shadow: inset 0 0 5px #ccc;
-  box-shadow: inset 0 0 5px #ccc;
+    -moz-border-radius: 5px 5px 5px 5px;
+    -webkit-border-radius: 5px;
+    background: #ffffff;
+    border: 1px solid #e3e3e3;
+    color: #2481c6;
+    font-size: 15px;
+    font-weight: bold;
+    margin-left: 20px;
+    padding: 5px 10px;
+    text-transform: capitalize;
+    -moz-box-shadow: inset 0 0 5px #ccc;
+    -webkit-box-shadow: inset 0 0 5px #ccc;
+    box-shadow: inset 0 0 5px #ccc;
 }
 .wpuf-admin .widefat td {
-  padding: 7px 12px;
-  vertical-align: top;
+    padding: 7px 12px;
+    vertical-align: top;
 }
 .wpuf-admin .meta td.label {
-  width: 140px;
-  font-size: 12px;
+    width: 140px;
+    font-size: 12px;
 }
 .wpuf-admin .meta .description {
-  font-size: 11px;
+    font-size: 11px;
 }
 .wpuf-admin td.label {
-  font-size: 12px;
+    font-size: 12px;
 }
 .wpuf-admin .options td:nth-child(odd) {
-  background-color: F9F9F9;
+    background-color: F9F9F9;
 }
 .wpuf-admin .nav-tab {
-  font-size: 15px;
-  margin: 0 0px -1px 0;
+    font-size: 15px;
+    margin: 0 0px -1px 0;
 }
 .wpuf_admin ul {
-  margin: 10px;
+    margin: 10px;
 }
 .wpuf_admin li {
-  padding: 0 0 10px;
-  margin: 0 0 10px;
-  border-bottom: 1px solid #E7E7E7;
-  line-height: 20px;
+    padding: 0 0 10px;
+    margin: 0 0 10px;
+    border-bottom: 1px solid #e7e7e7;
+    line-height: 20px;
 }
 .wpuf_admin li:last-child {
-  border-bottom: none;
+    border-bottom: none;
 }
 .wpuf_admin span.label {
-  float: left;
-  height: 20px;
-  line-height: 20px;
-  width: 200px;
+    float: left;
+    height: 20px;
+    line-height: 20px;
+    width: 200px;
 }
 span.wpuf_help {
-  height: 16px;
-  width: 16px;
-  background: url('../images/help.png') no-repeat;
-  cursor: pointer;
-  float: right;
-  display: none;
+    height: 16px;
+    width: 16px;
+    background: url("../images/help.png") no-repeat;
+    cursor: pointer;
+    float: right;
+    display: none;
 }
 span.wpuf-loading {
-  height: 16px;
-  width: 16px;
-  background: url('../images/wpspin_light.gif') no-repeat;
-  padding: 0;
-  margin: 5px 10px;
-  right: -40px;
-  top: 0;
-  float: left;
+    height: 16px;
+    width: 16px;
+    background: url("../images/wpspin_light.gif") no-repeat;
+    padding: 0;
+    margin: 5px 10px;
+    right: -40px;
+    top: 0;
+    float: left;
 }
 #option-saved {
-  -moz-border-radius: 5px 5px 5px 5px;
-  background: none repeat scroll 0 0 orange;
-  border: 1px solid #CCCCCC;
-  color: #FFFFFF;
-  display: none;
-  font-size: 30px;
-  padding: 50px;
-  position: absolute;
-  left: 50%;
-  z-index: 99;
-  -moz-box-shadow: 0 0 8px rgba(82, 168, 236, 0.5);
-  -webkit-box-shadow: 0 0 8px rgba(82, 168, 236, 0.5);
+    -moz-border-radius: 5px 5px 5px 5px;
+    background: none repeat scroll 0 0 orange;
+    border: 1px solid #cccccc;
+    color: #ffffff;
+    display: none;
+    font-size: 30px;
+    padding: 50px;
+    position: absolute;
+    left: 50%;
+    z-index: 99;
+    -moz-box-shadow: 0 0 8px rgba(82, 168, 236, 0.5);
+    -webkit-box-shadow: 0 0 8px rgba(82, 168, 236, 0.5);
 }
 .wpuf_loading {
-  height: 16px;
-  width: 16px;
-  background: url('../images/wpspin_light.gif') no-repeat;
-  padding: 0 0 0 20px;
-  margin-bottom: 10px;
+    height: 16px;
+    width: 16px;
+    background: url("../images/wpspin_light.gif") no-repeat;
+    padding: 0 0 0 20px;
+    margin-bottom: 10px;
 }
 .wpuf-status-completed {
-  background: url(../images/completed.png);
-  background-size: cover;
-  width: 18px;
-  height: 18px;
-  display: block;
+    background: url(../images/completed.png);
+    background-size: cover;
+    width: 18px;
+    height: 18px;
+    display: block;
 }
 .wpuf-status-processing {
-  background: url(../images/processing.png);
-  background-size: cover;
-  width: 18px;
-  height: 18px;
-  display: block;
+    background: url(../images/processing.png);
+    background-size: cover;
+    width: 18px;
+    height: 18px;
+    display: block;
 }
 .wpuf-footer-help {
-  box-sizing: border-box;
-  width: auto;
-  margin-left: -20px;
-  padding: 100px 0.8rem 2rem 0.8rem;
-  text-align: center;
-  background: white;
+    box-sizing: border-box;
+    width: auto;
+    margin-left: -20px;
+    padding: 100px 0.8rem 2rem 0.8rem;
+    text-align: center;
+    background: white;
 }
 .wpuf-footer-help .wpuf-footer-help-content {
-  border: 1px solid #ddd;
-  border-radius: 30px;
-  padding: 15px 25px;
-  font-size: 15px;
+    border: 1px solid #ddd;
+    border-radius: 30px;
+    padding: 15px 25px;
+    font-size: 15px;
 }
 .wpuf-footer-help-content .dashicons {
-  color: #47c1bf;
-  font-size: 30px;
-  height: 30px;
-  width: 30px;
-  margin-top: -5px;
+    color: #47c1bf;
+    font-size: 30px;
+    height: 30px;
+    width: 30px;
+    margin-top: -5px;
 }
 .wpuf-settings-wrap {
-  display: flex;
-  background: #fff;
-  box-shadow: 0 0 0 1px #c8d7e1, 0 1px 2px #e9eff3;
+    display: flex;
+    background: #fff;
+    box-shadow:
+        0 0 0 1px #c8d7e1,
+        0 1px 2px #e9eff3;
 }
 .wpuf-settings-wrap h2.nav-tab-wrapper {
-  flex: 1;
-  border-bottom: none;
-  padding: 0;
-  background-color: #f1f1f1;
-  border-right: 1px solid #c8d7e1;
+    flex: 1;
+    border-bottom: none;
+    padding: 0;
+    background-color: #f1f1f1;
+    border-right: 1px solid #c8d7e1;
 }
 .wpuf-settings-wrap h2.nav-tab-wrapper a.nav-tab {
-  float: none;
-  display: flex;
-  -webkit-align-items: center;
-  align-items: center;
-  border: none;
-  padding: 14px;
-  border-bottom: 1px solid #c8d7e1;
-  font-weight: 500;
-  font-size: 13px;
-  border-right: 1px solid #c8d7e1;
-  color: #444;
-  text-decoration: none;
-  margin: 0 -1px 0 0;
-  background-color: #f1f1f1;
+    float: none;
+    display: flex;
+    -webkit-align-items: center;
+    align-items: center;
+    border: none;
+    padding: 14px;
+    border-bottom: 1px solid #c8d7e1;
+    font-weight: 500;
+    font-size: 13px;
+    border-right: 1px solid #c8d7e1;
+    color: #444;
+    text-decoration: none;
+    margin: 0 -1px 0 0;
+    background-color: #f1f1f1;
 }
 .wpuf-settings-wrap h2.nav-tab-wrapper a.nav-tab.nav-tab-active {
-  background: #fff;
-  border-right: 1px solid #fff;
+    background: #fff;
+    border-right: 1px solid #fff;
 }
 .wpuf-settings-wrap h2.nav-tab-wrapper a.nav-tab .dashicons {
-  margin-right: 10px;
+    margin-right: 10px;
 }
 .wpuf-settings-wrap h2.nav-tab-wrapper a.nav-tab#wpuf_general-tab .dashicons {
-  color: #9b59b6;
+    color: #9b59b6;
 }
 .wpuf-settings-wrap h2.nav-tab-wrapper a.nav-tab#wpuf_dashboard-tab .dashicons {
-  color: #6c75ff;
+    color: #6c75ff;
 }
 .wpuf-settings-wrap h2.nav-tab-wrapper a.nav-tab#wpuf_profile-tab .dashicons {
-  color: #00aeff;
+    color: #00aeff;
 }
-.wpuf-settings-wrap h2.nav-tab-wrapper a.nav-tab#wpuf_frontend_posting-tab .dashicons {
-  color: #AD1457;
+.wpuf-settings-wrap
+    h2.nav-tab-wrapper
+    a.nav-tab#wpuf_frontend_posting-tab
+    .dashicons {
+    color: #ad1457;
 }
-.wpuf-settings-wrap h2.nav-tab-wrapper a.nav-tab#wpuf_my_account-tab .dashicons {
-  color: #64DD17;
+.wpuf-settings-wrap
+    h2.nav-tab-wrapper
+    a.nav-tab#wpuf_my_account-tab
+    .dashicons {
+    color: #64dd17;
 }
 .wpuf-settings-wrap h2.nav-tab-wrapper a.nav-tab#wpuf_payment-tab .dashicons {
-  color: #e67e22;
+    color: #e67e22;
 }
 .wpuf-settings-wrap h2.nav-tab-wrapper a.nav-tab#wpuf_mails-tab .dashicons {
-  color: #115da7;
+    color: #115da7;
 }
 .wpuf-settings-wrap h2.nav-tab-wrapper a.nav-tab#wpuf_sms-tab .dashicons {
-  color: #00aeff;
+    color: #00aeff;
 }
-.wpuf-settings-wrap h2.nav-tab-wrapper a.nav-tab#wpuf_payment_invoices-tab .dashicons {
-  color: #1abc9d;
+.wpuf-settings-wrap
+    h2.nav-tab-wrapper
+    a.nav-tab#wpuf_payment_invoices-tab
+    .dashicons {
+    color: #1abc9d;
 }
 .wpuf-settings-wrap h2.nav-tab-wrapper a.nav-tab#user_directory-tab .dashicons {
-  color: #e74c3c;
+    color: #e74c3c;
 }
 .wpuf-settings-wrap h2.nav-tab-wrapper a.nav-tab .pro-icon-title {
-  margin-left: auto;
+    margin-left: auto;
 }
 .wpuf-settings-wrap .metabox-holder {
-  flex: 3;
-  margin-bottom: 30px;
-  padding-left: 30px;
-  position: relative;
+    flex: 3;
+    margin-bottom: 30px;
+    padding-left: 30px;
+    position: relative;
 }
 .wpuf-settings-wrap .metabox-holder h2 {
-  border-bottom: 1px solid #c8d7e1;
-  padding-bottom: 15px;
-  margin-top: 14px;
+    border-bottom: 1px solid #c8d7e1;
+    padding-bottom: 15px;
+    margin-top: 14px;
 }
 .wpuf-settings-wrap .metabox-holder .form-table th {
-  padding-left: 0;
+    padding-left: 0;
 }
 .wpuf-settings-wrap .metabox-holder p.submit {
-  margin-left: -10px;
-  border-top: 1px solid #f1f1f1;
-  padding-top: 20px;
-  text-align: right;
-  padding-right: 34px;
+    margin-left: -10px;
+    border-top: 1px solid #f1f1f1;
+    padding-top: 20px;
+    text-align: right;
+    padding-right: 34px;
 }
 .wpuf-settings-wrap .metabox-holder p.submit .button-primary {
-  font-size: 15px;
-  height: 45px;
-  line-height: 100%;
-  padding: 0px 20px;
-  font-weight: normal;
+    font-size: 15px;
+    height: 45px;
+    line-height: 100%;
+    padding: 0px 20px;
+    font-weight: normal;
 }
 /**
  * Profile Edit Page
  */
 #profile-page .wpuf-user-subscription {
-  background-color: #fff;
-  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
-  border: 1px solid #e5e5e5;
-  margin-top: 15px;
+    background-color: #fff;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
+    border: 1px solid #e5e5e5;
+    margin-top: 15px;
 }
 #profile-page .wpuf-user-subscription h3 {
-  border-bottom: 1px solid #eee;
-  padding: 12px 15px;
-  font-size: 16px;
-  margin: 0;
+    border-bottom: 1px solid #eee;
+    padding: 12px 15px;
+    font-size: 16px;
+    margin: 0;
 }
 #profile-page .wpuf-user-subscription .wpuf-pack-dropdown th {
-  padding-left: 15px;
+    padding-left: 15px;
 }
 #profile-page .wpuf-user-subscription .wpuf-sub-actions {
-  padding: 10px;
-  border-top: 1px solid #ddd;
-  background: #f5f5f5;
-  overflow: hidden;
-  display: block;
+    padding: 10px;
+    border-top: 1px solid #ddd;
+    background: #f5f5f5;
+    overflow: hidden;
+    display: block;
 }
 #profile-page .wpuf-user-subscription .wpuf-sub-actions .wpuf-delete-pack-btn {
-  float: right;
+    float: right;
 }
 #profile-page .wpuf-user-subscription .wpuf-sub-summary {
-  background: #f8f8f8;
-  border-bottom: 1px solid #eee;
-  margin-bottom: 10px;
-  display: flex;
-  flex-wrap: wrap;
+    background: #f8f8f8;
+    border-bottom: 1px solid #eee;
+    margin-bottom: 10px;
+    display: flex;
+    flex-wrap: wrap;
 }
 #profile-page .wpuf-user-subscription .wpuf-sub-summary * {
-  box-sizing: border-box;
+    box-sizing: border-box;
 }
 #profile-page .wpuf-user-subscription .wpuf-sub-summary .sub-name,
 #profile-page .wpuf-user-subscription .wpuf-sub-summary .sub-price {
-  width: 50%;
-  padding: 10px 15px;
+    width: 50%;
+    padding: 10px 15px;
 }
 #profile-page .wpuf-user-subscription .wpuf-sub-summary .sub-name span,
 #profile-page .wpuf-user-subscription .wpuf-sub-summary .sub-price span {
-  display: block;
+    display: block;
 }
 #profile-page .wpuf-user-subscription .wpuf-sub-summary .sub-name span.label,
 #profile-page .wpuf-user-subscription .wpuf-sub-summary .sub-price span.label {
-  font-weight: bold;
+    font-weight: bold;
 }
 #profile-page .wpuf-user-subscription .wpuf-sub-summary .sub-name {
-  border-right: 1px solid #eee;
+    border-right: 1px solid #eee;
 }
 #profile-page .wpuf-user-subscription .wpuf-sub-summary .info {
-  flex-basis: 100%;
-  padding: 0 15px;
-  background: #fef5be;
-  border-top: 1px solid #ffe98d;
+    flex-basis: 100%;
+    padding: 0 15px;
+    background: #fef5be;
+    border-top: 1px solid #ffe98d;
 }
 #profile-page .wpuf-user-subscription .wpuf-sub-section {
-  padding: 0 15px;
-  border-bottom: 1px solid #eee;
+    padding: 0 15px;
+    border-bottom: 1px solid #eee;
 }
 #profile-page .wpuf-user-subscription .wpuf-sub-section h4 {
-  font-size: 15px;
+    font-size: 15px;
 }
 #profile-page .wpuf-user-subscription .wpuf-sub-section:last-child {
-  border-bottom: none;
-  padding-bottom: 15px;
+    border-bottom: none;
+    padding-bottom: 15px;
 }
 .wpuf-premium .wp-badge {
-  background: #40ce65 url(../images/wpuf-pro.png) no-repeat;
-  background-size: 100px 90px;
-  background-position: 35px 5px;
+    background: #40ce65 url(../images/wpuf-pro.png) no-repeat;
+    background-size: 100px 90px;
+    background-position: 35px 5px;
 }
 .wpuf-premium .wpuf-upgrade-sticky-footer {
-  position: fixed;
-  bottom: 0;
-  background: #fff;
-  width: calc(100% - 195px);
-  z-index: 9;
-  margin-left: -25px;
-  text-align: center;
-  border: 1px solid #dfdfdf;
-  padding: 20px 0 10px 0;
-  border-bottom: none;
-  display: flex;
-  border-top: 3px solid #FF9800;
+    position: fixed;
+    bottom: 0;
+    background: #fff;
+    width: calc(100% - 195px);
+    z-index: 9;
+    margin-left: -25px;
+    text-align: center;
+    border: 1px solid #dfdfdf;
+    padding: 20px 0 10px 0;
+    border-bottom: none;
+    display: flex;
+    border-top: 3px solid #ff9800;
 }
 .wpuf-premium .wpuf-upgrade-sticky-footer .text-left {
-  width: 70%;
+    width: 70%;
 }
 .wpuf-premium .wpuf-upgrade-sticky-footer .text-left h3 {
-  margin: 0;
+    margin: 0;
 }
 .wpuf-premium .wpuf-upgrade-sticky-footer .text-right {
-  width: 30%;
-  padding-top: 15px;
+    width: 30%;
+    padding-top: 15px;
 }
 .wpuf-premium .wpuf-upgrade-sticky-footer .text-right .button-primary {
-  background: #00aadc;
-  border-color: #0087be;
-  text-shadow: none;
-  padding: 5px 20px;
-  height: auto;
-  margin: 0.3125rem 0;
-  font-size: 16px;
+    background: #00aadc;
+    border-color: #0087be;
+    text-shadow: none;
+    padding: 5px 20px;
+    height: auto;
+    margin: 0.3125rem 0;
+    font-size: 16px;
 }
 .wpuf-premium .wpuf-upgrade-sticky-footer .text-right .button-primary:hover {
-  border-color: #005082;
+    border-color: #005082;
 }
 .wpuf-premium .four-col .col {
-  -webkit-align-self: flex-start;
-  -ms-flex-item-align: start;
-  align-self: flex-start;
-  min-width: 23%;
-  max-width: 23%;
+    -webkit-align-self: flex-start;
+    -ms-flex-item-align: start;
+    align-self: flex-start;
+    min-width: 23%;
+    max-width: 23%;
 }
 .wpuf-premium .feature-section .feature-wrap {
-  background-color: #fafafa;
-  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
-  border: 1px solid #e5e5e5;
+    background-color: #fafafa;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
+    border: 1px solid #e5e5e5;
 }
 .wpuf-premium .feature-section .feature-wrap .feature-details {
-  padding: 0 20px 10px 20px;
+    padding: 0 20px 10px 20px;
 }
 .wpuf-premium .feature-section .feature-wrap .feature-details h3 a {
-  text-decoration: none;
+    text-decoration: none;
 }
 .wpuf-premium .feature-section .feature-wrap .feature-details ul {
-  -moz-column-count: 4;
-  -moz-column-gap: 10px;
-  -webkit-column-count: 4;
-  -webkit-column-gap: 10px;
-  column-count: 4;
-  column-gap: 10px;
-  padding: 0;
-  margin: 0;
-  font-size: 14px;
+    -moz-column-count: 4;
+    -moz-column-gap: 10px;
+    -webkit-column-count: 4;
+    -webkit-column-gap: 10px;
+    column-count: 4;
+    column-gap: 10px;
+    padding: 0;
+    margin: 0;
+    font-size: 14px;
 }
 .wpuf-premium .feature-section .feature-wrap .feature-details ul li {
-  padding-left: 1em;
-  text-indent: -0.7em;
+    padding-left: 1em;
+    text-indent: -0.7em;
 }
 .wpuf-premium .feature-section .feature-wrap .feature-details ul li::before {
-  content: "• ";
-  color: red;
-  /* or whatever color you prefer */
+    content: "• ";
+    color: red;
+    /* or whatever color you prefer */
 }
 .wpuf-premium .feature-section .feature-wrap .feature-image {
-  border-bottom: 1px solid #e5e5e5;
-  margin-bottom: 15px;
+    border-bottom: 1px solid #e5e5e5;
+    margin-bottom: 15px;
 }
 .wpuf-premium .feature-section .feature-wrap .feature-image img {
-  max-width: 100%;
-  width: 100%;
-  height: auto;
-  margin-bottom: 0;
+    max-width: 100%;
+    width: 100%;
+    height: auto;
+    margin-bottom: 0;
 }
 .wpuf-premium .module-wrap {
-  height: 122px;
-  display: flex;
-  flex-wrap: wrap;
-  background-color: #fafafa;
-  margin-bottom: 20px;
-  box-shadow: 0 0 5px 0 #ccc;
+    height: 122px;
+    display: flex;
+    flex-wrap: wrap;
+    background-color: #fafafa;
+    margin-bottom: 20px;
+    box-shadow: 0 0 5px 0 #ccc;
 }
 .wpuf-premium .module-wrap .module-image {
-  width: 25%;
-  margin-right: 4%;
+    width: 25%;
+    margin-right: 4%;
 }
 .wpuf-premium .module-wrap .module-image img {
-  width: 100%;
+    width: 100%;
 }
 .wpuf-premium .module-wrap .module-details {
-  margin: 0;
-  width: 70%;
+    margin: 0;
+    width: 70%;
 }
 .wpuf-premium .module-wrap .module-details h3 {
-  margin: 10px 0 0 0;
+    margin: 10px 0 0 0;
 }
 .wpuf-premium .module-wrap .module-details h3 a {
-  text-decoration: none;
+    text-decoration: none;
 }
 #wpuf_mails table tbody tr.hide {
-  display: none;
+    display: none;
 }
 #wpuf_mails table tbody tr.heading {
-  cursor: pointer;
-  background-color: #f1f1f1;
-  border: 1px solid #c8d7e1;
+    cursor: pointer;
+    background-color: #f1f1f1;
+    border: 1px solid #c8d7e1;
 }
 #wpuf_mails table tbody tr.heading label {
-  font-size: 13px;
-  color: #444;
-  font-weight: 500;
+    font-size: 13px;
+    color: #444;
+    font-weight: 500;
 }
 #wpuf_mails table tbody tr.heading label span {
-  color: #0073aa;
-  padding-right: 6px;
+    color: #0073aa;
+    padding-right: 6px;
 }
 #wpuf_mails table tbody tr.heading label span.dashicons-admin-generic {
-  color: #9b59b6;
+    color: #9b59b6;
 }
 #wpuf_mails table tbody tr.heading label span.dashicons-universal-access-alt {
-  color: #AD1457;
+    color: #ad1457;
 }
 #wpuf_mails table tbody tr.heading label span.dashicons-unlock {
-  color: #9b59b6;
+    color: #9b59b6;
 }
 #wpuf_mails table tbody tr.heading label span.dashicons-email-alt {
-  color: #6c75ff;
+    color: #6c75ff;
 }
 #wpuf_mails table tbody tr.heading label span.dashicons-money {
-  color: #64DD17;
+    color: #64dd17;
 }
 #wpuf_mails table tbody tr.heading label span.dashicons-admin-users {
-  color: #00aeff;
+    color: #00aeff;
 }
 #wpuf_mails table tbody tr.heading label span.dashicons-groups {
-  color: #e67e22;
+    color: #e67e22;
 }
 #wpuf_mails table tbody tr.heading label span.dashicons-dismiss {
-  color: #115da7;
+    color: #115da7;
 }
 #wpuf_mails table tbody tr.heading label span.dashicons-smiley {
-  color: #e74c3c;
+    color: #e74c3c;
 }
 #wpuf_mails table tbody tr.heading th {
-  padding: 16px 10px 16px 30px;
+    padding: 16px 10px 16px 30px;
 }
 #wpuf_mails table tbody tr th {
-  padding-left: 30px;
+    padding-left: 30px;
 }
 tr.wpuf-form-layouts ul {
-  margin: 0;
-  overflow: hidden;
+    margin: 0;
+    overflow: hidden;
 }
 tr.wpuf-form-layouts ul li {
-  margin: 0;
-  padding: 0 15px 15px 0;
-  position: relative;
-  width: 50%;
-  float: left;
+    margin: 0;
+    padding: 0 15px 15px 0;
+    position: relative;
+    width: 50%;
+    float: left;
 }
 tr.wpuf-form-layouts ul li input[type="radio"] {
-  display: none;
+    display: none;
 }
 tr.wpuf-form-layouts ul li img {
-  max-width: 100%;
-  cursor: pointer;
+    max-width: 100%;
+    cursor: pointer;
 }
 tr.wpuf-form-layouts ul li label {
-  font-size: 20px;
-  font-weight: 500;
-  margin-bottom: 20px;
+    font-size: 20px;
+    font-weight: 500;
+    margin-bottom: 20px;
 }
 tr.wpuf-form-layouts ul li:hover {
-  opacity: 0.3;
-  transition: .3s;
+    opacity: 0.3;
+    transition: 0.3s;
 }
 tr.wpuf-form-layouts ul li.active:before {
-  position: absolute;
-  top: 0;
-  right: 15px;
-  width: 40px;
-  height: 40px;
-  font-family: dashicons;
-  font-size: 40px;
-  color: #18d118;
-  content: "\f147";
-  text-align: center;
-  background: inherit;
-  line-height: 40px;
+    position: absolute;
+    top: 0;
+    right: 15px;
+    width: 40px;
+    height: 40px;
+    font-family: dashicons;
+    font-size: 40px;
+    color: #18d118;
+    content: "\f147";
+    text-align: center;
+    background: inherit;
+    line-height: 40px;
 }
-ul.wpuf-form .wpuf-submit input[type=submit] {
-  font-size: 16px;
-  padding: 5px 15px;
-  border: 1px solid #ccc;
-  -webkit-border-radius: 3px;
-  -moz-border-radius: 3px;
-  border-radius: 3px;
-  background: #0085ba;
-  border-color: #0073aa #006799 #006799;
-  -webkit-box-shadow: 0 1px 0 #006799;
-  box-shadow: 0 1px 0 #006799;
-  color: #fff;
-  text-decoration: none;
-  text-shadow: 0 -1px 1px #006799, 1px 0 1px #006799, 0 1px 1px #006799, -1px 0 1px #006799;
+ul.wpuf-form .wpuf-submit input[type="submit"] {
+    font-size: 16px;
+    padding: 5px 15px;
+    border: 1px solid #ccc;
+    -webkit-border-radius: 3px;
+    -moz-border-radius: 3px;
+    border-radius: 3px;
+    background: #0085ba;
+    border-color: #0073aa #006799 #006799;
+    -webkit-box-shadow: 0 1px 0 #006799;
+    box-shadow: 0 1px 0 #006799;
+    color: #fff;
+    text-decoration: none;
+    text-shadow:
+        0 -1px 1px #006799,
+        1px 0 1px #006799,
+        0 1px 1px #006799,
+        -1px 0 1px #006799;
 }
 div#form-preview ul.wpuf-form li.wpuf_hidden_field {
-  display: block;
-  opacity: 0.3;
+    display: block;
+    opacity: 0.3;
 }
 ul.wpuf-form .wpuf-field-columns {
-  padding: 0;
-  border: 0;
-  overflow: hidden;
+    padding: 0;
+    border: 0;
+    overflow: hidden;
 }
-ul.wpuf-form .wpuf-field-columns.has-columns-1 .wpuf-column .wpuf-column-inner-fields {
-  width: 100%;
-  float: left;
+ul.wpuf-form
+    .wpuf-field-columns.has-columns-1
+    .wpuf-column
+    .wpuf-column-inner-fields {
+    width: 100%;
+    float: left;
 }
-ul.wpuf-form .wpuf-field-columns.has-columns-1 .wpuf-column .wpuf-column-inner-fields:nth-child(1) {
-  padding-right: 0!important;
+ul.wpuf-form
+    .wpuf-field-columns.has-columns-1
+    .wpuf-column
+    .wpuf-column-inner-fields:nth-child(1) {
+    padding-right: 0 !important;
 }
-ul.wpuf-form .wpuf-field-columns.has-columns-1 .wpuf-column .column-1 .ui-resizable-handle {
-  display: none !important;
+ul.wpuf-form
+    .wpuf-field-columns.has-columns-1
+    .wpuf-column
+    .column-1
+    .ui-resizable-handle {
+    display: none !important;
 }
-ul.wpuf-form .wpuf-field-columns.has-columns-1 .wpuf-column .column-2.wpuf-column-inner-fields,
-ul.wpuf-form .wpuf-field-columns.has-columns-1 .wpuf-column .column-3.wpuf-column-inner-fields {
-  display: none;
+ul.wpuf-form
+    .wpuf-field-columns.has-columns-1
+    .wpuf-column
+    .column-2.wpuf-column-inner-fields,
+ul.wpuf-form
+    .wpuf-field-columns.has-columns-1
+    .wpuf-column
+    .column-3.wpuf-column-inner-fields {
+    display: none;
 }
-ul.wpuf-form .wpuf-field-columns.has-columns-2 .wpuf-column .wpuf-column-inner-fields {
-  width: 50%;
-  float: left;
+ul.wpuf-form
+    .wpuf-field-columns.has-columns-2
+    .wpuf-column
+    .wpuf-column-inner-fields {
+    width: 50%;
+    float: left;
 }
-ul.wpuf-form .wpuf-field-columns.has-columns-2 .wpuf-column .wpuf-column-inner-fields:nth-child(2) {
-  padding-right: 0!important;
+ul.wpuf-form
+    .wpuf-field-columns.has-columns-2
+    .wpuf-column
+    .wpuf-column-inner-fields:nth-child(2) {
+    padding-right: 0 !important;
 }
-ul.wpuf-form .wpuf-field-columns.has-columns-2 .wpuf-column .column-2 .ui-resizable-handle {
-  display: none !important;
+ul.wpuf-form
+    .wpuf-field-columns.has-columns-2
+    .wpuf-column
+    .column-2
+    .ui-resizable-handle {
+    display: none !important;
 }
-ul.wpuf-form .wpuf-field-columns.has-columns-2 .wpuf-column .column-3.wpuf-column-inner-fields {
-  display: none;
+ul.wpuf-form
+    .wpuf-field-columns.has-columns-2
+    .wpuf-column
+    .column-3.wpuf-column-inner-fields {
+    display: none;
 }
-ul.wpuf-form .wpuf-field-columns.has-columns-3 .wpuf-column .wpuf-column-inner-fields {
-  width: 33.33%;
-  float: left;
+ul.wpuf-form
+    .wpuf-field-columns.has-columns-3
+    .wpuf-column
+    .wpuf-column-inner-fields {
+    width: 33.33%;
+    float: left;
 }
-ul.wpuf-form .wpuf-field-columns.has-columns-3 .wpuf-column .wpuf-column-inner-fields:nth-child(3) {
-  padding-right: 0!important;
+ul.wpuf-form
+    .wpuf-field-columns.has-columns-3
+    .wpuf-column
+    .wpuf-column-inner-fields:nth-child(3) {
+    padding-right: 0 !important;
 }
 ul.wpuf-form .wpuf-field-columns .wpuf-column-field-inner-columns {
-  margin-left: 0;
-  margin-right: 0;
+    margin-left: 0;
+    margin-right: 0;
 }
 ul.wpuf-form .wpuf-field-columns .wpuf-column-field-inner-columns .wpuf-column {
-  padding: 0;
-  border: 0;
-  float: none;
-  width: 100%;
-  display: flex;
+    padding: 0;
+    border: 0;
+    float: none;
+    width: 100%;
+    display: flex;
 }
-ul.wpuf-form .wpuf-field-columns .wpuf-column-field-inner-columns .wpuf-column .wpuf-column-inner-fields {
-  padding: 0 5px 0 0;
-  position: relative;
+ul.wpuf-form
+    .wpuf-field-columns
+    .wpuf-column-field-inner-columns
+    .wpuf-column
+    .wpuf-column-inner-fields {
+    padding: 0 5px 0 0;
+    position: relative;
 }
-ul.wpuf-form .wpuf-field-columns .wpuf-column-field-inner-columns .wpuf-column .wpuf-column-inner-fields ul.wpuf-column-fields-sortable-list {
-  margin: 0;
-  padding: 0 0 50px 0;
+ul.wpuf-form
+    .wpuf-field-columns
+    .wpuf-column-field-inner-columns
+    .wpuf-column
+    .wpuf-column-inner-fields
+    ul.wpuf-column-fields-sortable-list {
+    margin: 0;
+    padding: 0 0 50px 0;
 }
-ul.wpuf-form .wpuf-field-columns .wpuf-column-field-inner-columns .wpuf-column .wpuf-column-inner-fields ul.wpuf-column-fields-sortable-list li.column-field-items.current-editing {
-  background-color: rgba(255, 185, 0, 0.15);
+ul.wpuf-form
+    .wpuf-field-columns
+    .wpuf-column-field-inner-columns
+    .wpuf-column
+    .wpuf-column-inner-fields
+    ul.wpuf-column-fields-sortable-list
+    li.column-field-items.current-editing {
+    background-color: rgba(255, 185, 0, 0.15);
 }
-ul.wpuf-form .wpuf-field-columns .wpuf-column-field-inner-columns .wpuf-column .wpuf-column-inner-fields ul.wpuf-column-fields-sortable-list li.column-field-items:last-child {
-  margin-bottom: 0;
+ul.wpuf-form
+    .wpuf-field-columns
+    .wpuf-column-field-inner-columns
+    .wpuf-column
+    .wpuf-column-inner-fields
+    ul.wpuf-column-fields-sortable-list
+    li.column-field-items:last-child {
+    margin-bottom: 0;
 }
-ul.wpuf-form .wpuf-field-columns .wpuf-column-field-inner-columns .wpuf-column .wpuf-column-inner-fields ul.wpuf-column-fields-sortable-list li.column-field-items:hover .wpuf-column-field-control-buttons {
-  display: block;
+ul.wpuf-form
+    .wpuf-field-columns
+    .wpuf-column-field-inner-columns
+    .wpuf-column
+    .wpuf-column-inner-fields
+    ul.wpuf-column-fields-sortable-list
+    li.column-field-items:hover
+    .wpuf-column-field-control-buttons {
+    display: block;
 }
-ul.wpuf-form .wpuf-field-columns .wpuf-column-field-inner-columns .wpuf-column .wpuf-column-inner-fields ul.wpuf-column-fields-sortable-list li.column-field-items .wpuf-column-field-control-buttons {
-  position: absolute;
-  top: 0;
-  left: 0;
-  z-index: 10;
-  display: none;
-  width: 100%;
-  height: 100%;
-  margin: 0;
-  text-align: center;
-  background: rgba(255, 185, 0, 0.08);
-  border: 1px dashed #ffb900;
+ul.wpuf-form
+    .wpuf-field-columns
+    .wpuf-column-field-inner-columns
+    .wpuf-column
+    .wpuf-column-inner-fields
+    ul.wpuf-column-fields-sortable-list
+    li.column-field-items
+    .wpuf-column-field-control-buttons {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 10;
+    display: none;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    text-align: center;
+    background: rgba(255, 185, 0, 0.08);
+    border: 1px dashed #ffb900;
 }
-ul.wpuf-form .wpuf-field-columns .wpuf-column-field-inner-columns .wpuf-column .wpuf-column-inner-fields ul.wpuf-column-fields-sortable-list li.column-field-items .wpuf-column-field-control-buttons p {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  margin: -10px 0 0 -43px;
-  line-height: 1;
-  color: #eee;
-  background-color: #23282d;
+ul.wpuf-form
+    .wpuf-field-columns
+    .wpuf-column-field-inner-columns
+    .wpuf-column
+    .wpuf-column-inner-fields
+    ul.wpuf-column-fields-sortable-list
+    li.column-field-items
+    .wpuf-column-field-control-buttons
+    p {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    margin: -10px 0 0 -43px;
+    line-height: 1;
+    color: #eee;
+    background-color: #23282d;
 }
-ul.wpuf-form .wpuf-field-columns .wpuf-column-field-inner-columns .wpuf-column .wpuf-column-inner-fields ul.wpuf-column-fields-sortable-list li.column-field-items .wpuf-column-field-control-buttons i {
-  cursor: pointer;
-  padding: 5px;
-  font-size: 10px;
+ul.wpuf-form
+    .wpuf-field-columns
+    .wpuf-column-field-inner-columns
+    .wpuf-column
+    .wpuf-column-inner-fields
+    ul.wpuf-column-fields-sortable-list
+    li.column-field-items
+    .wpuf-column-field-control-buttons
+    i {
+    cursor: pointer;
+    padding: 5px;
+    font-size: 10px;
 }
-ul.wpuf-form .wpuf-field-columns .wpuf-column-field-inner-columns .wpuf-column .wpuf-column-inner-fields ul.wpuf-column-fields-sortable-list li.column-field-items .wpuf-column-field-control-buttons i:hover {
-  background-color: #0073aa;
+ul.wpuf-form
+    .wpuf-field-columns
+    .wpuf-column-field-inner-columns
+    .wpuf-column
+    .wpuf-column-inner-fields
+    ul.wpuf-column-fields-sortable-list
+    li.column-field-items
+    .wpuf-column-field-control-buttons
+    i:hover {
+    background-color: #0073aa;
 }
-ul.wpuf-form .wpuf-field-columns .wpuf-column-field-inner-columns .wpuf-column .wpuf-column-inner-fields ul.wpuf-column-fields-sortable-list li.column-field-items .wpuf-column-field-control-buttons i.move {
-  cursor: move;
+ul.wpuf-form
+    .wpuf-field-columns
+    .wpuf-column-field-inner-columns
+    .wpuf-column
+    .wpuf-column-inner-fields
+    ul.wpuf-column-fields-sortable-list
+    li.column-field-items
+    .wpuf-column-field-control-buttons
+    i.move {
+    cursor: move;
 }
-ul.wpuf-form .wpuf-field-columns .wpuf-column-field-inner-columns .wpuf-column .wpuf-column-inner-fields .drop-message {
-  text-align: center;
-  border: 1px dashed #ffb900;
-  border-top: 0;
-  background: rgba(255, 185, 0, 0.08);
-  margin: 0;
-  padding: 15px 0;
+ul.wpuf-form
+    .wpuf-field-columns
+    .wpuf-column-field-inner-columns
+    .wpuf-column
+    .wpuf-column-inner-fields
+    .drop-message {
+    text-align: center;
+    border: 1px dashed #ffb900;
+    border-top: 0;
+    background: rgba(255, 185, 0, 0.08);
+    margin: 0;
+    padding: 15px 0;
 }
 #form-preview-stage .field-items .wpuf-field-columns + div.control-buttons {
-  top: 10px;
-  z-index: 10;
-  height: auto;
-  margin: 0;
-  background: transparent;
-  border: 0;
+    top: 10px;
+    z-index: 10;
+    height: auto;
+    margin: 0;
+    background: transparent;
+    border: 0;
 }
 .wpuf-setup-menu-link {
-  display: none;
+    display: none;
 }
 tr.pro-preview td {
-  display: inline-block;
-  position: relative;
+    display: inline-block;
+    position: relative;
 }
 .pro-preview-html {
-  position: relative;
+    position: relative;
 }
 tr.pro-preview td:hover .pro-field-overlay,
 .pro-preview-html:hover .pro-field-overlay {
-  -webkit-opacity: 1;
-  opacity: 1;
-  display: block;
+    -webkit-opacity: 1;
+    opacity: 1;
+    display: block;
 }
 tr.pro-preview .pro-field-overlay,
 .pro-preview-html .pro-field-overlay,
 .metabox-holder .pro-field-overlay {
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.4);
-  border-radius: 5px;
-  top: 0;
-  left: 0;
-  display: none;
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.4);
+    border-radius: 5px;
+    top: 0;
+    left: 0;
+    display: none;
 }
 tr.pro-preview-html th {
-  width: 50%;
+    width: 50%;
 }
 .pro-preview-html:hover ~ .pro-field-overlay {
-  display: block;
+    display: block;
 }
 .pro-field-overlay:hover {
-  display: block;
+    display: block;
 }
-.wpuf-subscription-pack-settings nav .tab-current a.wpuf-button.button-upgrade-to-pro,
+.wpuf-subscription-pack-settings
+    nav
+    .tab-current
+    a.wpuf-button.button-upgrade-to-pro,
 a.wpuf-button.button-upgrade-to-pro {
-  padding: 10px 15px;
-  background: #ff9000;
-  color: #fff;
-  min-height: auto;
-  border-radius: 5px;
-  text-decoration: none;
-  border: none;
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  white-space: nowrap;
+    padding: 10px 15px;
+    background: #ff9000;
+    color: #fff;
+    min-height: auto;
+    border-radius: 5px;
+    text-decoration: none;
+    border: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    white-space: nowrap;
 }
 .pro-field-overlay a.wpuf-button.button-upgrade-to-pro {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  -webkit-transform: translate(-50%, -50%);
-  transform: translate(-50%, -50%);
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    -webkit-transform: translate(-50%, -50%);
+    transform: translate(-50%, -50%);
 }
-.wpuf-subscription-pack-settings nav .tab-current a.wpuf-button.button-upgrade-to-pro:hover,
+.wpuf-subscription-pack-settings
+    nav
+    .tab-current
+    a.wpuf-button.button-upgrade-to-pro:hover,
 a.wpuf-button.button-upgrade-to-pro:hover {
-  background: #d07805;
+    background: #d07805;
 }
 span.pro-icon {
-  display: inline-flex;
-  align-items: center;
+    display: inline-flex;
+    align-items: center;
 }
 span.pro-icon svg {
-  height: 1em;
-  margin-left: 5px;
+    height: 1em;
+    margin-left: 5px;
 }
 span.pro-icon.icon-white svg path {
-  fill: #fff;
+    fill: #fff;
 }
 label span.pro-icon svg path {
-  fill: #fB9a28;
+    fill: #fb9a28;
 }
 img.profile-header,
 img.user-listing {
-  display: block;
-  width: 50%;
-  background: #fff;
-  -webkit-box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.1);
-  box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.1);
-  margin: -25px 0 15px 30px;
-  position: relative;
-  line-height: 0;
-  border: 1px solid #ededed;
-  padding: 4px;
-  -webkit-filter: grayscale(100%) opacity(0.3);
-  /* Safari 6.0 - 9.0 */
-  filter: grayscale(100%) opacity(0.3);
+    display: block;
+    width: 50%;
+    background: #fff;
+    -webkit-box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.1);
+    box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.1);
+    margin: -25px 0 15px 30px;
+    position: relative;
+    line-height: 0;
+    border: 1px solid #ededed;
+    padding: 4px;
+    -webkit-filter: grayscale(100%) opacity(0.3);
+    /* Safari 6.0 - 9.0 */
+    filter: grayscale(100%) opacity(0.3);
 }
 img.profile-header:hover,
-input[type=radio]:checked + img.profile-header,
+input[type="radio"]:checked + img.profile-header,
 img.profile-header.active,
 img.user-listing:hover,
-input[type=radio]:checked + img.user-listing,
+input[type="radio"]:checked + img.user-listing,
 img.user-listing.active {
-  -webkit-filter: grayscale(0%) opacity(1) drop-shadow(8px 8px 5px #ccc);
-  /* Safari 6.0 - 9.0 */
-  filter: grayscale(0%) opacity(1) drop-shadow(8px 8px 5px #ccc);
+    -webkit-filter: grayscale(0%) opacity(1) drop-shadow(8px 8px 5px #ccc);
+    /* Safari 6.0 - 9.0 */
+    filter: grayscale(0%) opacity(1) drop-shadow(8px 8px 5px #ccc);
 }
 .wpuf-subscription-pack-settings nav ul .wpuf-pro-field-tooltip,
 .wpuf-pro-field-tooltip {
-  background: #000;
-  width: max-content;
-  padding: 25px 35px 30px 20px;
-  border-radius: 5px;
-  color: #fff;
-  position: absolute;
-  top: 0;
-  left: 50%;
-  -webkit-transform: translate(-50%, -100%);
-  transform: translate(-50%, -100%);
-  -webkit-box-sizing: border-box;
-  box-sizing: border-box;
-  z-index: 99999;
-  display: none;
-  -webkit-opacity: 0;
-  opacity: 0;
-  -webkit-transition: opacity 0.8s;
-  transition: opacity 0.8s;
+    background: #000;
+    width: max-content;
+    padding: 25px 35px 30px 20px;
+    border-radius: 5px;
+    color: #fff;
+    position: absolute;
+    top: 0;
+    left: 50%;
+    -webkit-transform: translate(-50%, -100%);
+    transform: translate(-50%, -100%);
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
+    z-index: 99999;
+    display: none;
+    -webkit-opacity: 0;
+    opacity: 0;
+    -webkit-transition: opacity 0.8s;
+    transition: opacity 0.8s;
 }
 h3.tooltip-header {
-  color: #fff;
-  font-size: 1.3rem;
+    color: #fff;
+    font-size: 1.3rem;
 }
-.wpuf-subscription-pack-settings nav ul .wpuf-pro-field-tooltip ul li span.tooltip-check svg path,
+.wpuf-subscription-pack-settings
+    nav
+    ul
+    .wpuf-pro-field-tooltip
+    ul
+    li
+    span.tooltip-check
+    svg
+    path,
 .wpuf-pro-field-tooltip ul li span.tooltip-check svg path {
-  fill: #139F84;
+    fill: #139f84;
 }
 .wpuf-subscription-pack-settings nav ul .wpuf-pro-field-tooltip ul,
 .wpuf-pro-field-tooltip ul {
-  margin-bottom: 30px;
+    margin-bottom: 30px;
 }
 .wpuf-subscription-pack-settings nav ul .wpuf-pro-field-tooltip ul li,
 .wpuf-pro-field-tooltip ul li {
-  line-height: 1.5rem;
-  font-weight: 400;
-  margin-bottom: 6px;
+    line-height: 1.5rem;
+    font-weight: 400;
+    margin-bottom: 6px;
 }
 span.tooltip-check {
-  margin-right: 10px;
+    margin-right: 10px;
 }
 .wpuf-subscription-pack-settings nav ul .wpuf-pro-field-tooltip .pro-link,
 .wpuf-pro-field-tooltip .pro-link {
-  display: flex;
-  -webkit-justify-content: center;
-  justify-content: center;
-  margin-left: 25px;
+    display: flex;
+    -webkit-justify-content: center;
+    justify-content: center;
+    margin-left: 25px;
 }
 .wpuf-subscription-pack-settings nav ul .wpuf-pro-field-tooltip i,
 .wpuf-pro-field-tooltip i {
-  position: absolute;
-  top: 100%;
-  left: 50%;
-  margin-left: -12px;
-  width: 24px;
-  height: 12px;
-  overflow: hidden;
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    margin-left: -12px;
+    width: 24px;
+    height: 12px;
+    overflow: hidden;
 }
 .wpuf-subscription-pack-settings nav ul .wpuf-pro-field-tooltip i::after,
 .wpuf-pro-field-tooltip i::after {
-  content: '';
-  position: absolute;
-  width: 12px;
-  height: 12px;
-  left: 50%;
-  -webkit-transform: translate(-50%, -50%) rotate(45deg);
-  transform: translate(-50%, -50%) rotate(45deg);
-  background-color: #000;
+    content: "";
+    position: absolute;
+    width: 12px;
+    height: 12px;
+    left: 50%;
+    -webkit-transform: translate(-50%, -50%) rotate(45deg);
+    transform: translate(-50%, -50%) rotate(45deg);
+    background-color: #000;
 }
 tr.pro-preview.wpuf-subscription-recurring {
-  position: relative;
+    position: relative;
 }
 tr.pro-preview.wpuf-subscription-recurring td {
-  position: initial;
+    position: initial;
 }
 tr.pro-preview span.pro-icon,
 tr span.pro-icon-title {
-  position: relative;
-  padding-top: 10px;
+    position: relative;
+    padding-top: 10px;
 }
 a span.pro-icon-title {
-  position: relative;
+    position: relative;
 }
 a span.pro-icon-title .wpuf-pro-field-tooltip {
-  left: 185px;
+    left: 185px;
 }
 span.pro-icon-title:hover .wpuf-pro-field-tooltip {
-  display: block;
-  -webkit-opacity: 1;
-  opacity: 1;
+    display: block;
+    -webkit-opacity: 1;
+    opacity: 1;
 }
 span.pro-icon:hover .wpuf-pro-field-tooltip {
-  display: block;
-  -webkit-opacity: 1;
-  opacity: 1;
+    display: block;
+    -webkit-opacity: 1;
+    opacity: 1;
 }
 .wpuf-xmp-tag {
-  display: inline;
+    display: inline;
 }
 #wpuf-search-section {
-  display: flex;
-  position: relative;
-  align-items: center;
-  color: red;
-  cursor: pointer;
-  justify-content: space-between;
-  border-bottom: 1px solid #c8d7e1;
-  height: 46px;
+    display: flex;
+    position: relative;
+    align-items: center;
+    color: red;
+    cursor: pointer;
+    justify-content: space-between;
+    border-bottom: 1px solid #c8d7e1;
+    height: 46px;
 }
 #wpuf-settings-search {
-  width: 100%;
-  height: 100%;
-  background: #f1f1f1;
-  border: 0;
-  border-radius: 0;
-  margin: 0;
-  line-height: 20px;
-  font-weight: 400;
-  padding: 0 15px;
+    width: 100%;
+    height: 100%;
+    background: #f1f1f1;
+    border: 0;
+    border-radius: 0;
+    margin: 0;
+    line-height: 20px;
+    font-weight: 400;
+    padding: 0 15px;
 }
 #wpuf-search-section .dashicons-no-alt {
-  display: none;
-  position: absolute;
-  right: 5px;
+    display: none;
+    position: absolute;
+    right: 5px;
 }
 .headway-header {
-  display: flex;
-  justify-content: space-between;
+    display: flex;
+    justify-content: space-between;
 }
 .headway-header ul {
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  margin: 10px 0;
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    margin: 10px 0;
 }
 .headway-header ul li.headway-icon {
-  background: #eea6d0;
-  margin-right: 1rem;
-  border-radius: 20px;
-  width: 10px;
-  height: 10px;
-  position: relative;
-  margin-top: 2px;
+    background: #eea6d0;
+    margin-right: 1rem;
+    border-radius: 20px;
+    width: 10px;
+    height: 10px;
+    position: relative;
+    margin-top: 2px;
 }
 .headway-header ul li.headway-icon:hover {
-  background: #ee62b4;
+    background: #ee62b4;
 }
 .headway-header ul li.headway-icon span#HW_badge_cont {
-  position: absolute;
-  top: -6px;
-  left: -6px;
+    position: absolute;
+    top: -6px;
+    left: -6px;
 }
 .headway-header ul li a {
-  font-size: 1rem;
-  text-decoration: none;
+    font-size: 1rem;
+    text-decoration: none;
 }
 .headway-header ul li a:hover {
-  text-decoration: underline;
+    text-decoration: underline;
 }
 .wrap h2.with-headway-icon,
 .wrap h2.with-headway-icon,
 .wrap h2.with-headway-icon {
-  display: flex;
-  justify-content: space-between;
+    display: flex;
+    justify-content: space-between;
 }
 .wrap h2.with-headway-icon .flex-end,
 .wrap h2.with-headway-icon .flex-end,
 .wrap h2.with-headway-icon .flex-end {
-  display: flex;
-  align-items: center;
+    display: flex;
+    align-items: center;
 }
 .wrap h2.with-headway-icon .flex-end .HW_badge.HW_softHidden,
 .wrap h2.with-headway-icon .flex-end .HW_badge.HW_softHidden,
 .wrap h2.with-headway-icon .flex-end .HW_badge.HW_softHidden {
-  background: #eea6d0 !important;
+    background: #eea6d0 !important;
 }
-.wrap h2.with-headway-icon .flex-end .flex-end .headway-icon:hover .HW_badge.HW_softHidden,
-.wrap h2.with-headway-icon .flex-end .flex-end .headway-icon:hover .HW_badge.HW_softHidden,
-.wrap h2.with-headway-icon .flex-end .flex-end .headway-icon:hover .HW_badge.HW_softHidden {
-  background: #ee62b4 !important;
+.wrap
+    h2.with-headway-icon
+    .flex-end
+    .flex-end
+    .headway-icon:hover
+    .HW_badge.HW_softHidden,
+.wrap
+    h2.with-headway-icon
+    .flex-end
+    .flex-end
+    .headway-icon:hover
+    .HW_badge.HW_softHidden,
+.wrap
+    h2.with-headway-icon
+    .flex-end
+    .flex-end
+    .headway-icon:hover
+    .HW_badge.HW_softHidden {
+    background: #ee62b4 !important;
 }
 .wrap h2.with-headway-icon .flex-end a.canny-link,
 .wrap h2.with-headway-icon .flex-end a.canny-link,
 .wrap h2.with-headway-icon .flex-end a.canny-link {
-  font-size: 1rem;
-  text-decoration: none;
+    font-size: 1rem;
+    text-decoration: none;
 }
 .wrap h2.with-headway-icon .flex-end a.canny-link:hover,
 .wrap h2.with-headway-icon .flex-end a.canny-link:hover,
 .wrap h2.with-headway-icon .flex-end a.canny-link:hover {
-  text-decoration: underline;
+    text-decoration: underline;
 }
 .wrap h2.with-headway-icon #HW_frame_cont,
 .wrap h2.with-headway-icon #HW_frame_cont,
 .wrap h2.with-headway-icon #HW_frame_cont {
-  top: 78px !important;
+    top: 78px !important;
 }
 .wpuf-toggle-switch {
-  position: relative;
-  display: inline-block;
-  width: 50px;
-  height: 26px;
+    position: relative;
+    display: inline-block;
+    width: 50px;
+    height: 26px;
 }
 .wpuf-toggle-switch input {
-  display: none;
+    display: none;
 }
 .wpuf-toggle-switch input:checked + .slider {
-  background-color: #0073aa;
+    background-color: #0073aa;
 }
 .wpuf-toggle-switch input:focus + .slider {
-  box-shadow: 0 0 1px #2196F3;
+    box-shadow: 0 0 1px #2196f3;
 }
 .wpuf-toggle-switch input:checked + .slider:before {
-  transform: translateX(26px);
+    transform: translateX(26px);
 }
 .wpuf-toggle-switch .slider {
-  position: absolute;
-  cursor: pointer;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: #ccc;
-  transition: .2s;
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    transition: 0.2s;
 }
 .wpuf-toggle-switch .slider.round {
-  border-radius: 34px;
+    border-radius: 34px;
 }
 .wpuf-toggle-switch .slider.round:before {
-  border-radius: 50%;
+    border-radius: 50%;
 }
 .wpuf-toggle-switch .slider::before {
-  position: absolute;
-  content: "";
-  height: 18px;
-  width: 18px;
-  left: 3px;
-  bottom: 4px;
-  background-color: white;
-  transition: .2s;
+    position: absolute;
+    content: "";
+    height: 18px;
+    width: 18px;
+    left: 3px;
+    bottom: 4px;
+    background-color: white;
+    transition: 0.2s;
 }
 @media only screen and (max-width: 1399px) {
-  a.wpuf-button.button-upgrade-to-pro {
-    padding: 10px;
-  }
+    a.wpuf-button.button-upgrade-to-pro {
+        padding: 10px;
+    }
 }
 .plugin-card .desc > p,
 .plugin-card .name {
-  margin-left: 148px !important;
+    margin-left: 148px !important;
 }
 .wpuf-help-tabbed {
-  display: flex;
-  width: 100%;
-  margin-top: 20px;
-  box-shadow: 0 0 0 1px #c8d7e1, 0 1px 2px #e9eff3;
+    display: flex;
+    width: 100%;
+    margin-top: 20px;
+    box-shadow:
+        0 0 0 1px #c8d7e1,
+        0 1px 2px #e9eff3;
 }
 .wpuf-help-tabbed nav {
-  order: 1;
-  background-color: #f1f1f1;
-  flex-basis: auto;
-  padding: 0;
-  min-height: 405px;
-  border-right: 1px solid #c8d7e1;
-  min-width: 250px;
+    order: 1;
+    background-color: #f1f1f1;
+    flex-basis: auto;
+    padding: 0;
+    min-height: 405px;
+    border-right: 1px solid #c8d7e1;
+    min-width: 250px;
 }
 .wpuf-help-tabbed nav ul,
 .wpuf-help-tabbed nav li {
-  margin: 0;
+    margin: 0;
 }
 .wpuf-help-tabbed nav a {
-  display: block;
-  border: none;
-  padding: 0.5rem;
-  border-bottom: 1px solid #c8d7e1;
-  border-right: 1px solid #c8d7e1;
-  background-color: #f1f1f1;
-  color: #444;
-  text-decoration: none;
-  margin-right: -1px;
-  font-weight: 500;
+    display: block;
+    border: none;
+    padding: 0.5rem;
+    border-bottom: 1px solid #c8d7e1;
+    border-right: 1px solid #c8d7e1;
+    background-color: #f1f1f1;
+    color: #444;
+    text-decoration: none;
+    margin-right: -1px;
+    font-weight: 500;
 }
 .wpuf-help-tabbed nav a label {
-  padding: 0.5rem;
-  display: inline-block;
+    padding: 0.5rem;
+    display: inline-block;
 }
 .wpuf-help-tabbed nav a:focus,
 .wpuf-help-tabbed nav a:active {
-  outline: 0;
-  box-shadow: none;
+    outline: 0;
+    box-shadow: none;
 }
 .wpuf-help-tabbed nav .dashicons {
-  padding: 8px 0 0 5px;
+    padding: 8px 0 0 5px;
 }
 .wpuf-help-tabbed nav .dashicons.dashicons-admin-home {
-  color: #9b59b6;
+    color: #9b59b6;
 }
 .wpuf-help-tabbed nav .dashicons.dashicons-media-text {
-  color: #6c75ff;
+    color: #6c75ff;
 }
 .wpuf-help-tabbed nav .dashicons.dashicons-dashboard {
-  color: #00aeff;
+    color: #00aeff;
 }
 .wpuf-help-tabbed nav .dashicons.dashicons-admin-users {
-  color: #e67e22;
+    color: #e67e22;
 }
 .wpuf-help-tabbed nav .dashicons.dashicons-lock {
-  color: #3d566e;
+    color: #3d566e;
 }
 .wpuf-help-tabbed nav .dashicons.dashicons-edit {
-  color: #1abc9d;
+    color: #1abc9d;
 }
 .wpuf-help-tabbed nav .dashicons.dashicons-cart {
-  color: #e74c3c;
+    color: #e74c3c;
 }
 .wpuf-help-tabbed nav .dashicons.dashicons-unlock {
-  color: #00aeff;
+    color: #00aeff;
 }
 .wpuf-help-tabbed nav .tab-current a {
-  border-right: 1px solid #fff;
-  background: #fff;
-  color: #2e4453;
+    border-right: 1px solid #fff;
+    background: #fff;
+    color: #2e4453;
 }
 .wpuf-help-tabbed .nav-content {
-  order: 1;
-  background-color: #fff;
-  padding: 2rem;
-  width: 100%;
+    order: 1;
+    background-color: #fff;
+    padding: 2rem;
+    width: 100%;
 }
 .wpuf-help-tabbed .nav-content h2 {
-  margin-top: 30px;
-  color: #23282d;
-  line-height: 1.6;
-  margin-bottom: 0;
-  padding-bottom: 0;
+    margin-top: 30px;
+    color: #23282d;
+    line-height: 1.6;
+    margin-bottom: 0;
+    padding-bottom: 0;
 }
 .wpuf-help-tabbed .nav-content h2:first-child {
-  margin-top: 0;
+    margin-top: 0;
 }
 .wpuf-help-tabbed .nav-content section {
-  display: none;
-  color: #444;
-  font-size: 0.875rem;
+    display: none;
+    color: #444;
+    font-size: 0.875rem;
 }
 .wpuf-help-tabbed .nav-content section p {
-  font-size: 0.875rem;
+    font-size: 0.875rem;
 }
 .wpuf-help-tabbed .nav-content section.content-current {
-  display: block;
+    display: block;
 }
 .wpuf-help-tabbed .nav-content section ul {
-  list-style-type: disc;
-  padding-left: 40px;
+    list-style-type: disc;
+    padding-left: 40px;
 }
 .wpuf-help-tabbed .nav-content section ul.related-articles {
-  list-style: none;
-  padding-left: 10px;
+    list-style: none;
+    padding-left: 10px;
 }
 .wpuf-help-tabbed .nav-content section .button-primary {
-  background: #00aadc;
-  border-color: #0087be;
-  text-shadow: none;
-  padding: 3px 20px;
-  height: auto;
-  margin: 0.3125rem 0;
+    background: #00aadc;
+    border-color: #0087be;
+    text-shadow: none;
+    padding: 3px 20px;
+    height: auto;
+    margin: 0.3125rem 0;
 }
 .wpuf-help-tabbed .nav-content section .button-primary:hover {
-  border-color: #005082;
+    border-color: #005082;
 }
 .wpuf-help-page .wpuf-subscribe-box {
-  display: flex;
-  justify-content: space-between;
-  border: 1px solid #e5e5e5;
-  background: #fff;
-  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
-  margin-top: 15px;
+    display: flex;
+    justify-content: space-between;
+    border: 1px solid #e5e5e5;
+    background: #fff;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
+    margin-top: 15px;
 }
 .wpuf-help-page .wpuf-subscribe-box .wpuf-text-wrap {
-  padding: 10px 15px;
-  width: 60%;
+    padding: 10px 15px;
+    width: 60%;
 }
 .wpuf-help-page .wpuf-subscribe-box .wpuf-text-wrap h3 {
-  color: #ff5722;
-  margin: 4px 0 0 0;
+    color: #ff5722;
+    margin: 4px 0 0 0;
 }
 .wpuf-help-page .wpuf-subscribe-box .wpuf-form-wrap {
-  background: #f7f7f7;
-  padding: 10px 15px;
-  width: 40%;
-  border-left: 1px solid #eee;
+    background: #f7f7f7;
+    padding: 10px 15px;
+    width: 40%;
+    border-left: 1px solid #eee;
 }
 .wpuf-help-page .wpuf-subscribe-box .wpuf-form-wrap label {
-  color: #666;
+    color: #666;
 }
 .wpuf-help-page .wpuf-subscribe-box .wpuf-form-wrap form {
-  display: flex;
-  align-items: flex-end;
+    display: flex;
+    align-items: flex-end;
 }
 .wpuf-help-page .wpuf-subscribe-box .wpuf-form-wrap form input {
-  margin-right: 15px;
+    margin-right: 15px;
 }
 .wpuf-help-page .help-blocks {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  margin-top: 30px;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    margin-top: 30px;
 }
 .wpuf-help-page .help-blocks .help-block {
-  flex: 1;
-  align-self: flex-start;
-  min-width: 25%;
-  max-width: 30%;
-  border: 1px solid #ddd;
-  margin-right: 2%;
-  margin-bottom: 25px;
-  border-radius: 3px;
-  padding: 25px 15px;
-  text-align: center;
-  background: #fff;
+    flex: 1;
+    align-self: flex-start;
+    min-width: 25%;
+    max-width: 30%;
+    border: 1px solid #ddd;
+    margin-right: 2%;
+    margin-bottom: 25px;
+    border-radius: 3px;
+    padding: 25px 15px;
+    text-align: center;
+    background: #fff;
 }
 .wpuf-help-page .help-blocks .help-block img {
-  max-height: 44px;
+    max-height: 44px;
 }
 .wpuf-help-page .wpuf-help-questions ul {
-  margin: 5px 0;
+    margin: 5px 0;
 }
 .wpuf-help-page .wpuf-help-questions li {
-  padding: 10px 5px;
-  margin: 0;
-  display: block;
-  border-bottom: 1px solid #eee;
+    padding: 10px 5px;
+    margin: 0;
+    display: block;
+    border-bottom: 1px solid #eee;
 }
 .wpuf-help-page .wpuf-help-questions li:hover {
-  background-color: #F5F5F5;
+    background-color: #f5f5f5;
 }
 .wpuf-help-page .wpuf-help-questions li:last-child {
-  border-bottom: none;
+    border-bottom: none;
 }
 .wpuf-help-page .wpuf-help-questions li .dashicons {
-  color: #ccc;
-  margin-top: -3px;
+    color: #ccc;
+    margin-top: -3px;
 }
 .wpuf-help-page .wpuf-help-questions li .dashicons-media-text {
-  padding-left: 8px;
+    padding-left: 8px;
 }
 .wpuf-help-page .wpuf-help-questions li .dashicons-arrow-right-alt2 {
-  float: right;
+    float: right;
 }
 .notice.wpuf-whats-new-notice {
-  display: flex;
-  position: relative;
-  padding: 0;
-  height: 65px;
+    display: flex;
+    position: relative;
+    padding: 0;
+    height: 65px;
 }
 .notice.wpuf-whats-new-notice .wpuf-whats-new-icon {
-  width: 75px;
-  height: 65px;
-  overflow: hidden;
+    width: 75px;
+    height: 65px;
+    overflow: hidden;
 }
 .notice.wpuf-whats-new-notice .wpuf-whats-new-icon img {
-  max-width: 65px;
+    max-width: 65px;
 }
 .notice.wpuf-whats-new-notice .wpuf-whats-new-text {
-  width: calc(100% - 240px);
+    width: calc(100% - 240px);
 }
 .notice.wpuf-whats-new-notice .wpuf-whats-new-actions {
-  width: 165px;
+    width: 165px;
 }
 .notice.wpuf-whats-new-notice .wpuf-whats-new-actions a {
-  display: inline-block;
-  margin-top: 20px;
+    display: inline-block;
+    margin-top: 20px;
 }
 .wpuf-whats-new .error,
 .wpuf-whats-new .udpated,
 .wpuf-whats-new .info,
 .wpuf-whats-new .notice {
-  display: none;
+    display: none;
 }
 .wpuf-whats-new h1 {
-  text-align: center;
-  margin-top: 20px;
-  font-size: 30px;
+    text-align: center;
+    margin-top: 20px;
+    font-size: 30px;
 }
 .wpuf-whats-new .wedevs-changelog {
-  display: flex;
-  max-width: 920px;
-  border: 1px solid #e5e5e5;
-  padding: 12px 20px 20px 20px;
-  margin: 20px auto;
-  background: #fff;
-  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
+    display: flex;
+    max-width: 920px;
+    border: 1px solid #e5e5e5;
+    padding: 12px 20px 20px 20px;
+    margin: 20px auto;
+    background: #fff;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
 }
 .wpuf-whats-new .wedevs-changelog .wedevs-changelog-version {
-  width: 360px;
+    width: 360px;
 }
 .wpuf-whats-new .wedevs-changelog .wedevs-changelog-version .released {
-  font-style: italic;
+    font-style: italic;
 }
 .wpuf-whats-new .wedevs-changelog .wedevs-changelog-history {
-  width: 100%;
-  font-size: 14px;
+    width: 100%;
+    font-size: 14px;
 }
 .wpuf-whats-new .wedevs-changelog .wedevs-changelog-history li {
-  margin-bottom: 20px;
+    margin-bottom: 20px;
 }
 .wpuf-whats-new .wedevs-changelog .wedevs-changelog-history h4 {
-  margin: 0 0 10px 0;
-  font-size: 1.3em;
-  line-height: 26px;
+    margin: 0 0 10px 0;
+    font-size: 1.3em;
+    line-height: 26px;
 }
 .wpuf-whats-new .wedevs-changelog .wedevs-changelog-history p {
-  font-size: 14px;
-  line-height: 1.5;
+    font-size: 14px;
+    line-height: 1.5;
 }
 .wpuf-whats-new .wedevs-changelog .wedevs-changelog-history img {
-  margin-top: 30px;
-  max-width: 100%;
+    margin-top: 30px;
+    max-width: 100%;
 }
 .wpuf-whats-new .wedevs-changelog .wedevs-changelog-history span.label {
-  margin-left: 10px;
-  position: relative;
-  color: #fff;
-  border-radius: 20px;
-  padding: 0 8px;
-  font-size: 12px;
-  height: 20px;
-  line-height: 19px;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-  font-weight: normal;
+    margin-left: 10px;
+    position: relative;
+    color: #fff;
+    border-radius: 20px;
+    padding: 0 8px;
+    font-size: 12px;
+    height: 20px;
+    line-height: 19px;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    font-weight: normal;
 }
 .wpuf-whats-new .wedevs-changelog .wedevs-changelog-history span.label.new {
-  background: #3778ff;
-  border: 1px solid #3778ff;
+    background: #3778ff;
+    border: 1px solid #3778ff;
 }
-.wpuf-whats-new .wedevs-changelog .wedevs-changelog-history span.label.improvement,
-.wpuf-whats-new .wedevs-changelog .wedevs-changelog-history span.label.enhancement {
-  background: #3aaa55;
-  border: 1px solid #3aaa a;
+.wpuf-whats-new
+    .wedevs-changelog
+    .wedevs-changelog-history
+    span.label.improvement,
+.wpuf-whats-new
+    .wedevs-changelog
+    .wedevs-changelog-history
+    span.label.enhancement {
+    background: #3aaa55;
+    border: 1px solid #3aaa a;
 }
 .wpuf-whats-new .wedevs-changelog .wedevs-changelog-history span.label.fix {
-  background: #ff4772;
-  border: 1px solid #ff4772;
+    background: #ff4772;
+    border: 1px solid #ff4772;
 }
 .wpuf-whats-new .wedevs-changelog .wedevs-changelog-history span.label.tweak {
-  background: #f9a825;
-  border: 1px solid #ffa000;
+    background: #f9a825;
+    border: 1px solid #ffa000;
 }
 #wpuf_subs_metabox .inside {
-  margin: 0;
-  padding: 0;
+    margin: 0;
+    padding: 0;
 }
 .wpuf-subscription-pack-settings {
-  display: flex;
+    display: flex;
 }
 .wpuf-subscription-pack-settings nav {
-  background-color: #f1f1f1;
-  min-width: max-content;
-  border-right: 1px solid #e5e5e5;
+    background-color: #f1f1f1;
+    min-width: max-content;
+    border-right: 1px solid #e5e5e5;
 }
 .wpuf-subscription-pack-settings nav ul,
 .wpuf-subscription-pack-settings nav li {
-  margin: 0;
+    margin: 0;
 }
 .wpuf-subscription-pack-settings nav a {
-  display: block;
-  border: none;
-  padding: 12px 5px 12px 15px;
-  border-bottom: 1px solid #e5e5e5;
-  border-right: 1px solid #e5e5e5;
-  background-color: #f1f1f1;
-  text-decoration: none;
-  margin-right: -1px;
-  font-weight: 500;
+    display: block;
+    border: none;
+    padding: 12px 5px 12px 15px;
+    border-bottom: 1px solid #e5e5e5;
+    border-right: 1px solid #e5e5e5;
+    background-color: #f1f1f1;
+    text-decoration: none;
+    margin-right: -1px;
+    font-weight: 500;
 }
 .wpuf-subscription-pack-settings nav a label {
-  padding: 0.5rem;
-  display: inline-block;
+    padding: 0.5rem;
+    display: inline-block;
 }
 .wpuf-subscription-pack-settings nav a:focus,
 .wpuf-subscription-pack-settings nav a:active {
-  outline: 0;
-  box-shadow: none;
+    outline: 0;
+    box-shadow: none;
 }
 .wpuf-subscription-pack-settings nav .tab-current a {
-  border-right: 1px solid #fff;
-  background: #fff;
-  color: #2e4453;
+    border-right: 1px solid #fff;
+    background: #fff;
+    color: #2e4453;
 }
 .wpuf-subscription-pack-settings .subscription-nav-content {
-  padding: 15px 25px;
-  width: 100%;
+    padding: 15px 25px;
+    width: 100%;
 }
 .wpuf-subscription-pack-settings .subscription-nav-content section {
-  display: none;
+    display: none;
 }
-.wpuf-subscription-pack-settings .subscription-nav-content section.content-current {
-  display: block;
+
+/* Hide WordPress default footer on WP User Frontend pages */
+body.toplevel_page_wp-user-frontend #wpfooter,
+body.user-frontend_page_wpuf-post-forms #wpfooter,
+body.post-type-wpuf_forms #wpfooter,
+body[class*="wpuf"] #wpfooter,
+body[class*="wp-user-frontend"] #wpfooter {
+    display: none !important;
 }
-.wpuf-subscription-pack-settings .subscription-nav-content section .form-table th {
-  width: 150px;
-  min-width: 150px;
-}
-.wpuf-subscription-pack-settings .subscription-nav-content section .form-table td {
-  padding: 15px 0;
+
+#wpbody-content {
+    padding-bottom: unset !important;
 }

--- a/assets/less/admin.less
+++ b/assets/less/admin.less
@@ -1238,6 +1238,18 @@ span.pro-icon:hover .wpuf-pro-field-tooltip {
     margin-left: 148px !important;
 }
 
+/* Hide WordPress default footer on WP User Frontend pages */
+body.toplevel_page_wp-user-frontend #wpfooter,
+body.user-frontend_page_wpuf-post-forms #wpfooter,
+body.post-type-wpuf_forms #wpfooter,
+body[class*="wpuf"] #wpfooter,
+body[class*="wp-user-frontend"] #wpfooter {
+    display: none !important;
+}
+
+#wpbody-content {
+    padding-bottom: unset !important;
+}
 @import "help.less";
 @import "whats-new.less";
 @import "metabox-tabs.less";


### PR DESCRIPTION
Close #[issue](https://github.com/weDevsOfficial/wpuf-pro/issues/873)


**Final Implementation:** Added CSS rules to hide only the WordPress admin footer (#wpfooter) on WP User Frontend admin pages.

**CSS Rule Added:
What This Accomplishes:**
Removes WordPress Admin Footer: Hides the default WordPress footer that typically displays "Thank you for creating with WordPress" and version information.

Targets Specific Pages: Only affects WP User Frontend related admin pages:

**Main WP User Frontend admin page**
Post forms management page
Individual form editing pages
Any page with "wpuf" or "wp-user-frontend" in the body class
Preserves Functionality: Keeps all form lists, content, and functionality intact while only removing the footer branding.

Clean Interface: Provides a cleaner, more focused admin interface for WP User Frontend without WordPress branding at the bottom.
![image](https://github.com/user-attachments/assets/1b0b9dab-5dd3-4e43-b488-2051f6321da8)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The WordPress admin footer is now hidden on all WP User Frontend-related admin pages for a cleaner interface.
  * Adjusted page layout by unsetting bottom padding on relevant admin pages.

* **Style**
  * Improved consistency in CSS formatting and spacing for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->