### PR TITLE
fix: remove exe from allowed file upload list

### DIFF
--- a/includes/AI/RestController.php
+++ b/includes/AI/RestController.php
@@ -1678,7 +1678,7 @@ class RestController extends WP_REST_Controller {
                     $field['count'] = '1';
                 }
                 if (!isset($field['extension'])) {
-                    $field['extension'] = ['images', 'audio', 'video', 'pdf', 'office', 'zip', 'exe', 'csv'];
+                    $field['extension'] = ['images', 'audio', 'video', 'pdf', 'office', 'zip', 'csv'];
                 }
             }
 

--- a/wpuf-functions.php
+++ b/wpuf-functions.php
@@ -554,10 +554,6 @@ function wpuf_allowed_extensions() {
             'ext' => 'zip,gz,gzip,rar,7z',
             'label' => __( 'Zip Archives', 'wp-user-frontend' ),
         ],
-        'exe'    => [
-            'ext' => 'exe',
-            'label' => __( 'Executable Files', 'wp-user-frontend' ),
-        ],
         'csv'    => [
             'ext' => 'csv',
             'label' => __( 'CSV', 'wp-user-frontend' ),


### PR DESCRIPTION
related PR [#1353](https://github.com/weDevsOfficial/wpuf-pro/pull/1353)

This PR removes executable files (.exe) from the list of allowed file types in the file upload field.

WordPress restricts file uploads by default to a whitelist of safe MIME types, such as common images (jpg, png), documents (pdf, doc), audio (mp3), and videos (mp4), blocking others for security reasons.
The "unfiltered_upload" capability allows bypassing these restrictions to upload any file type, but no user role, including `Administrator`, has this capability by default. As the `Administrator` is not getting the capability by default, we are also not allowing it from our end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled uploading of executable files (.exe extension) to enhance security and prevent potential malware uploads.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->