### PR TITLE
Fix: Disable Update Post Notification in free version

### DIFF
--- a/admin/form-builder/views/post-form-settings.php
+++ b/admin/form-builder/views/post-form-settings.php
@@ -313,6 +313,8 @@ function wpuf_render_settings_field( $field_key, $field, $form_settings, $post_t
     $value = ! empty( $field['default'] ) ? $field['default'] : '';
     $value = ! empty( $field['value'] ) ? $field['value'] : $value;                           // default value
 
+    $is_pro_preview = ! empty( $field['pro_preview'] ) || ( ! wpuf_is_pro_active() && in_array( $field_key, [ 'notification_edit', 'notification_edit_to', 'notification_edit_subject', 'notification_edit_body' ] ) );
+
     // replace default value if already saved in DB
     if ( ! empty( $field['name'] ) ) {
         preg_match('/wpuf_settings\[(.*?)\]\[(.*?)\]/', $field['name'], $matches);
@@ -327,7 +329,9 @@ function wpuf_render_settings_field( $field_key, $field, $form_settings, $post_t
     }
 
     // if the field is a pro fields preview, no need to load fields from db
-    if ( empty( $field['pro_preview'] ) ) {
+    if ( $is_pro_preview ) {
+        $value = ! empty( $field['value'] ) ? $field['value'] : $value;
+    } else {
         $value = isset( $form_settings[ $field_key ] ) ? $form_settings[ $field_key ] : $value;   // checking with isset because saved value can be empty string
     }
 
@@ -342,8 +346,9 @@ function wpuf_render_settings_field( $field_key, $field, $form_settings, $post_t
                     <input
                         :class="[setting_class_names('checkbox'), '!wpuf-mr-2']"
                         type="checkbox"
-                        name="<?php echo $name; ?>"
+                        name="<?php echo $is_pro_preview ? '' : $name; ?>"
                         <?php echo esc_attr( checked( $value, 'on', false ) ); ?>
+                        <?php echo $is_pro_preview ? 'disabled' : ''; ?>
                         id="<?php echo $field_key; ?>"/>
                 <?php } ?>
                 <?php
@@ -373,15 +378,22 @@ function wpuf_render_settings_field( $field_key, $field, $form_settings, $post_t
                     echo '</div>';
                 }
                 ?>
-                <?php if ( 'toggle' === $field['type'] ) { ?>
+                <?php if ( 'toggle' === $field['type'] ) { 
+                    // For pro preview notification fields, always show as 'off' (unchecked)
+                    $toggle_value = $value;
+                    if ( $is_pro_preview && strpos( $field_key, 'notification_' ) === 0 ) {
+                        $toggle_value = 'off';
+                    }
+                ?>
                     <label
                         for="<?php echo $field_key; ?>"
                         class="wpuf-relative wpuf-inline-flex wpuf-items-center wpuf-cursor-pointer wpuf-ml-2">
                         <input
                             type="checkbox"
                             id="<?php echo $field_key; ?>"
-                            name="<?php echo $name; ?>"
-                            <?php echo esc_attr( checked( $value, 'on', false ) ); ?>
+                            name="<?php echo $is_pro_preview ? '' : $name; ?>"
+                            <?php echo esc_attr( checked( $toggle_value, 'on', false ) ); ?>
+                            <?php echo $is_pro_preview ? 'disabled' : ''; ?>
                             class="wpuf-sr-only wpuf-peer">
                         <span class="wpuf-flex wpuf-items-center wpuf-w-10 wpuf-h-4 wpuf-bg-gray-300 wpuf-rounded-full wpuf-peer peer-checked:wpuf-bg-primary after:wpuf-w-6 after:wpuf-h-6 after:wpuf-bg-white after:wpuf-rounded-full after:wpuf-shadow-md after:wpuf-duration-300 peer-checked:after:wpuf-translate-x-4 after:wpuf-border after:wpuf-border-solid after:wpuf-border-gray-50"></span>
                     </label>
@@ -458,8 +470,9 @@ function wpuf_render_settings_field( $field_key, $field, $form_settings, $post_t
                 <input
                     :class="setting_class_names('text')"
                     type="<?php echo $field['type']; ?>"
-                    name="<?php echo $name; ?>"
+                    name="<?php echo $is_pro_preview ? '' : $name; ?>"
                     <?php echo ! empty( $field['placeholder'] ) ? 'placeholder=' . $field['placeholder'] : ''; ?>
+                    <?php echo $is_pro_preview ? 'disabled' : ''; ?>
                     id="<?php echo $field_key; ?>"
                     value="<?php echo $value; ?>"/>
             <?php } ?>
@@ -470,7 +483,8 @@ function wpuf_render_settings_field( $field_key, $field, $form_settings, $post_t
                 <textarea
                     :class="setting_class_names('textarea')"
                     rows="6"
-                    name="<?php echo $name; ?>"
+                    name="<?php echo $is_pro_preview ? '' : $name; ?>"
+                    <?php echo $is_pro_preview ? 'disabled' : ''; ?>
                     id="<?php echo $field_key; ?>"><?php echo $value; ?></textarea>
             <?php } ?>
 

--- a/includes/Admin/Forms/Admin_Form_Builder.php
+++ b/includes/Admin/Forms/Admin_Form_Builder.php
@@ -337,7 +337,7 @@ class Admin_Form_Builder {
      *
      * @param array $data Contains form_fields, form_settings, form_settings_key data
      *
-     * @return bool
+     * @return array
      */
     public static function save_form( $data ) {
         $saved_wpuf_inputs = [];
@@ -373,6 +373,29 @@ class Admin_Form_Builder {
                 wp_delete_post( $delete_id, true );
             }
         }
+        
+        // Filter out pro notification settings if pro version is not active
+        if ( ! wpuf_is_pro_active() && isset( $data['form_settings']['notification'] ) ) {
+            // Remove update post notification settings for free version
+            if ( isset( $data['form_settings']['notification']['edit'] ) ) {
+                unset( $data['form_settings']['notification']['edit'] );
+            }
+            if ( isset( $data['form_settings']['notification']['edit_to'] ) ) {
+                unset( $data['form_settings']['notification']['edit_to'] );
+            }
+            if ( isset( $data['form_settings']['notification']['edit_subject'] ) ) {
+                unset( $data['form_settings']['notification']['edit_subject'] );
+            }
+            if ( isset( $data['form_settings']['notification']['edit_body'] ) ) {
+                unset( $data['form_settings']['notification']['edit_body'] );
+            }
+        }
+        
+        // Also filter out standalone notification_edit field if it exists
+        if ( ! wpuf_is_pro_active() && isset( $data['form_settings']['notification_edit'] ) ) {
+            unset( $data['form_settings']['notification_edit'] );
+        }
+        
         update_post_meta( $data['form_id'], $data['form_settings_key'], $data['form_settings'] );
         update_post_meta( $data['form_id'], 'notifications', $data['notifications'] );
         update_post_meta( $data['form_id'], 'integrations', $data['integrations'] );

--- a/includes/Free/Free_Loader.php
+++ b/includes/Free/Free_Loader.php
@@ -6,6 +6,7 @@ use WeDevs\Wpuf\Admin\Forms\Post\Templates\Post_Form_Template_Events_Calendar;
 use WeDevs\Wpuf\Admin\Forms\Post\Templates\Post_Form_Template_WooCommerce;
 use WeDevs\Wpuf\Admin\Forms\Post\Templates\Pro_Form_Preview_EDD;
 use WeDevs\Wpuf\Pro\Admin\Coupon_Elements;
+use WeDevs\Wpuf\Hooks\Form_Settings_Cleanup;
 
 class Free_Loader extends Pro_Prompt {
 
@@ -72,6 +73,7 @@ class Free_Loader extends Pro_Prompt {
     public function includes() {
         // class files to include pro elements
         require_once WPUF_INCLUDES . '/functions/user/edit-user.php';
+        require_once WPUF_INCLUDES . '/Hooks/Form_Settings_Cleanup.php';
     }
 
     public function instantiate() {
@@ -90,6 +92,7 @@ class Free_Loader extends Pro_Prompt {
 
             if ( $load_free ) {
                 new WPUF_Admin_Form_Free();
+                new Form_Settings_Cleanup();
             }
         }
     }

--- a/includes/Hooks/Form_Settings_Cleanup.php
+++ b/includes/Hooks/Form_Settings_Cleanup.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace WeDevs\Wpuf\Hooks;
+
+/**
+ * Form Settings Cleanup
+ * 
+ * Cleans up pro-only settings from form configurations in the free version
+ * to prevent unintended activation of premium features.
+ */
+class Form_Settings_Cleanup {
+
+    /**
+     * Constructor
+     */
+    public function __construct() {
+        add_action( 'wpuf_form_builder_save_form', [ $this, 'cleanup_pro_settings' ], 10, 1 );
+        add_action( 'save_post', [ $this, 'cleanup_form_meta_pro_settings' ], 10, 2 );
+    }
+
+    /**
+     * Clean up pro settings after form save
+     *
+     * @param int $form_id Form ID
+     */
+    public function cleanup_pro_settings( $form_id ) {
+        if ( wpuf_is_pro_active() ) {
+            return;
+        }
+
+        $form_settings = wpuf_get_form_settings( $form_id );
+        
+        if ( empty( $form_settings ) ) {
+            return;
+        }
+
+        $cleaned_settings = $this->remove_pro_notification_settings( $form_settings );
+        
+        // Update if settings were modified
+        if ( $cleaned_settings !== $form_settings ) {
+            update_post_meta( $form_id, 'wpuf_form_settings', $cleaned_settings );
+        }
+    }
+
+    /**
+     * Clean up pro settings from post meta
+     *
+     * @param int     $post_id Post ID
+     * @param \WP_Post $post    Post object
+     */
+    public function cleanup_form_meta_pro_settings( $post_id, $post ) {
+        if ( wpuf_is_pro_active() || $post->post_type !== 'wpuf_forms' ) {
+            return;
+        }
+
+        $form_settings = get_post_meta( $post_id, 'wpuf_form_settings', true );
+        
+        if ( empty( $form_settings ) ) {
+            return;
+        }
+
+        $cleaned_settings = $this->remove_pro_notification_settings( $form_settings );
+        
+        // Update if settings were modified
+        if ( $cleaned_settings !== $form_settings ) {
+            update_post_meta( $post_id, 'wpuf_form_settings', $cleaned_settings );
+        }
+    }
+
+    /**
+     * Remove pro notification settings from form settings
+     *
+     * @param array $form_settings Form settings array
+     * @return array Cleaned form settings
+     */
+    private function remove_pro_notification_settings( $form_settings ) {
+        if ( ! is_array( $form_settings ) ) {
+            return $form_settings;
+        }
+
+        // List of pro-only notification settings to remove
+        $pro_notification_keys = [
+            'notification_edit',
+            'notification_edit_to', 
+            'notification_edit_subject',
+            'notification_edit_body'
+        ];
+
+        foreach ( $pro_notification_keys as $key ) {
+            if ( isset( $form_settings[ $key ] ) ) {
+                unset( $form_settings[ $key ] );
+            }
+        }
+
+        if ( isset( $form_settings['notification'] ) && is_array( $form_settings['notification'] ) ) {
+            $notification_pro_keys = [ 'edit', 'edit_to', 'edit_subject', 'edit_body' ];
+            
+            foreach ( $notification_pro_keys as $key ) {
+                if ( isset( $form_settings['notification'][ $key ] ) ) {
+                    unset( $form_settings['notification'][ $key ] );
+                }
+            }
+        }
+
+        return $form_settings;
+    }
+}


### PR DESCRIPTION
- Prevent update post notification from being enabled by default in free version
- Filter out pro notification fields from form settings before saving
- Update UI to show Update Post Notification toggle as disabled/off in free version
- Add Form_Settings_Cleanup hook to remove pro notification settings from saved form meta
- Ensure backward compatibility and no impact on pro users
- Resolves issue #1613 where free users received unwanted update notifications