### PR TITLE
Enhance/product tag searchable

### DIFF
--- a/admin/form-builder/assets/js/components/field-select/index.js
+++ b/admin/form-builder/assets/js/components/field-select/index.js
@@ -12,6 +12,59 @@ Vue.component('field-select', {
         };
     },
 
+    mounted: function() {
+        // Initialize selectedOption when component mounts
+        this.initializeSelectedOption();
+    },
+
+    watch: {
+        value: {
+            handler: function(newVal) {
+                // Update selectedOption when value changes
+                
+                this.initializeSelectedOption();
+            },
+            immediate: true
+        },
+        'editing_form_field': {
+            handler: function(newVal, oldVal) {
+                // When the entire editing_form_field object changes (like on data load)
+                this.initializeSelectedOption();
+            },
+            deep: true
+        },
+        'option_field.options': {
+            handler: function(newVal) {
+                // When options change, reinitialize
+                this.initializeSelectedOption();
+            },
+            deep: true
+        }
+    },
+
+    methods: {
+        initializeSelectedOption: function() {
+            var self = this;
+            this.$nextTick(function() {
+                // Get the current value
+                var currentValue = self.editing_form_field[self.option_field.name];
+                
+                if (currentValue && self.option_field.options && self.option_field.options[currentValue]) {
+                    self.selectedOption = self.option_field.options[currentValue];
+                } else if (!currentValue && self.option_field.default && self.option_field.options && self.option_field.options[self.option_field.default]) {
+                    // If no value but there's a default, show the default
+                    self.selectedOption = self.option_field.options[self.option_field.default];
+                    // Also set the value to default if there's no current value
+                    if (!currentValue) {
+                        self.value = self.option_field.default;
+                    }
+                } else {
+                    self.selectedOption = 'Select an option';
+                }
+            });
+        }
+    },
+
     computed: {
         value: {
             get: function () {

--- a/admin/form-builder/assets/js/components/form-taxonomy/index.js
+++ b/admin/form-builder/assets/js/components/form-taxonomy/index.js
@@ -27,6 +27,16 @@ Vue.component('form-taxonomy', {
             return [];
         },
 
+        should_show_text_input: function () {
+            // Show text input for ajax type
+            return this.field.type === 'ajax';
+        },
+
+        should_show_ajax_dropdown: function () {
+            // Never show ajax dropdown - always use text input for ajax type
+            return false;
+        },
+
         sorted_terms: function () {
             var self  = this;
             var terms = $.extend(true, [], this.terms);

--- a/assets/js-templates/form-components.php
+++ b/assets/js-templates/form-components.php
@@ -1421,17 +1421,15 @@
         v-html ="get_term_dropdown_options()">
     </select>
 
-    <div v-if="'ajax' === field.type" class="category-wrap">
-        <div>
-            <select
-                :class="builder_class_names('select')"
-                class="!wpuf-text-base"
-            >
-                <option class="wpuf-text-base !wpuf-leading-none"><?php esc_html_e( '— Select —', 'wp-user-frontend' ); ?></option>
-                <option v-for="term in sorted_terms" :value="term.id">{{ term.name }}</option>
-            </select>
-        </div>
-    </div>
+    <input
+        v-if="'ajax' === field.type"
+        type="text"
+        :class="builder_class_names('text')"
+        :placeholder="field.placeholder || 'Type to search ' + field.label"
+        :size="field.size"
+        value=""
+        autocomplete="off"
+    >
 
     <div v-if="'multiselect' === field.type" class="category-wrap">
         <select

--- a/assets/js/wpuf-form-builder-components.js
+++ b/assets/js/wpuf-form-builder-components.js
@@ -828,6 +828,59 @@ Vue.component('field-select', {
         };
     },
 
+    mounted: function() {
+        // Initialize selectedOption when component mounts
+        this.initializeSelectedOption();
+    },
+
+    watch: {
+        value: {
+            handler: function(newVal) {
+                // Update selectedOption when value changes
+                
+                this.initializeSelectedOption();
+            },
+            immediate: true
+        },
+        'editing_form_field': {
+            handler: function(newVal, oldVal) {
+                // When the entire editing_form_field object changes (like on data load)
+                this.initializeSelectedOption();
+            },
+            deep: true
+        },
+        'option_field.options': {
+            handler: function(newVal) {
+                // When options change, reinitialize
+                this.initializeSelectedOption();
+            },
+            deep: true
+        }
+    },
+
+    methods: {
+        initializeSelectedOption: function() {
+            var self = this;
+            this.$nextTick(function() {
+                // Get the current value
+                var currentValue = self.editing_form_field[self.option_field.name];
+                
+                if (currentValue && self.option_field.options && self.option_field.options[currentValue]) {
+                    self.selectedOption = self.option_field.options[currentValue];
+                } else if (!currentValue && self.option_field.default && self.option_field.options && self.option_field.options[self.option_field.default]) {
+                    // If no value but there's a default, show the default
+                    self.selectedOption = self.option_field.options[self.option_field.default];
+                    // Also set the value to default if there's no current value
+                    if (!currentValue) {
+                        self.value = self.option_field.default;
+                    }
+                } else {
+                    self.selectedOption = 'Select an option';
+                }
+            });
+        }
+    },
+
     computed: {
         value: {
             get: function () {

--- a/assets/js/wpuf-form-builder-components.js
+++ b/assets/js/wpuf-form-builder-components.js
@@ -2026,6 +2026,16 @@ Vue.component('form-taxonomy', {
             return [];
         },
 
+        should_show_text_input: function () {
+            // Show text input for ajax type
+            return this.field.type === 'ajax';
+        },
+
+        should_show_ajax_dropdown: function () {
+            // Never show ajax dropdown - always use text input for ajax type
+            return false;
+        },
+
         sorted_terms: function () {
             var self  = this;
             var terms = $.extend(true, [], this.terms);

--- a/includes/Fields/Form_Field_Post_Taxonomy.php
+++ b/includes/Fields/Form_Field_Post_Taxonomy.php
@@ -97,7 +97,9 @@ class Form_Field_Post_Taxonomy extends Field_Contract {
 
         switch ( $this->field_settings['type'] ) {
             case 'ajax':
-                $this->tax_ajax( $post_id );
+                // Use text input with ajax search for all taxonomies
+                $post_id = null;
+                $this->tax_input( $post_id, $field_settings );
                 break;
 
             case 'select':
@@ -420,7 +422,8 @@ class Form_Field_Post_Taxonomy extends Field_Contract {
 
     public function tax_input( $post_id = null, $field_settings = [] ) {
         $attr = $this->field_settings;
-        $query_string = '?action=wpuf_ajax_tag_search&tax=' . $attr['name'];
+        $nonce = wp_create_nonce( 'wpuf_ajax_tag_search' );
+        $query_string = '?action=wpuf_ajax_tag_search&tax=' . $attr['name'] . '&nonce=' . $nonce;
 
         if ( 'child_of' === $this->exclude_type ) {
             $exclude = wpuf_get_field_settings_excludes( $this->field_settings, $this->exclude_type );


### PR DESCRIPTION
close [issue](https://github.com/weDevsOfficial/wp-user-frontend/issues/1648)
---

### ✨ Enhanced Tag Input with AJAX Autocomplete for Taxonomies
Improved the user experience for taxonomy fields marked as `ajax-type` by replacing dropdowns with a searchable text input using jQuery's suggest/autocomplete functionality. This is particularly useful for taxonomies with a large number of terms, such as product tags.

#### 🔧 Key Improvements:

* Replaced `<select>` dropdowns with `<input type="text">` for ajax-enabled taxonomy fields in the form builder.
* Implemented `tax_input` in PHP backend to properly handle submitted taxonomy terms.
* Added secure nonce validation to the AJAX endpoint responsible for tag suggestions.
* Users can now search and select tags dynamically with autocomplete support, reducing UI clutter and improving usability.

This enhancement makes managing large taxonomies more efficient and user-friendly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced form field selection to better synchronize displayed options with underlying data.
  * Taxonomy fields with 'ajax' type now display a text input for searching, replacing the previous dropdown.

* **Bug Fixes**
  * Improved initialization and updating of selected options to ensure consistent display as form data changes.

* **Security**
  * Added a security nonce to AJAX search URLs for taxonomy fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->