### PR TITLE
Rename 'Published' tab to 'Saved' in form list pages

### DIFF
--- a/assets/js/components/FormsList.vue
+++ b/assets/js/components/FormsList.vue
@@ -548,7 +548,7 @@ onMounted(() => {
                       'wpuf-bg-gray-100 wpuf-border-gray-200 wpuf-text-gray-800': form.post_status === 'draft'
                     }"
                     class="wpuf-inline-flex wpuf-items-center wpuf-py-[2px] wpuf-px-[12px] wpuf-rounded-[5px] wpuf-text-xs wpuf-font-medium wpuf-border">
-                    {{ form.post_status === 'publish' ? 'Published' :
+                    {{ form.post_status === 'publish' ? 'Saved' :
                        form.post_status === 'pending' ? 'Pending Review' :
                        form.post_status === 'private' ? 'Private' : 'Draft' }}
                   </span>

--- a/wpuf-functions.php
+++ b/wpuf-functions.php
@@ -5606,7 +5606,7 @@ function wpuf_get_forms_counts_with_status( $post_type = 'wpuf_forms' ) {
 
     $post_statuses = apply_filters( 'wpuf_post_forms_list_table_post_statuses', [
         'all'     => __( 'All', 'wp-user-frontend' ),
-        'publish' => __( 'Published', 'wp-user-frontend' ),
+        'publish' => __( 'Saved', 'wp-user-frontend' ),
         'trash'   => __( 'Trash', 'wp-user-frontend' ),
     ] );
 


### PR DESCRIPTION
Related Free [PR](https://github.com/weDevsOfficial/wpuf-pro/pull/1155), Close [issue](https://github.com/weDevsOfficial/wpuf-pro/issues/1129)

- Updated tab label from 'Published' to 'Saved' in wpuf_get_forms_counts_with_status()
- Changed status badge text in FormsList.vue
- Clarifies that forms are stored in the database rather than published content