### PR TITLE
Fix: Namespaced global JS variables in forms-list.min.js to prevent conflicts with other plugins (gm, qm)

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -33,13 +33,16 @@ export default defineConfig(({ mode }) => {
                             return `css/[name].min.${extType}`;
                         }
                     },
-                    manualChunks: () => null,
+                    format: 'iife',
+                    name: 'WPUF',
+                    inlineDynamicImports: true,
                 },
             },
             outDir: './assets',
             emptyOutDir: false,
             sourcemap: true,
             assetsInlineLimit: 0,
+            chunkSizeWarningLimit: 1000, // Increase warning limit to 1000 kB
         },
     }
 });


### PR DESCRIPTION
Close [issue](https://github.com/weDevsOfficial/wpuf-pro/issues/953)
---
**Description:**
Scoped WPUF’s frontend scripts using IIFE bundling via Vite. This change ensures variables like `gm` and `qm` are no longer declared globally, preventing JavaScript conflicts with other plugins (e.g., Query Monitor, Multisite Global Media). The output bundle is now wrapped under a global `WPUF` namespace using `format: 'iife'`, avoiding global namespace pollution.

**Technical Details:**

* `format: 'iife'`: Wraps the bundle in an immediately-invoked function to create local scope.
* `name: 'WPUF'`: Exposes the bundle under the `window.WPUF` namespace.
* `inlineDynamicImports: true`: Ensures the entire bundle is self-contained and doesn't rely on external dynamic imports.

**Outcome:**
Fixes JS errors like `Uncaught SyntaxError: redeclaration of non-configurable global property 'gm'`, improving plugin compatibility and frontend stability.