### PR TITLE
fix: wpuf-post-forms-list-table-overflow-hidden

### DIFF
--- a/includes/Admin/views/post-forms-list-table-view.php
+++ b/includes/Admin/views/post-forms-list-table-view.php
@@ -1,4 +1,4 @@
-<div id="wpuf-post-forms-list-table-view" class="wpuf-h-100vh wpuf-bg-white wpuf-ml-[-20px] wpuf-py-0 wpuf-px-[20px]">
+<div id="wpuf-post-forms-list-table-view" class="wpuf-h-100vh wpuf-bg-white wpuf-ml-[-20px] wpuf-py-0 wpuf-px-[20px] wpuf-overflow-hidden">
     <noscript>
         <strong>
             <?php esc_html_e( "We're sorry but this page doesn't work properly without JavaScript. Please enable it to continue.", 'wp-user-frontend' ); ?>


### PR DESCRIPTION

* **Style**
  * Updated the main container styling in the post forms list table view to hide overflow content, which may affect how content is displayed or clipped within this section.
  
<img width="1920" height="589" alt="image" src="https://github.com/user-attachments/assets/08d57f9b-af33-4c03-8b96-fa8ae2f872dc" />

