### PR TITLE
fix: Add authorization checks for attachment deletion in form submission

### DIFF
--- a/includes/Ajax/Frontend_Form_Ajax.php
+++ b/includes/Ajax/Frontend_Form_Ajax.php
@@ -159,10 +159,6 @@ class Frontend_Form_Ajax {
             if ( $post_id_for_edit > 0 ) {
                 $attachment_parent = (int) $attachment->post_parent;
 
-                // Allow deletion only if:
-                // 1. Attachment is orphaned (post_parent = 0) - likely from current upload session
-                // 2. Attachment is attached to the post being edited
-                // 3. User has capability to delete others' posts (admin)
                 if ( $attachment_parent !== 0 && $attachment_parent !== $post_id_for_edit && ! $can_delete_others ) {
                     continue;
                 }


### PR DESCRIPTION
Close [1335](https://github.com/weDevsOfficial/wpuf-pro/issues/1335)

<html><head></head><body><h2>🔐 Security Fix: Prevent Unauthorized Attachment Deletion</h2><h3>Summary</h3><p>This PR fixes a critical authorization vulnerability in attachment deletion during frontend form submission. Previously, attachments could be deleted without verifying user authentication, ownership, or capabilities—allowing unauthenticated users to delete arbitrary media library items by ID.</p><h3>🐛 Security Issue</h3><p>The <code inline="">submit_post()</code> method in <code inline="">Frontend_Form_Ajax.php</code> processed <code inline="">delete_attachments[]</code> without validating user permissions.<br>As a result, unauthenticated or unauthorized users could delete any attachment if they knew the attachment ID.</p><h3>✅ Fix Implemented</h3><p>The following safeguards have been added before calling <code inline="">wp_delete_attachment()</code>:</p><ul><li><p>Ensure the attachment exists and is a valid attachment type</p></li><li><p>Block all deletion attempts from unauthenticated users (<code inline="">user_id === 0</code>)</p></li><li><p>Allow deletion only if:</p><ul><li><p>The current user is the attachment owner, <strong>or</strong></p></li><li><p>The user has the <code inline="">delete_others_posts</code> capability</p></li></ul></li><li><p>Validate attachment–post relationship when editing an existing post</p></li><li><p>Prevent deletion of attachments belonging to different posts</p></li></ul><h3>🧪 Test Plan</h3><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Unauthenticated users cannot delete attachments</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Regular users cannot delete other users’ attachments</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Owners can delete their own attachments</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Admins can delete any attachment</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> Users cannot delete attachments from different posts</p></li></ul>



<h3>✅ Conclusion</h3><p>This patch fully mitigates the attachment deletion vulnerability by enforcing proper authentication, ownership, and capability checks.<br>All identified attack vectors are now secured.</p><hr></ul></body></html>



<h2 style="margin-top: 0px; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(0, 33, 43); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Security Test Results - All Tests Passed ✓</h2><p style="display: inline; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(0, 33, 43); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The security fix has been verified with comprehensive testing. Here's the summary:</p><span style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(0, 33, 43); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; display: inline !important; float: none;"></span><h3 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(0, 33, 43); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Test Results</h3>
Scenario | Before Fix | After Fix | Status
-- | -- | -- | --
Unauthenticated user deletion | ALLOWED ❌ | BLOCKED ✓ | PASS
Unauthorized user deletion | ALLOWED ❌ | BLOCKED ✓ | PASS
Owner deletes own attachment | ALLOWED ✓ | ALLOWED ✓ | PASS
Admin deletes any attachment | ALLOWED ✓ | ALLOWED ✓ | PASS
Cross-post attachment deletion | ALLOWED ❌ | BLOCKED ✓ | PASS

<h3 style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(0, 33, 43); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Key Findings</h3><p style="display: inline; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(0, 33, 43); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>Before the fix:</strong></p><span style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(0, 33, 43); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; display: inline !important; float: none;"></span><ul style="padding-inline-start: 1.5em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(0, 33, 43); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>The vulnerable code had<span> </span><strong>NO SECURITY CHECKS</strong><span> </span>- it would blindly delete any attachment ID passed in the<span> </span><code style="font-family: monospace; color: rgb(215, 186, 125); background-color: rgba(255, 255, 255, 0.1); padding: 2px 4px; border-radius: 3px; font-size: 0.9em; word-break: break-word;">delete_attachments</code><span> </span>array</li><li>Unauthenticated users could delete any media from the site</li><li>Any logged-in user could delete other users' attachments</li></ul><p style="display: inline; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(0, 33, 43); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong>After the fix:</strong></p><span style="color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(0, 33, 43); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; display: inline !important; float: none;"></span><ul style="padding-inline-start: 1.5em; color: rgb(204, 204, 204); font-family: -apple-system, &quot;system-ui&quot;, &quot;Segoe UI&quot;, Roboto, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(0, 33, 43); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li>Unauthenticated users (user ID 0) are completely blocked from deleting attachments</li><li>Regular users can only delete their own attachments</li><li>Administrators retain full control (can delete any attachment)</li><li>Post relationship is validated - users cannot delete attachments belonging to other posts while editing a specific post</li></ul><br class="Apple-interchange-newline">

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authorization checks for attachment deletion. Users must now have proper permissions or be the attachment author to delete attachments from posts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->