### PR TITLE
enhance: warning message for empty field options

### DIFF
--- a/admin/form-builder/assets/js/components/field-options/template.php
+++ b/admin/form-builder/assets/js/components/field-options/template.php
@@ -1,8 +1,6 @@
 <div class="wpuf-form-builder-field-options">
     <div v-if="!parseInt(editing_field_id)" class="options-fileds-section text-center">
-        <p>
-            <span class="loader"></span>
-        </p>
+        <p class="wpuf-text-gray-500 wpuf-text-lg wpuf-font-medium">{{ i18n.empty_field_options_msg }}</p>
     </div>
 
     <div v-else>

--- a/admin/form-builder/assets/js/form-builder.js
+++ b/admin/form-builder/assets/js/form-builder.js
@@ -404,6 +404,7 @@
             delete_form_field_element: function (state, index) {
                 state.current_panel = 'form-fields-v4-1';
                 state.form_fields.splice(index, 1);
+                state.editing_field_id = 0;
             },
 
             // set fields for a panel section

--- a/admin/form-builder/views/form-builder-v4.1.php
+++ b/admin/form-builder/views/form-builder-v4.1.php
@@ -176,7 +176,7 @@
                     </div>
                 </section>
             </div>
-    </div>
+        </div>
     </div>
     <div
         v-show="active_tab === 'form-settings'"

--- a/assets/js-templates/form-components.php
+++ b/assets/js-templates/form-components.php
@@ -509,9 +509,7 @@
 <script type="text/x-template" id="tmpl-wpuf-field-options">
 <div class="wpuf-form-builder-field-options">
     <div v-if="!parseInt(editing_field_id)" class="options-fileds-section text-center">
-        <p>
-            <span class="loader"></span>
-        </p>
+        <p class="wpuf-text-gray-500 wpuf-text-lg wpuf-font-medium">{{ i18n.empty_field_options_msg }}</p>
     </div>
 
     <div v-else>

--- a/assets/js/wpuf-form-builder.js
+++ b/assets/js/wpuf-form-builder.js
@@ -404,6 +404,7 @@
             delete_form_field_element: function (state, index) {
                 state.current_panel = 'form-fields-v4-1';
                 state.form_fields.splice(index, 1);
+                state.editing_field_id = 0;
             },
 
             // set fields for a panel section

--- a/includes/Admin/Forms/Admin_Form_Builder.php
+++ b/includes/Admin/Forms/Admin_Form_Builder.php
@@ -346,6 +346,7 @@ class Admin_Form_Builder {
                 'saved_form_data'         => __( 'Saved form data', 'wp-user-frontend' ),
                 'unsaved_changes'         => __( 'You have unsaved changes.', 'wp-user-frontend' ),
                 'copy_shortcode'          => __( 'Click to copy shortcode', 'wp-user-frontend' ),
+                'empty_field_options_msg' => __( 'To view field options, please start adding fields in the builder', 'wp-user-frontend' ),
                 'pro_field_message'       => $field_messages,
             ]
         );


### PR DESCRIPTION
fixes [#1016](https://github.com/weDevsOfficial/wpuf-pro/issues/1016)

## Summary

This PR improves the form builder UX by replacing the loading spinner with a clear instructional message when there is no field in the form builder editing panel. Users now see helpful guidance instead of a generic loader.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the currently selected field wasn't cleared after deletion, preventing proper state reset.

* **New Features**
  * Replaced the loading indicator with a helpful text message when no field is selected for editing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->