### PR TITLE
hotfix: remove wpnonce in edit option

### DIFF
--- a/assets/js/components/FormsList.vue
+++ b/assets/js/components/FormsList.vue
@@ -251,9 +251,13 @@ const buildAdminUrl = (formId, action) => {
   const params = new URLSearchParams({
     page: 'wpuf-post-forms',
     id: formId.toString(),
-    _wpnonce: wpuf_forms_list.bulk_nonce,
     action
   });
+  
+
+  if (action !== 'edit') {
+    params.append('_wpnonce', wpuf_forms_list.bulk_nonce);
+  }
   
   return `${wpuf_admin_script.admin_url}admin.php?${params.toString()}`;
 };


### PR DESCRIPTION
* **Bug Fixes**
  * Improved URL generation to only include the security parameter when appropriate, ensuring more accurate and relevant links in the interface.