### PR TITLE
fix: Add italic, underline, and bold styling to Settings link in field validators

### DIFF
--- a/includes/Fields/Form_Field_Cloudflare_Turnstile.php
+++ b/includes/Fields/Form_Field_Cloudflare_Turnstile.php
@@ -77,7 +77,7 @@ class Form_Field_Cloudflare_Turnstile extends Field_Contract {
                 __( 'Site key and Secret key', 'wp-user-frontend' )
             ),
             'msg' => sprintf(
-                '<span class="wpuf-text-xl wpuf-text-gray-500">%1$s <a class="wpuf-text-primary" href="%2$s" target="_blank">%3$s</a> %4$s <a class="wpuf-text-primary" href="%5$s" target="_blank">%6$s</a></span>',
+                '<span class="wpuf-text-xl wpuf-text-gray-500">%1$s <a class="wpuf-text-primary wpuf-italic wpuf-font-bold" style="text-decoration: underline;" href="%2$s" target="_blank">%3$s</a> %4$s <a class="wpuf-text-primary" href="%5$s" target="_blank">%6$s</a></span>',
                 __( 'You need to set Site key and Secret key in', 'wp-user-frontend' ),
                 admin_url( 'admin.php?page=wpuf-settings' ),
                 __( 'Settings', 'wp-user-frontend' ),

--- a/includes/Fields/Form_Field_reCaptcha.php
+++ b/includes/Fields/Form_Field_reCaptcha.php
@@ -129,7 +129,7 @@ class Form_Field_reCaptcha extends Field_Contract {
             'msg_title'     => __( 'Site key and Secret key', 'wp-user-frontend' ),
             'msg'           => sprintf(
                 // translators: %1$s wpuf admin settings url and %2$s is recaptcha url
-                __( 'You need to set Site key and Secret key in <a href="%1$s" target="_blank">Settings</a> in order to use "Recaptcha" field. <a href="%2$s" target="_blank">Click here to get the these key</a>.', 'wp-user-frontend' ),
+                __( 'You need to set Site key and Secret key in <a class="wpuf-text-primary wpuf-italic wpuf-font-bold" style="text-decoration: underline;" href="%1$s" target="_blank">Settings</a> in order to use "Recaptcha" field. <a class="wpuf-text-primary" href="%2$s" target="_blank">Click here to get the these key</a>.', 'wp-user-frontend' ),
                 admin_url( 'admin.php?page=wpuf-settings' ),
                 __( 'Settings', 'wp-user-frontend' ),
                 __( 'in order to use "Recaptcha" field.', 'wp-user-frontend' ),

--- a/wpuf-functions.php
+++ b/wpuf-functions.php
@@ -5455,7 +5455,7 @@ function wpuf_get_post_form_builder_setting_menu_contents() {
                 'label'   => __( 'Payment Success Page', 'wp-user-frontend' ),
                 'type'    => 'select',
                 'options' => $pages,
-                'help'    => __( 'Select the page users will be redirected to after a successful payment', 'wp-user-frontend' ),
+                'help_text'    => __( 'Select the page to redirect after successful payment.', 'wp-user-frontend' ),
             ],
         ]
     );
@@ -5474,7 +5474,7 @@ function wpuf_get_post_form_builder_setting_menu_contents() {
                         'new'         => [
                             'label' => __( 'New Post Notification', 'wp-user-frontend' ),
                             'type'  => 'toggle',
-                            'help'  => __( 'Enable email alerts for each new post submitted through this form', 'wp-user-frontend' ),
+                            'help_text'  => __( 'Enable email alerts for new submissions through this form', 'wp-user-frontend' ),
                             'name'  => 'wpuf_settings[notification][new]',
                         ],
                         'new_to'      => [


### PR DESCRIPTION
## Summary
Added consistent styling (italic, underlined, bold) to the "Settings" link in validator messages for Cloudflare Turnstile and reCaptcha fields, and added the primary color class for consistent link styling.

## Changes

### 1. `includes/Fields/Form_Field_Cloudflare_Turnstile.php`
- Added `wpuf-italic`, `wpuf-font-bold` classes and inline `style="text-decoration: underline;"` to the "Settings" link
- Link now displays with italic, bold, underlined styling in the primary (green) color

### 2. `includes/Fields/Form_Field_reCaptcha.php`
- Added `wpuf-text-primary`, `wpuf-italic`, `wpuf-font-bold` classes and inline `style="text-decoration: underline;"` to the "Settings" link
- Added `wpuf-text-primary` class to the "Click here to get the these key" link (was showing blue, now shows green)
- Both links now have consistent primary color styling

### 3. `wpuf-functions.php`
- Changed `help` to `help_text` for "Payment Success Page" field
- Changed `help` to `help_text` for "New Post Notification" field
- Updated help text wording for better clarity

## Why
- To improve visual emphasis on the Settings link in validator messages
- To maintain consistent styling across both Cloudflare Turnstile and reCaptcha field types
- To fix the blue color issue on reCaptcha links (now uses primary green color)

## Testing
1. Go to Form Builder
2. Add a "Cloudflare Turnstile" or "reCaptcha" field without configuring API keys in settings
3. Verify the "Settings" link appears with italic, underlined, and bold styling in green color

##Close [844](https://github.com/weDevsOfficial/wpuf-pro/issues/844)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the visual styling of validation message links in Cloudflare Turnstile and reCaptcha field integrations with improved formatting.

* **Documentation**
  * Refined help text descriptions for Payment Success Page and New Post Notification form builder settings with clearer, more concise wording.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->