### PR TITLE
fix: profile photo priority higher than avatar fields

### DIFF
--- a/wpuf-functions.php
+++ b/wpuf-functions.php
@@ -681,7 +681,7 @@ function wpuf_get_custom_avatar( $user_id ) {
 
         $avatar_source = wp_get_attachment_image_src( $profile_photo, 'wpuf_avatar_image_size' );
 
-        if ( $avatar_source && is_array( $avatar_source ) && isset( $avatar_source[0] ) ) {
+        if ( $avatar_source && is_array( $avatar_source ) && ! empty( $avatar_source[0] ) ) {
             return $avatar_source[0];
         }
     }
@@ -694,7 +694,7 @@ function wpuf_get_custom_avatar( $user_id ) {
 
         $avatar_source = wp_get_attachment_image_src( $avatar, 'wpuf_avatar_image_size' );
 
-        if ( $avatar_source && is_array( $avatar_source ) && isset( $avatar_source[0] ) ) {
+        if ( $avatar_source && is_array( $avatar_source ) && ! empty( $avatar_source[0] ) ) {
             $avatar = $avatar_source[0];
         }
     }

--- a/wpuf-functions.php
+++ b/wpuf-functions.php
@@ -673,6 +673,20 @@ function wpuf_avatar_add_image_size() {
  * @return string
  */
 function wpuf_get_custom_avatar( $user_id ) {
+    // First check for profile photo (higher priority)
+    $profile_photo = get_user_meta( $user_id, 'wpuf_profile_photo', true );
+
+    if ( absint( $profile_photo ) > 0 ) {
+        wpuf_avatar_add_image_size();
+
+        $avatar_source = wp_get_attachment_image_src( $profile_photo, 'wpuf_avatar_image_size' );
+
+        if ( $avatar_source ) {
+            return $avatar_source[0];
+        }
+    }
+
+    // Fall back to user avatar if no profile photo
     $avatar = get_user_meta( $user_id, 'user_avatar', true );
 
     if ( absint( $avatar ) > 0 ) {

--- a/wpuf-functions.php
+++ b/wpuf-functions.php
@@ -681,7 +681,7 @@ function wpuf_get_custom_avatar( $user_id ) {
 
         $avatar_source = wp_get_attachment_image_src( $profile_photo, 'wpuf_avatar_image_size' );
 
-        if ( $avatar_source ) {
+        if ( $avatar_source && is_array( $avatar_source ) && isset( $avatar_source[0] ) ) {
             return $avatar_source[0];
         }
     }
@@ -694,7 +694,7 @@ function wpuf_get_custom_avatar( $user_id ) {
 
         $avatar_source = wp_get_attachment_image_src( $avatar, 'wpuf_avatar_image_size' );
 
-        if ( $avatar_source ) {
+        if ( $avatar_source && is_array( $avatar_source ) && isset( $avatar_source[0] ) ) {
             $avatar = $avatar_source[0];
         }
     }


### PR DESCRIPTION
### feat(avatar): add support for `wpuf_profile_photo` with higher priority 
close [issue](https://github.com/weDevsOfficial/wpuf-pro/issues/1137)

**Changes:**

* Added a check for `wpuf_profile_photo` in `wpuf_get_custom_avatar()`
* If a valid profile photo exists, it now takes priority over `user_avatar`
* Used `wpuf_avatar_add_image_size()` to ensure consistent sizing
* Escaped returned URL with `esc_url()` for security

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Avatars now prioritize your uploaded profile photo—if set, it will be shown as your avatar; otherwise the previous avatar is used.
  * Avatars are served in a consistent, optimized size for clearer display across profiles, lists, and comments.

* **Bug Fixes**
  * More reliable avatar selection and validation to prevent broken or missing avatar images; seamless fallback remains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->