### PR TITLE
Fix admin height issues by unsetting height constraints

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1001,6 +1001,10 @@ span.pro-icon:hover .wpuf-pro-field-tooltip {
 .plugin-card .name {
   margin-left: 148px !important;
 }
+#wpcontent,
+#wpfooter {
+  height: unset !important;
+}
 .wpuf-help-tabbed {
   display: flex;
   width: 100%;

--- a/assets/less/admin.less
+++ b/assets/less/admin.less
@@ -1238,6 +1238,11 @@ span.pro-icon:hover .wpuf-pro-field-tooltip {
     margin-left: 148px !important;
 }
 
+#wpcontent,
+#wpfooter {
+	height: unset !important;
+}
+
 @import "help.less";
 @import "whats-new.less";
 @import "metabox-tabs.less";


### PR DESCRIPTION
- Add CSS rule to unset height constraints on #wpcontent and #wpfooter
- This resolves layout issues in WordPress admin areas
- Applied changes to both LESS source and compiled CSS files

before: 
![iScreen Shoter - 20250704101214694](https://github.com/user-attachments/assets/5aa65370-5441-4536-b929-f51e83177541)
![iScreen Shoter - 20250704101031795](https://github.com/user-attachments/assets/2f662849-0923-45e0-ae18-ca1358dc799c)

after: 
![image](
![iScreen Shoter - 20250704101048810](https://github.com/user-attachments/assets/3dc283bf-465e-4b0c-b777-7f8985fc37cb)
https://github.com/user-attachments/assets/2e15a2a4-be9e-4127-b2cd-bedf859ad689)

