### PR TITLE
fix: conditionally show 'Require email verification'

### DIFF
--- a/admin/form-builder/assets/js/form-builder.js
+++ b/admin/form-builder/assets/js/form-builder.js
@@ -926,10 +926,16 @@
                 },
                 guest_email_verify: {
                     type: 'text',
-                    dependsOn: [{
-                        field: 'post_permission',
-                        value: 'guest_post'
-                    }]
+                    dependsOn: [
+                        {
+                            field: 'post_permission',
+                            value: 'guest_post'
+                        },
+                        {
+                            field: 'guest_details',
+                            value: true
+                        }
+                    ]
                 },
                 name_label: {
                     type: 'text',

--- a/assets/js/wpuf-form-builder.js
+++ b/assets/js/wpuf-form-builder.js
@@ -926,10 +926,16 @@
                 },
                 guest_email_verify: {
                     type: 'text',
-                    dependsOn: [{
-                        field: 'post_permission',
-                        value: 'guest_post'
-                    }]
+                    dependsOn: [
+                        {
+                            field: 'post_permission',
+                            value: 'guest_post'
+                        },
+                        {
+                            field: 'guest_details',
+                            value: true
+                        }
+                    ]
                 },
                 name_label: {
                     type: 'text',


### PR DESCRIPTION
## Changes Made: Close [Issue](https://github.com/weDevsOfficial/wpuf-pro/issues/921)

1. **JavaScript Dependency Configuration**: In [`form-builder.js`](wp-content/plugins/wp-user-frontend/admin/form-builder/assets/js/form-builder.js:927), I updated the `guest_email_verify` field dependencies to include both:
   - `post_permission` must be `'guest_post'` (existing)
   - `guest_details` must be `true` (new dependency)

## How it works:

The `FormDependencyHandler` class in the JavaScript file now ensures that:
- The "Require email verification" checkbox will only be visible when both:
  1. "Post Permission" is set to "Guest Post" 
  2. "Require Name and Email address" is checked

This creates the correct logical flow where users must first enable guest posting, then enable name/email collection, and only then can they enable email verification - ensuring email verification only appears when it's actually relevant.

The fix uses the existing dependency system in WPUF's form builder, which handles all the show/hide logic automatically through JavaScript.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The "Guest Email Verify" field in the form builder now only appears when both "Post Permission" is set to "Guest Post" and "Guest Details" is enabled, adding an extra layer of conditional visibility for users configuring forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->