### PR TITLE
feat(upload): allow webp image format in file upload fields

### DIFF
--- a/includes/Fields/Form_Field_Featured_Image.php
+++ b/includes/Fields/Form_Field_Featured_Image.php
@@ -95,7 +95,7 @@ class Form_Field_Featured_Image extends Field_Contract {
         <script type="text/javascript">
             ;(function($) {
                 $(document).ready( function(){
-                    var uploader = new WPUF_Uploader('wpuf-<?php echo esc_attr( $unique_id ); ?>-pickfiles', 'wpuf-<?php echo esc_attr( $unique_id ); ?>-upload-container', <?php echo esc_attr($field_settings['count'] ); ?>, '<?php echo esc_attr( $field_settings['name'] ); ?>', 'jpg,jpeg,gif,png,bmp', <?php echo esc_attr( $field_settings['max_size'] ); ?>);
+                    var uploader = new WPUF_Uploader('wpuf-<?php echo esc_attr( $unique_id ); ?>-pickfiles', 'wpuf-<?php echo esc_attr( $unique_id ); ?>-upload-container', <?php echo esc_attr($field_settings['count'] ); ?>, '<?php echo esc_attr( $field_settings['name'] ); ?>', 'jpg,jpeg,gif,png,bmp,webp', <?php echo esc_attr( $field_settings['max_size'] ); ?>);
                     wpuf_plupload_items.push(uploader);
                 });
             })(jQuery);

--- a/includes/Fields/Form_Field_Image.php
+++ b/includes/Fields/Form_Field_Image.php
@@ -78,7 +78,7 @@ class Form_Field_Image extends Field_Contract {
             <script type="text/javascript">
                 (function($) {
                     $(document).ready( function(){
-                        var uploader = new WPUF_Uploader('wpuf-<?php echo esc_attr( $unique_id ); ?>-pickfiles', 'wpuf-<?php echo esc_attr( $unique_id ); ?>-upload-container', <?php echo esc_attr( $field_settings['count'] ); ?>, '<?php echo esc_attr( $field_settings['name'] ); ?>', 'jpg,jpeg,gif,png,bmp', <?php echo esc_attr( $field_settings['max_size'] ); ?>);
+                        var uploader = new WPUF_Uploader('wpuf-<?php echo esc_attr( $unique_id ); ?>-pickfiles', 'wpuf-<?php echo esc_attr( $unique_id ); ?>-upload-container', <?php echo esc_attr( $field_settings['count'] ); ?>, '<?php echo esc_attr( $field_settings['name'] ); ?>', 'jpg,jpeg,gif,png,bmp,webp', <?php echo esc_attr( $field_settings['max_size'] ); ?>);
                         wpuf_plupload_items.push(uploader);
                     });
                 })(jQuery);

--- a/wpuf-functions.php
+++ b/wpuf-functions.php
@@ -531,7 +531,7 @@ function wpuf_get_image_sizes() {
 function wpuf_allowed_extensions() {
     $extesions = [
         'images' => [
-            'ext' => 'jpg,jpeg,gif,png,bmp',
+            'ext' => 'jpg,jpeg,gif,png,bmp,webp',
             'label' => __( 'Images', 'wp-user-frontend' ),
         ],
         'audio'  => [


### PR DESCRIPTION
Added support for uploading .webp images in all file upload fields to improve compatibility with modern image formats.

Closes #[1014](https://github.com/weDevsOfficial/wpuf-pro/issues/1014) , Related PRO [PR](https://github.com/weDevsOfficial/wpuf-pro/pull/1058)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for uploading WebP images across image-related form fields, including Featured Image and Image fields.
  - Updated upload validation to accept WebP alongside existing formats (JPG, JPEG, GIF, PNG, BMP).
  - Ensures consistent client-side and server-side handling of WebP files for smoother uploads and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->