### PR TITLE
 Fix: Ensure Google Map fields display on frontend posts

### DIFF
--- a/wpuf-functions.php
+++ b/wpuf-functions.php
@@ -909,7 +909,16 @@ function wpuf_show_custom_fields( $content ) {
                     if ( ! empty( $column_fields ) ) {
                         // ignore section break and HTML input type
                         foreach ( $column_fields as $column_field_key => $column_field ) {
-                            if ( isset( $column_field['show_in_post'] ) && 'yes' === $column_field['show_in_post'] ) {
+                            // Skip if input type is not set
+                            if ( ! isset( $column_field['input_type'] ) ) {
+                                continue;
+                            }
+                            
+                            // Check if it's a map field
+                            $is_map_field = in_array( $column_field['input_type'], [ 'map', 'google_map' ], true );
+                            
+                            // Include field if it's a map or if show_in_post is enabled
+                            if ( $is_map_field || ( isset( $column_field['show_in_post'] ) && wpuf_is_checkbox_or_toggle_on( $column_field['show_in_post'] ) ) ) {
                                 $meta[] = $column_field;
                             }
                         }
@@ -918,7 +927,16 @@ function wpuf_show_custom_fields( $content ) {
                 continue;
             }
 
-            if ( isset( $attr['show_in_post'] ) && 'yes' === $attr['show_in_post'] ) {
+            // Skip if input type is not set
+            if ( ! isset( $attr['input_type'] ) ) {
+                continue;
+            }
+            
+            // Check if it's a map field
+            $is_map_field = in_array( $attr['input_type'], [ 'map', 'google_map' ], true );
+            
+            // Include field if it's a map or if show_in_post is enabled
+            if ( $is_map_field || ( isset( $attr['show_in_post'] ) && wpuf_is_checkbox_or_toggle_on( $attr['show_in_post'] ) ) ) {
                 $meta[] = $attr;
             }
         }


### PR DESCRIPTION
close [issue](https://github.com/weDevsOfficial/wpuf-pro/issues/960)

**Fix: Display Google Map fields on frontend posts**

**Description:**

This update ensures that Google Map custom fields (of type `map` or `google_map`) created using WP User Frontend are consistently displayed on the frontend when the "Custom Fields in post" option is enabled.

**Changes:**

* Added support for both `'map'` and `'google_map'` field types in frontend display logic.
* Ensured map fields render regardless of the "Show in post" toggle in the field settings.
* Optimized logic using early returns and extracted variables for better performance.
* Enforced strict type checking during array comparisons.
* Improved code readability with inline comments and a more structured approach.

**Impact:**

* Fixes an issue where Google Map fields were not being displayed despite having valid location data.
* Improves consistency of custom field output on frontend post templates.