### PR TITLE
Fix typo: From Expired Message → Form Expired Message

### DIFF
--- a/includes/Free/Free_Loader.php
+++ b/includes/Free/Free_Loader.php
@@ -1716,7 +1716,7 @@ class Free_Loader extends Pro_Prompt {
                 'help_text' => __( 'Verification of email addresses will be mandatory', 'wp-user-frontend' ),
             ],
             'post_expiration_message'   => [
-                'label' => __( 'From Expired Message', 'wp-user-frontend' ),
+                'label' => __( 'Form Expired Message', 'wp-user-frontend' ),
                 'type'  => 'textarea',
             ],
         ];


### PR DESCRIPTION
Close #1645 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the label in the post expiration settings preview from "From Expired Message" to "Form Expired Message" for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->