### PR TITLE
Chore/remove unused cat in predefined template

### DIFF
--- a/includes/Admin/template-parts/modal-v4.2.php
+++ b/includes/Admin/template-parts/modal-v4.2.php
@@ -25,14 +25,14 @@ if ( strpos( strtolower( $form_type ), 'registration' ) !== false || strpos( str
             'label'    => __( 'Membership', 'wp-user-frontend' ),
             'keywords' => [ 'membership' ],
         ],
-        'community'    => [
-            'label'    => __( 'Community', 'wp-user-frontend' ),
-            'keywords' => [],
-        ],
-        'associations' => [
-            'label'    => __( 'Associations', 'wp-user-frontend' ),
-            'keywords' => [],
-        ],
+        // 'community'    => [
+        //     'label'    => __( 'Community', 'wp-user-frontend' ),
+        //     'keywords' => [],
+        // ],
+        // 'associations' => [
+        //     'label'    => __( 'Associations', 'wp-user-frontend' ),
+        //     'keywords' => [],
+        // ],
     ];
 } else {
     // Post form categories


### PR DESCRIPTION
Commented out the categories with 0 template
<img width="869" height="1193" alt="image" src="https://github.com/user-attachments/assets/6c32e20b-e238-4318-9511-677336d68557" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed 'community' and 'associations' categories from profile and registration form options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->