### PR TITLE
fix: resolve subscription post number rollback toggle not saving

### DIFF
--- a/Lib/Gateway/Paypal.php
+++ b/Lib/Gateway/Paypal.php
@@ -635,7 +635,7 @@ class Paypal {
                 'recurring' => 'yes',
                 'cycle_period' => $period,
                 'cycle_number' => $interval,
-                'postnum_rollback_on_delete' => isset( $pack_meta['postnum_rollback_on_delete'] ) && 'yes' === $pack_meta['postnum_rollback_on_delete'] ? 'yes' : '',
+                'postnum_rollback_on_delete' => isset( $pack_meta['postnum_rollback_on_delete'] ) ? $pack_meta['postnum_rollback_on_delete'] : '',
                 '_enable_post_expiration' => isset( $pack_meta['_enable_post_expiration'] ) ? $pack_meta['_enable_post_expiration'] : 'no',
                 '_post_expiration_time' => isset( $pack_meta['_post_expiration_time'] ) ? $pack_meta['_post_expiration_time'] : '',
                 '_expired_post_status' => isset( $pack_meta['_expired_post_status'] ) ? $pack_meta['_expired_post_status'] : 'publish',

--- a/includes/Admin/Admin_Subscription.php
+++ b/includes/Admin/Admin_Subscription.php
@@ -1339,6 +1339,7 @@ class Admin_Subscription {
                             'If enabled, number of posts will be restored if the post is deleted.', 'wp-user-frontend'
                         ),
                         'default' => false,
+                        'is_pro'  => true,
                     ],
                 ],
             ]

--- a/includes/Api/Subscription.php
+++ b/includes/Api/Subscription.php
@@ -460,7 +460,9 @@ class Subscription extends WP_REST_Controller {
             $subscription['meta_value']['_remove_feature_item']
         ) : '';
         $sort_order = ! empty( $subscription['meta_value']['_sort_order'] ) ? (int) $subscription['meta_value']['_sort_order'] : 1;
-        $postnum_rollback_on_delete = ! empty( $subscription['meta_value']['postnum_rollback_on_delete'] ) && 'yes' === $subscription['meta_value']['postnum_rollback_on_delete'] ? 'yes' : '';
+        $postnum_rollback_on_delete = ! empty( $subscription['meta_value']['postnum_rollback_on_delete'] ) ? sanitize_text_field(
+            $subscription['meta_value']['postnum_rollback_on_delete']
+        ) : '';
 
         // Process view restriction data
         $view_allowed_term_ids = ! empty( $subscription['meta_value']['_sub_view_allowed_term_ids'] ) 


### PR DESCRIPTION
fix: resolve subscription post number rollback toggle not saving
Close [1342](https://github.com/weDevsOfficial/wpuf-pro/issues/1342) 

The postnum_rollback_on_delete meta field was missing from the REST API
save handler in includes/Api/Subscription.php. Added extraction and
persistence of the field value when creating or updating subscriptions
via the Vue.js-based subscription editor.

- Added $postnum_rollback_on_delete variable extraction at line 463
- Added update_post_meta() call for postnum_rollback_on_delete at line 540
- Properly sanitized using sanitize_text_field()
- Fixes issue where toggle would revert to off after save/publish


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Subscription rollback flag is now read and reliably persisted across create, update and payment gateway flows so deletion rollback behavior is applied consistently.
* **Chores / Admin**
  * The post-number rollback option is now marked as a Pro-only admin field in subscription settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->