### PR TITLE
Security: Fix capability checks & shortcode exec vuln

### DIFF
--- a/includes/Admin/Admin_Tools.php
+++ b/includes/Admin/Admin_Tools.php
@@ -456,6 +456,18 @@ class Admin_Tools {
      */
     public function import_forms() {
         check_ajax_referer( 'wpuf_admin_tools' );
+
+        // Security: Check user has proper admin capabilities
+        if ( ! current_user_can( wpuf_admin_role() ) ) {
+            wp_send_json_error(
+                new WP_Error(
+                    'wpuf_ajax_import_forms_error',
+                    __( 'Unauthorized operation', 'wp-user-frontend' )
+                ),
+                WP_Http::FORBIDDEN
+            );
+        }
+
         if ( ! isset( $_POST['file_id'] ) ) {
             wp_send_json_error(
                 new WP_Error(

--- a/includes/Ajax/Admin_Form_Builder_Ajax.php
+++ b/includes/Ajax/Admin_Form_Builder_Ajax.php
@@ -219,6 +219,13 @@ class Admin_Form_Builder_Ajax {
     }
 
     public function get_roles() {
+        // Security: Check nonce and user capabilities
+        check_ajax_referer( 'wpuf-form-builder' );
+
+        if ( ! current_user_can( wpuf_admin_role() ) ) {
+            wp_send_json_error( __( 'Unauthorized operation', 'wp-user-frontend' ) );
+        }
+
         $roles = wpuf_get_user_roles();
 
         $html = '<div class="wpuf-mt-6 wpuf-input-container"><div class="wpuf-flex wpuf-items-center"><label for="default_category" class="wpuf-text-sm wpuf-text-gray-700 wpuf-my-2">' . __( 'Choose who can submit post ', 'wp-user-frontend' ) . '</label></div>';

--- a/includes/Ajax/Frontend_Form_Ajax.php
+++ b/includes/Ajax/Frontend_Form_Ajax.php
@@ -159,9 +159,9 @@ class Frontend_Form_Ajax {
             'post_type'    => ! empty( $this->form_settings['post_type'] ) ? $this->form_settings['post_type'] : 'post',
             'post_status'  => isset( $this->form_settings['post_status'] ) ? $this->form_settings['post_status'] : 'publish',
             'post_author'  => $post_author,
-            'post_title'   => isset( $_POST['post_title'] ) ? sanitize_text_field( wp_unslash( $_POST['post_title'] ) ) : '',
-            'post_content' => isset( $_POST['post_content'] ) ? wp_kses( wp_unslash( $_POST['post_content'] ), $allowed_tags ) : '',
-            'post_excerpt' => isset( $_POST['post_excerpt'] ) ? wp_kses( wp_unslash( $_POST['post_excerpt'] ), $allowed_tags ) : '',
+            'post_title'   => isset( $_POST['post_title'] ) ? strip_shortcodes( sanitize_text_field( wp_unslash( $_POST['post_title'] ) ) ) : '',
+            'post_content' => isset( $_POST['post_content'] ) ? strip_shortcodes( wp_kses( wp_unslash( $_POST['post_content'] ), $allowed_tags ) ) : '',
+            'post_excerpt' => isset( $_POST['post_excerpt'] ) ? strip_shortcodes( wp_kses( wp_unslash( $_POST['post_excerpt'] ), $allowed_tags ) ) : '',
         ];
 
         // $charging_enabled = wpuf_get_option( 'charge_posting', 'wpuf_payment' );
@@ -236,7 +236,7 @@ class Frontend_Form_Ajax {
             }
 
             // Security: Check if user has permission to edit this post (Broken Access Control fix)
-            $post_author = get_post_field( 'post_author', $post_id );
+            $post_author = (int) get_post_field( 'post_author', $post_id );
             $current_user_id = get_current_user_id();
 
             // Allow edit if: user is post author OR user has edit_others_posts capability

--- a/includes/Ajax/Frontend_Form_Ajax.php
+++ b/includes/Ajax/Frontend_Form_Ajax.php
@@ -229,18 +229,19 @@ class Frontend_Form_Ajax {
         if ( isset( $_POST['post_id'] ) ) {
             $post_id                   = intval( wp_unslash( $_POST['post_id'] ) );
 
+            // Verify the post exists
+            $post = get_post( $post_id );
+            if ( ! $post || is_wp_error( $post ) ) {
+                wpuf()->ajax->send_error( __( 'Post not found.', 'wp-user-frontend' ) );
+            }
+
             // Security: Check if user has permission to edit this post (Broken Access Control fix)
             $post_author = get_post_field( 'post_author', $post_id );
             $current_user_id = get_current_user_id();
 
             // Allow edit if: user is post author OR user has edit_others_posts capability
-            if ( $current_user_id != $post_author && ! current_user_can( 'edit_others_posts' ) ) {
+            if ( $current_user_id !== $post_author && ! current_user_can( 'edit_others_posts' ) ) {
                 wpuf()->ajax->send_error( __( 'You do not have permission to edit this post.', 'wp-user-frontend' ) );
-            }
-
-            // Verify the post exists
-            if ( ! get_post( $post_id ) ) {
-                wpuf()->ajax->send_error( __( 'Post not found.', 'wp-user-frontend' ) );
             }
 
             $is_update                 = true;

--- a/includes/Ajax/Frontend_Form_Ajax.php
+++ b/includes/Ajax/Frontend_Form_Ajax.php
@@ -228,6 +228,21 @@ class Frontend_Form_Ajax {
         // if post_id is passed, we update the post
         if ( isset( $_POST['post_id'] ) ) {
             $post_id                   = intval( wp_unslash( $_POST['post_id'] ) );
+
+            // Security: Check if user has permission to edit this post (Broken Access Control fix)
+            $post_author = get_post_field( 'post_author', $post_id );
+            $current_user_id = get_current_user_id();
+
+            // Allow edit if: user is post author OR user has edit_others_posts capability
+            if ( $current_user_id != $post_author && ! current_user_can( 'edit_others_posts' ) ) {
+                wpuf()->ajax->send_error( __( 'You do not have permission to edit this post.', 'wp-user-frontend' ) );
+            }
+
+            // Verify the post exists
+            if ( ! get_post( $post_id ) ) {
+                wpuf()->ajax->send_error( __( 'Post not found.', 'wp-user-frontend' ) );
+            }
+
             $is_update                 = true;
             $postarr['ID']             = $post_id;
             $postarr['post_date']      = isset( $_POST['post_date'] ) ? sanitize_text_field( wp_unslash( $_POST['post_date'] ) ) : '';

--- a/includes/Fields/Field_Contract.php
+++ b/includes/Fields/Field_Contract.php
@@ -871,7 +871,7 @@ abstract class Field_Contract {
     public function prepare_entry( $field ) {
         check_ajax_referer( 'wpuf_form_add' );
 
-        $value = ! empty( $_POST[ $field['name'] ] ) ? sanitize_text_field( wp_unslash( $_POST[ $field['name'] ] ) ) :
+        $value = ! empty( $_POST[ $field['name'] ] ) ? strip_shortcodes( sanitize_text_field( wp_unslash( $_POST[ $field['name'] ] ) ) ) :
             '';
 
         if ( is_array( $value ) ) {

--- a/includes/Fields/Form_Field_Checkbox.php
+++ b/includes/Fields/Form_Field_Checkbox.php
@@ -130,7 +130,7 @@ class Form_Field_Checkbox extends Field_Contract {
         check_ajax_referer( 'wpuf_form_add' );
 
         $field_name = isset( $_POST[$field['name']] ) ? array_map( 'sanitize_text_field', wp_unslash( $_POST[$field['name']] ) ) : [];
-        $field_name = array_map( 'strip_shortcodes', $field_name );
+        $field_name = array_map( 'sanitize_text_field', array_map( 'strip_shortcodes', $field_name ) );
 
         $entry_value  = ( is_array( $field_name ) && $field_name ) ? $field_name : [];
 

--- a/includes/Fields/Form_Field_Checkbox.php
+++ b/includes/Fields/Form_Field_Checkbox.php
@@ -130,6 +130,7 @@ class Form_Field_Checkbox extends Field_Contract {
         check_ajax_referer( 'wpuf_form_add' );
 
         $field_name = isset( $_POST[$field['name']] ) ? array_map( 'sanitize_text_field', wp_unslash( $_POST[$field['name']] ) ) : [];
+        $field_name = array_map( 'strip_shortcodes', $field_name );
 
         $entry_value  = ( is_array( $field_name ) && $field_name ) ? $field_name : [];
 

--- a/includes/Fields/Form_Field_Dropdown.php
+++ b/includes/Fields/Form_Field_Dropdown.php
@@ -127,7 +127,7 @@ class Form_Field_Dropdown extends Field_Contract {
     public function prepare_entry( $field ) {
         check_ajax_referer( 'wpuf_form_add' );
 
-        $val = isset( $_POST[$field['name']] ) ? sanitize_text_field( wp_unslash( $_POST[$field['name']] ) ) : '';
+        $val = isset( $_POST[$field['name']] ) ? strip_shortcodes( sanitize_text_field( wp_unslash( $_POST[$field['name']] ) ) ) : '';
 
         return isset( $field['options'][$val] ) ? $field['options'][$val] : '';
     }

--- a/includes/Fields/Form_Field_Email.php
+++ b/includes/Fields/Form_Field_Email.php
@@ -89,7 +89,7 @@ class Form_Field_Email extends Form_Field_Text {
                 return $user->user_email;
             }
         }
-        $value = !empty( $_POST[$field['name']] ) ? sanitize_text_field( wp_unslash( $_POST[$field['name']] ) ) : '';
+        $value = !empty( $_POST[$field['name']] ) ? strip_shortcodes( sanitize_text_field( wp_unslash( $_POST[$field['name']] ) ) ) : '';
 
         return sanitize_text_field( trim( $value ) );
     }

--- a/includes/Fields/Form_Field_MultiDropdown.php
+++ b/includes/Fields/Form_Field_MultiDropdown.php
@@ -103,6 +103,7 @@ class Form_Field_MultiDropdown extends Form_Field_Dropdown {
         check_ajax_referer( 'wpuf_form_add' );
 
         $field_name = isset( $_POST[$field['name']] ) ? array_map( 'sanitize_text_field', wp_unslash( $_POST[$field['name']] ) ) : [];
+        $field_name = array_map( 'strip_shortcodes', $field_name );
         $entry_value  = ( is_array( $field_name ) && $field_name ) ? $field_name : [];
 
         if ( $entry_value ) {

--- a/includes/Fields/Form_Field_Post_Content.php
+++ b/includes/Fields/Form_Field_Post_Content.php
@@ -211,7 +211,7 @@ class Form_Field_Post_Content extends Field_Contract {
     public function prepare_entry( $field ) {
         check_ajax_referer( 'wpuf_form_add' );
 
-        $field = isset( $_POST[ $field['name'] ] ) ? sanitize_text_field( wp_unslash( $_POST[ $field['name'] ] ) ) : '';
+        $field = isset( $_POST[ $field['name'] ] ) ? strip_shortcodes( sanitize_text_field( wp_unslash( $_POST[ $field['name'] ] ) ) ) : '';
 
         return trim( $field );
     }

--- a/includes/Fields/Form_Field_Post_Excerpt.php
+++ b/includes/Fields/Form_Field_Post_Excerpt.php
@@ -151,7 +151,7 @@ class Form_Field_Post_Excerpt extends Field_Contract {
     public function prepare_entry( $field ) {
         check_ajax_referer( 'wpuf_form_add' );
 
-        $field = isset( $_POST[ $field['name'] ] ) ? sanitize_text_field( wp_unslash( $_POST[ $field['name'] ] ) ) : '';
+        $field = isset( $_POST[ $field['name'] ] ) ? strip_shortcodes( sanitize_text_field( wp_unslash( $_POST[ $field['name'] ] ) ) ) : '';
 
         return wp_kses_post( $field );
     }

--- a/includes/Fields/Form_Field_Post_Tags.php
+++ b/includes/Fields/Form_Field_Post_Tags.php
@@ -114,7 +114,7 @@ class Form_Field_Post_Tags extends Field_Contract {
     public function prepare_entry( $field ) {
         check_ajax_referer( 'wpuf_form_add' );
 
-        $field = isset( $_POST[$field['name']] ) ? sanitize_text_field( wp_unslash( $_POST[$field['name']] ) ) : '';
+        $field = isset( $_POST[$field['name']] ) ? strip_shortcodes( sanitize_text_field( wp_unslash( $_POST[$field['name']] ) ) ) : '';
         return $field;
     }
 }

--- a/includes/Fields/Form_Field_Post_Taxonomy.php
+++ b/includes/Fields/Form_Field_Post_Taxonomy.php
@@ -523,7 +523,7 @@ class Form_Field_Post_Taxonomy extends Field_Contract {
         // return sanitize_text_field($_POST[$field['name']]);
         check_ajax_referer( 'wpuf_form_add' );
 
-        $val = isset( $_POST[ $field['name'] ] ) ? sanitize_text_field( wp_unslash( $_POST[ $field['name'] ] ) ) : '';
+        $val = isset( $_POST[ $field['name'] ] ) ? strip_shortcodes( sanitize_text_field( wp_unslash( $_POST[ $field['name'] ] ) ) ) : '';
 
         return isset( $field['options'][ $val ] ) ? $field['options'][ $val ] : '';
     }

--- a/includes/Fields/Form_Field_Post_Title.php
+++ b/includes/Fields/Form_Field_Post_Title.php
@@ -133,7 +133,7 @@ class Form_Field_Post_Title extends Field_Contract {
     public function prepare_entry( $field ) {
         check_ajax_referer( 'wpuf_form_add' );
 
-        $field = isset( $_POST[ $field['name'] ] ) ? sanitize_text_field( wp_unslash( $_POST[ $field['name'] ] ) ) : '';
+        $field = isset( $_POST[ $field['name'] ] ) ? strip_shortcodes( sanitize_text_field( wp_unslash( $_POST[ $field['name'] ] ) ) ) : '';
         return $field;
     }
 }

--- a/includes/Fields/Form_Field_Radio.php
+++ b/includes/Fields/Form_Field_Radio.php
@@ -129,7 +129,7 @@ class Form_Field_Radio extends Form_Field_Checkbox {
     public function prepare_entry( $field ) {
         check_ajax_referer( 'wpuf_form_add' );
 
-        $val   = isset( $_POST[$field['name']] ) ? sanitize_text_field( wp_unslash( $_POST[$field['name']] ) ) : '';
+        $val   = isset( $_POST[$field['name']] ) ? strip_shortcodes( sanitize_text_field( wp_unslash( $_POST[$field['name']] ) ) ) : '';
 
         return isset( $field['options'][$val] ) ? $field['options'][$val] : '';
     }

--- a/includes/Fields/Form_Field_Text.php
+++ b/includes/Fields/Form_Field_Text.php
@@ -152,7 +152,7 @@ class Form_Field_Text extends Field_Contract {
     public function prepare_entry( $field ) {
         check_ajax_referer( 'wpuf_form_add' );
 
-        $value = isset( $_POST[ $field['name'] ] ) ? sanitize_text_field( wp_unslash( $_POST[ $field['name'] ] ) ) : '';
+        $value = isset( $_POST[ $field['name'] ] ) ? strip_shortcodes( sanitize_text_field( wp_unslash( $_POST[ $field['name'] ] ) ) ) : '';
         // return sanitize_text_field( trim( $_POST[$field['name']] ) );
         return $value;
     }

--- a/includes/Fields/Form_Field_Textarea.php
+++ b/includes/Fields/Form_Field_Textarea.php
@@ -189,7 +189,7 @@ class Form_Field_Textarea extends Field_Contract {
                <?php if ( ! $hide_label ) : ?>
                     <label><?php echo esc_html( $field['label'] ); ?>:</label>
                 <?php endif; ?>
-               <?php echo wp_kses_post( wpautop( make_clickable( $data ) ) ); ?>
+               <?php echo wp_kses_post( wpautop( make_clickable( strip_shortcodes( $data ) ) ) ); ?>
             </li>
          <?php
             return ob_get_clean();
@@ -206,6 +206,6 @@ class Form_Field_Textarea extends Field_Contract {
       * @return string
       */
     public function sanitize_field_data( $data, $field ) {
-        return wp_kses_post( $data );
+        return strip_shortcodes( wp_kses_post( $data ) );
     }
 }

--- a/includes/Fields/Form_Field_Textarea.php
+++ b/includes/Fields/Form_Field_Textarea.php
@@ -157,7 +157,7 @@ class Form_Field_Textarea extends Field_Contract {
     public function prepare_entry( $field ) {
         check_ajax_referer( 'wpuf_form_add' );
 
-        $field = isset( $_POST[ $field['name'] ] ) ? sanitize_text_field( wp_unslash( $_POST[ $field['name'] ] ) ) : '';
+        $field = isset( $_POST[ $field['name'] ] ) ? strip_shortcodes( sanitize_text_field( wp_unslash( $_POST[ $field['name'] ] ) ) ) : '';
         return trim( $field );
     }
 

--- a/includes/Fields/Form_Field_URL.php
+++ b/includes/Fields/Form_Field_URL.php
@@ -115,7 +115,7 @@ class Form_Field_URL extends Form_Field_Text {
     public function prepare_entry( $field ) {
         check_ajax_referer( 'wpuf_form_add' );
 
-        $field = isset( $_POST[ $field['name'] ] ) ? sanitize_text_field( wp_unslash( $_POST[ $field['name'] ] ) ) : '';
+        $field = isset( $_POST[ $field['name'] ] ) ? strip_shortcodes( sanitize_text_field( wp_unslash( $_POST[ $field['name'] ] ) ) ) : '';
         return esc_url( trim( $field ) );
     }
 

--- a/includes/Frontend_Render_Form.php
+++ b/includes/Frontend_Render_Form.php
@@ -118,6 +118,11 @@ class Frontend_Render_Form {
      * @return void
      */
     public function preview_form() {
+        // Security: Check user has proper admin capabilities
+        if ( ! current_user_can( wpuf_admin_role() ) ) {
+            wp_send_json_error( __( 'Unauthorized operation', 'wp-user-frontend' ) );
+        }
+
         $form_id = isset( $_GET['form_id'] ) ? intval( wp_unslash( $_GET['form_id'] ) ) : 0;
 
         if ( $form_id ) {

--- a/includes/Traits/FieldableTrait.php
+++ b/includes/Traits/FieldableTrait.php
@@ -589,9 +589,9 @@ trait FieldableTrait {
                 $meta_key_value[ $value['name'] ] = $wpuf_field->sanitize_field_data( $posted_field_data, $value );
                 continue;
             } elseif ( isset( $post_data[ $value['name'] ] ) && is_array( $post_data[ $value['name'] ] ) ) {
-                $value_name = isset( $post_data[ $value['name'] ] ) ? array_map( 'sanitize_text_field', wp_unslash( $post_data[ $value['name'] ] ) ) : '';
+                $value_name = isset( $post_data[ $value['name'] ] ) ? array_map( function( $item ) { return strip_shortcodes( sanitize_text_field( $item ) ); }, wp_unslash( $post_data[ $value['name'] ] ) ) : '';
             } else {
-                $value_name = isset( $post_data[ $value['name'] ] ) ? sanitize_text_field( wp_unslash( $post_data[ $value['name'] ] ) ) : '';
+                $value_name = isset( $post_data[ $value['name'] ] ) ? strip_shortcodes( sanitize_text_field( wp_unslash( $post_data[ $value['name'] ] ) ) ) : '';
             }
 
             if ( isset( $post_data['wpuf_files'][ $value['name'] ] ) ) {
@@ -635,13 +635,13 @@ trait FieldableTrait {
                                     if ( in_array( $inner_field['template'], [ 'checkbox_field', 'multiple_select' ] ) ) {
                                         // For checkbox and multiselect, keep as array and sanitize each element
                                         if ( is_array( $row[ $fname ] ) ) {
-                                            $sanitized_row[ $fname ] = array_map( 'sanitize_text_field', $row[ $fname ] );
+                                            $sanitized_row[ $fname ] = array_map( function( $item ) { return strip_shortcodes( sanitize_text_field( $item ) ); }, $row[ $fname ] );
                                         } else {
-                                            $sanitized_row[ $fname ] = sanitize_text_field( $row[ $fname ] );
+                                            $sanitized_row[ $fname ] = strip_shortcodes( sanitize_text_field( $row[ $fname ] ) );
                                         }
                                     } else {
                                         // For other fields, sanitize as string
-                                        $sanitized_row[ $fname ] = sanitize_text_field( $row[ $fname ] );
+                                        $sanitized_row[ $fname ] = strip_shortcodes( sanitize_text_field( $row[ $fname ] ) );
                                     }
                                 } else {
                                     $sanitized_row[ $fname ] = '';

--- a/wpuf-functions.php
+++ b/wpuf-functions.php
@@ -1202,15 +1202,15 @@ function wpuf_show_custom_fields( $content ) {
                                     // Handle different field types
                                     if ( 'checkbox' === $inner_field['input_type'] && is_array( $inner_field_value ) ) {
                                         // For checkbox fields, join multiple values
-                                        $repeat_html .= '<span>' . make_clickable( implode( ', ', $inner_field_value ) ) . '</span>';
+                                        $repeat_html .= '<span>' . make_clickable( strip_shortcodes( implode( ', ', $inner_field_value ) ) ) . '</span>';
                                     } elseif ( 'multiselect' === $inner_field['input_type'] && is_array( $inner_field_value ) ) {
-                                        $repeat_html .= '<span>' . make_clickable( implode( ', ', $inner_field_value ) ) . '</span>';
+                                        $repeat_html .= '<span>' . make_clickable( strip_shortcodes( implode( ', ', $inner_field_value ) ) ) . '</span>';
                                     } elseif ( 'radio' === $inner_field['input_type'] || 'select' === $inner_field['input_type'] ) {
                                         // For radio and select fields, display single value
-                                        $repeat_html .= '<span>' . make_clickable( $inner_field_value ) . '</span>';
+                                        $repeat_html .= '<span>' . make_clickable( strip_shortcodes( $inner_field_value ) ) . '</span>';
                                     } else {
                                         // For text and other fields
-                                        $repeat_html .= '<span>' . make_clickable( $inner_field_value ) . '</span>';
+                                        $repeat_html .= '<span>' . make_clickable( strip_shortcodes( $inner_field_value ) ) . '</span>';
                                     }
 
                                     $repeat_html .= '</li>';
@@ -1279,7 +1279,7 @@ function wpuf_show_custom_fields( $content ) {
                         $html .= '<label>' . $attr['label'] . ':</label>';
                     }
 
-                    $html .= sprintf( ' %s</li>', make_clickable( $value ) );
+                    $html .= sprintf( ' %s</li>', make_clickable( strip_shortcodes( $value ) ) );
                     break;
 
                 case 'country_list':
@@ -1297,7 +1297,7 @@ function wpuf_show_custom_fields( $content ) {
                         $html .= '<label>' . $attr['label'] . ':</label>';
                     }
 
-                    $html .= sprintf( ' %s</li>', make_clickable( $value ) );
+                    $html .= sprintf( ' %s</li>', make_clickable( strip_shortcodes( $value ) ) );
                     break;
 
                 default:
@@ -1318,7 +1318,7 @@ function wpuf_show_custom_fields( $content ) {
                                 $html .= '<label>' . $attr['label'] . ':</label>';
                             }
 
-                            $html .= sprintf( ' %s</li>', make_clickable( $modified_value ) );
+                            $html .= sprintf( ' %s</li>', make_clickable( strip_shortcodes( $modified_value ) ) );
                         }
                     } elseif ( ( 'checkbox' === $attr['input_type'] || 'multiselect' === $attr['input_type'] ) && is_array( $value[0] ) ) {
                         if ( ! empty( $value[0] ) ) {
@@ -1331,7 +1331,7 @@ function wpuf_show_custom_fields( $content ) {
                                     $html .= '<label>' . $attr['label'] . ':</label>';
                                 }
 
-                                $html .= sprintf( ' %s</li>', make_clickable( $modified_value ) );
+                                $html .= sprintf( ' %s</li>', make_clickable( strip_shortcodes( $modified_value ) ) );
                             }
                         }
                     } else {
@@ -1344,7 +1344,7 @@ function wpuf_show_custom_fields( $content ) {
                                 $html .= '<label>' . $attr['label'] . ':</label>';
                             }
 
-                            $html .= sprintf( ' %s</li>', make_clickable( $new ) );
+                            $html .= sprintf( ' %s</li>', make_clickable( strip_shortcodes( $new ) ) );
                         }
                     }
 
@@ -1519,7 +1519,7 @@ function wpuf_meta_shortcode( $atts ) {
     } elseif ( 'normal' === $type ) {
         return implode( ', ', get_post_meta( $post->ID, $name ) );
     } else {
-        return make_clickable( implode( ', ', get_post_meta( $post->ID, $name ) ) );
+        return make_clickable( strip_shortcodes( implode( ', ', get_post_meta( $post->ID, $name ) ) ) );
     }
 }
 


### PR DESCRIPTION
Security: Fix capability checks & shortcode execution vuln Close [issue](https://github.com/weDevsOfficial/wpuf-pro/issues/1173) , close  [issue](https://github.com/weDevsOfficial/wpuf-pro/issues/1163), Related PRO [PR](https://github.com/weDevsOfficial/wpuf-pro/pull/1182)

This patch addresses multiple critical vulnerabilities in WP User Frontend v4.1.12:

1. Arbitrary Shortcode Execution (CVE-TBD)
   - File: includes/Frontend/Form_Preview.php
   - Fix: Added wpuf_admin_role() checks in constructor and the_content()
     with absint() validation

2. Missing Capability Check in AJAX Preview
   - File: includes/Frontend_Render_Form.php
   - Fix: Added wpuf_admin_role() check to preview_form() handler

3. Unauthorized Form Import
   - File: includes/Admin/Admin_Tools.php
   - Fix: Added wpuf_admin_role() capability check with HTTP 403 response

4. Information Disclosure via get_roles()
   - File: includes/Ajax/Admin_Form_Builder_Ajax.php
   - Fix: Added check_ajax_referer() + wpuf_admin_role() check

Security improvements:
- Replaced intval() with absint() for safer validation
- Defense-in-depth with multiple capability checks
- Proper HTTP 403 responses for unauthorized requests
- Clearer error messages

Testing:
- All admin functions validate wpuf_admin_role()
- Form preview restricted to admins
- AJAX handlers now enforce nonce + capability checks
- Input sanitization verified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted admin-only flows (imports, role retrieval, preview rendering, preview API) to authorized users and added nonce check for role retrieval.
  * Enforced post existence and edit-permission checks before post updates; clear errors on denial.
  * Validated preview form IDs and return explicit errors for invalid/unauthorized access.
  * Consistently strip shortcodes from field input and output to prevent unexpected frontend content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->