### PR TITLE
enhance: login register help text

### DIFF
--- a/includes/Free/Simple_Login.php
+++ b/includes/Free/Simple_Login.php
@@ -320,8 +320,9 @@ class Simple_Login {
         $links = [];
 
         if ( $args['login'] ) {
-            $links[] = /* translators: %1$s: login URL, %2$s: login text */
+            $links[] =
                     sprintf(
+                        /* translators: %1$s: login URL, %2$s: login text */
                         wp_kses_post( __( 'Already have an account? <a href="%1$s">%2$s</a>', 'wp-user-frontend' ) ),
                         esc_url( $this->get_action_url( 'login' ) ),
                         esc_html( __( 'Login', 'wp-user-frontend' ) )


### PR DESCRIPTION
related PR in pro [#1329](https://github.com/weDevsOfficial/wpuf-pro/pull/1329)
closes [#1317](https://github.com/weDevsOfficial/wpuf-pro/issues/1317) 

Add **text and login option**:


Already have an account? [Log In](url)

<img width="766" height="305" alt="Image" src="https://github.com/user-attachments/assets/64f0aac5-a425-4dc5-bfa9-d1df65bedb90" />


---

Add **text:** 

Don’t have an account? [Register](url)


<img width="1104" height="526" alt="Image" src="https://github.com/user-attachments/assets/76b70262-2844-4e45-887c-9e71a3f956f6" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved authentication prompts: the login link is now prefixed with "Already have an account?" and the register link is prefixed with "Don't have an account?" and wrapped with additional markup to support styling and accessibility. The forgotten-password flow and underlying behavior remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->