### PR TITLE
Revert "form builder meta empty meta key which comes from empty level and dup…"

### DIFF
--- a/admin/form-builder/assets/js/form-builder.js
+++ b/admin/form-builder/assets/js/form-builder.js
@@ -122,21 +122,7 @@
                             state.form_fields[i]['read_only'] = false;
                         }
 
-                        let meta_exist = state.form_fields.filter( function (field) {
-                            return 'yes' === field.is_meta && field.name === payload.value;
-                        });
-
-                        if ( meta_exist.length ) {
-                            swal({
-                                text: 'Duplicate Meta Key',
-                                type: 'warning',
-                                confirmButtonColor: '#d54e21',
-                                confirmButtonText: 'Enter another key',
-                                confirmButtonClass: 'btn btn-success',
-                            });
-                        }
-
-                        if ( ( payload.field_name === 'name'  && payload.value.length - 2 < payload.field_name.length ) || ! state.form_fields[i].hasOwnProperty('is_new') ) {
+                        if (payload.field_name === 'name'  && ! state.form_fields[i].hasOwnProperty('is_new') ) {
                             continue;
                         } else {
                             state.form_fields[i][payload.field_name] = payload.value;

--- a/assets/js/wpuf-form-builder.js
+++ b/assets/js/wpuf-form-builder.js
@@ -122,21 +122,7 @@
                             state.form_fields[i]['read_only'] = false;
                         }
 
-                        let meta_exist = state.form_fields.filter( function (field) {
-                            return 'yes' === field.is_meta && field.name === payload.value;
-                        });
-
-                        if ( meta_exist.length ) {
-                            swal({
-                                text: 'Duplicate Meta Key',
-                                type: 'warning',
-                                confirmButtonColor: '#d54e21',
-                                confirmButtonText: 'Enter another key',
-                                confirmButtonClass: 'btn btn-success',
-                            });
-                        }
-
-                        if ( ( payload.field_name === 'name'  && payload.value.length - 2 < payload.field_name.length ) || ! state.form_fields[i].hasOwnProperty('is_new') ) {
+                        if (payload.field_name === 'name'  && ! state.form_fields[i].hasOwnProperty('is_new') ) {
                             continue;
                         } else {
                             state.form_fields[i][payload.field_name] = payload.value;


### PR DESCRIPTION
Reverts weDevsOfficial/wp-user-frontend#1271

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Changes
  * Removed duplicate meta key validation and warning in the form builder; duplicates are no longer blocked or alerted.
  * Disallowed renaming the “name” property of existing fields; other properties remain editable.
  * New fields can still have their “name” and other properties edited as before.
  * No changes to public APIs or external integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->