### PR TITLE
fix: correctly detect ACF taxonomies by checking post_content

### DIFF
--- a/includes/Admin/Forms/Admin_Form_Builder.php
+++ b/includes/Admin/Forms/Admin_Form_Builder.php
@@ -517,21 +517,21 @@ class Admin_Form_Builder {
             return $form_fields;
         }
 
-        // Get free taxonomies (built-in + ACF taxonomies)
+        // Get free taxonomies (built-in + taxonomies for post/page)
         $free_taxonomies = wpuf_get_free_taxonomies();
 
-        // Filter out custom taxonomy fields (excluding ACF taxonomies)
+        // Filter out custom taxonomy fields that are not in the free list
         $filtered_fields = array();
 
         foreach ( $form_fields as $field ) {
-            // Skip custom taxonomy fields when pro is not active (but keep ACF taxonomies)
+            // Skip custom taxonomy fields when pro is not active
             if ( isset( $field['input_type'] ) && $field['input_type'] === 'taxonomy' ) {
                 if ( isset( $field['name'] ) && ! in_array( $field['name'], $free_taxonomies, true ) ) {
-                    continue; // Skip this custom taxonomy field (not ACF)
+                    continue; // Skip this custom taxonomy field
                 }
             }
 
-            // Keep all other fields including built-in and ACF taxonomies
+            // Keep all other fields including built-in taxonomies
             $filtered_fields[] = $field;
         }
 
@@ -549,7 +549,7 @@ class Admin_Form_Builder {
         if ( wpuf_is_pro_active() ) {
             return false;
         }
-        // Get free taxonomies (built-in + ACF taxonomies)
+        // Get free taxonomies (built-in + taxonomies for post/page)
         $free_taxonomies = wpuf_get_free_taxonomies();
         $stack = is_array($original_fields) ? $original_fields : [];
         while ( $stack ) {
@@ -591,7 +591,7 @@ class Admin_Form_Builder {
         }
 
         $hidden_ids = array();
-        // Get free taxonomies (built-in + ACF taxonomies)
+        // Get free taxonomies (built-in + taxonomies for post/page)
         $free_taxonomies = wpuf_get_free_taxonomies();
 
         // Extract IDs from filtered fields for quick lookup
@@ -602,7 +602,7 @@ class Admin_Form_Builder {
             }
         }
 
-        // Find original fields that are custom taxonomy fields and were filtered out (excluding ACF)
+        // Find original fields that are custom taxonomy fields and were filtered out
         foreach ( $original_fields as $field ) {
             if ( isset( $field['input_type'] ) && $field['input_type'] === 'taxonomy' ) {
                 if ( isset( $field['name'] ) && ! in_array( $field['name'], $free_taxonomies, true ) ) {

--- a/includes/Fields/Form_Field_Post_Taxonomy.php
+++ b/includes/Fields/Form_Field_Post_Taxonomy.php
@@ -47,10 +47,10 @@ class Form_Field_Post_Taxonomy extends Field_Contract {
      * @return bool
      */
     public function is_pro() {
-        // Get free taxonomies (built-in + ACF taxonomies)
+        // Get free taxonomies (built-in + taxonomies for post/page)
         $free_taxonomies = wpuf_get_free_taxonomies();
-        
-        // If this is a custom taxonomy (not built-in or ACF) and pro is not active, treat it as a pro feature
+
+        // If this is a custom taxonomy (not in free list) and pro is not active, treat it as a pro feature
         if ( ! in_array( $this->tax_name, $free_taxonomies, true ) && ! wpuf_is_pro_active() ) {
             return true;
         }
@@ -69,12 +69,12 @@ class Form_Field_Post_Taxonomy extends Field_Contract {
      * @return void
      */
     public function render( $field_settings, $form_id, $type = 'post', $post_id = null ) {
-        // Check if this is a custom taxonomy and pro is not active (excluding ACF taxonomies)
+        // Check if this is a custom taxonomy and pro is not active
         $free_taxonomies = wpuf_get_free_taxonomies();
         $taxonomy_name = isset( $field_settings['name'] ) ? $field_settings['name'] : $this->tax_name;
-        
+
         if ( ! in_array( $taxonomy_name, $free_taxonomies, true ) && ! wpuf_is_pro_active() ) {
-            // Don't render custom taxonomies on frontend when pro is not active (ACF taxonomies are allowed)
+            // Don't render custom taxonomies on frontend when pro is not active
             return;
         }
 

--- a/includes/Render_Form.php
+++ b/includes/Render_Form.php
@@ -1340,7 +1340,7 @@ class Render_Form {
             return false;
         }
         
-        // Get free taxonomies (built-in + ACF taxonomies)
+        // Get free taxonomies (built-in + taxonomies for post/page)
         $free_taxonomies = wpuf_get_free_taxonomies();
         return ! in_array( $form_field['name'], $free_taxonomies, true );
     }
@@ -1352,10 +1352,10 @@ class Render_Form {
      * @param int|null $post_id
      */
     public function taxonomy( $attr, $post_id, $form_id ) {
-        // Check if this is a custom taxonomy and pro is not active (excluding ACF taxonomies)
+        // Check if this is a custom taxonomy and pro is not active
         $free_taxonomies = wpuf_get_free_taxonomies();
         if ( ! in_array( $attr['name'], $free_taxonomies, true ) && ! wpuf_is_pro_active() ) {
-            // Don't render custom taxonomies when pro is not active (ACF taxonomies are allowed)
+            // Don't render custom taxonomies when pro is not active
             return;
         }
 

--- a/wpuf-functions.php
+++ b/wpuf-functions.php
@@ -5762,7 +5762,7 @@ if ( ! function_exists( 'wpuf_field_profile_photo_allowed_mimes' ) ) {
 /**
  * Get taxonomy object types (post types the taxonomy is associated with)
  *
- * This works for all taxonomies - built-in, custom, ACF, or any other.
+ * This works for all taxonomies - built-in or custom.
  *
  * @since WPUF_SINCE
  *
@@ -5795,7 +5795,7 @@ if ( ! function_exists( 'wpuf_get_taxonomy_post_types' ) ) {
 /**
  * Get list of taxonomies that should be available in free version
  *
- * This includes built-in taxonomies and ACF-registered taxonomies.
+ * This includes built-in taxonomies and custom taxonomies associated with 'post' or 'page' post types.
  *
  * @since WPUF_SINCE
  *


### PR DESCRIPTION
fix: correctly detect ACF taxonomies by checking post_content

The wpuf_is_acf_taxonomy() function was incorrectly checking the post_name
field when querying for ACF-registered taxonomies. ACF stores the actual
taxonomy slug in the serialized post_content under the 'taxonomy' key,
while post_name contains ACF's internal identifier (e.g., 'taxonomy_69242380c35d7').

Changes:
- Modified database query to fetch all acf-taxonomy posts
- Added loop to unserialize post_content and check taxonomy key
- ACF taxonomies now properly detected as free fields
- Removed PRO badge from ACF taxonomy fields in form builder

This ensures ACF custom taxonomies are available in the free version
without requiring PRO upgrade, as they are user-created content.

Close #1672 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ACF and other non-built-in taxonomies are now included in the free taxonomy set, so they render and can be selected without Pro.
  * Taxonomy visibility/filtering for non‑Pro users updated to preserve these taxonomies when listing or filtering fields.
  * Added utilities to build and expose the free-taxonomy list used by the UI.

* **Chores**
  * Minor array/format refactors for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->