### PR TITLE
Fix Turnstile field display logic in post forms

### DIFF
--- a/includes/Fields/Form_Field_Cloudflare_Turnstile.php
+++ b/includes/Fields/Form_Field_Cloudflare_Turnstile.php
@@ -31,7 +31,7 @@ class Form_Field_Cloudflare_Turnstile extends Field_Contract {
         $size             = ! empty( $field_settings['turnstile_size'] ) ? $field_settings['turnstile_size'] : 'normal';
         $action           = ! empty( $field_settings['turnstile_type'] ) ? $field_settings['turnstile_type'] : 'non-interactive';
 
-        if ( 'on' !== $enable_turnstile || empty( $site_key ) ) {
+        if ( wpuf_is_checkbox_or_toggle_on( $enable_turnstile ) || empty( $site_key ) ) {
             return;
         }
 


### PR DESCRIPTION
- Change condition from login_form_turnstile to global enable_turnstile setting
- Turnstile field in post forms should be controlled by global setting, not login-specific setting
- Fixes issue where Turnstile field was incorrectly hidden/shown based on login form setting

Fixes: Turnstile field display logic inconsistency

Close #1571 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the handling of the Cloudflare Turnstile field to better respect the enablement setting and prevent rendering when not configured or enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->