### PR TITLE
fix: format wording of plugin update notice

### DIFF
--- a/wpuf.php
+++ b/wpuf.php
@@ -260,8 +260,13 @@ final class WP_User_Frontend {
             <h2><?php esc_html_e( 'Your WP User Frontend Pro is almost ready!', 'wp-user-frontend' ); ?></h2>
             <p>
                 <?php
-                /* translators: 1: opening anchor tag, 2: closing anchor tag. */
-                echo sprintf( wp_kses_post( __( 'We\'ve pushed a major update on both <b>WP User Frontend Free</b> and <b>WP User Frontend Pro</b> that requires you to use latest version of both. Please update the WPUF pro to the latest version. <br><strong>Please make sure to take a complete backup of your site before updating.</strong>', 'wp-user-frontend' ), '<a target="_blank" href="https://wordpress.org/plugins/wp-user-frontend/">', '</a>' ) );
+                    echo wp_kses_post( 
+                        sprintf( 
+                            __( 'We\'ve pushed a major update on both <b>WP User Frontend Free</b> and <b>%1$sWP User Frontend Pro%2$s</b> that requires you to use latest version of both. Please update the WPUF pro to the latest version. <br><strong>Please make sure to take a complete backup of your site before updating.</strong>', 'wp-user-frontend' ),
+                            '<a target="_blank" href="https://wordpress.org/plugins/wp-user-frontend/">',
+                            '</a>'
+                        )
+                    );
                 ?>
             </p>
         </div>


### PR DESCRIPTION
fix #1785

This line appears to be incorrectly formatted:

https://github.com/weDevsOfficial/wp-user-frontend/blob/c7ed209fa9397ff1671d22d6f5b17f63b5e6640f/wpuf.php#L264

The line isn’t formatted correctly. The `wp_kses_post()` function only accepts one parameter, so the additional arguments passed to `sprintf()` are ignored. As a result, the string isn’t being processed as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated upgrade notice message formatting to improve link placement and readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->