### PR TITLE
fix: show subscription plan in field options

### DIFF
--- a/admin/form-builder/assets/js/components/field-visibility/template.php
+++ b/admin/form-builder/assets/js/components/field-visibility/template.php
@@ -92,7 +92,7 @@
     	<ul>
     		<?php
 
-                if ( class_exists( 'WPUF_Subscription' ) ) {
+                if ( class_exists( 'WeDevs\Wpuf\Admin\Subscription' ) ) {
                     $subscriptions  = wpuf()->subscription->get_subscriptions();
 
                     if ( $subscriptions ) {

--- a/assets/js-templates/form-components.php
+++ b/assets/js-templates/form-components.php
@@ -739,7 +739,7 @@
     	<ul>
     		<?php
 
-                if ( class_exists( 'WPUF_Subscription' ) ) {
+                if ( class_exists( 'WeDevs\Wpuf\Admin\Subscription' ) ) {
                     $subscriptions  = wpuf()->subscription->get_subscriptions();
 
                     if ( $subscriptions ) {


### PR DESCRIPTION
fixes [#1178](https://github.com/weDevsOfficial/wpuf-pro/issues/1178)

In Post Forms > Field Options > Visibility, selecting the `Subscription users only` option will now let the user select the subscription pack. Only the selected subscription pack holder will see this field in the frontend.

<img width="586" height="309" alt="CleanShot 2025-10-20 at 11 08 26" src="https://github.com/user-attachments/assets/d6eefe48-1e2f-4282-9e5a-c16c7549bdb2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized internal class references to improve code organization and consistency. Subscription management functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->