### PR TITLE
Add Cloudflare Turnstile validation

### DIFF
--- a/includes/Fields/Form_Field_Cloudflare_Turnstile.php
+++ b/includes/Fields/Form_Field_Cloudflare_Turnstile.php
@@ -31,7 +31,7 @@ class Form_Field_Cloudflare_Turnstile extends Field_Contract {
         $size             = ! empty( $field_settings['turnstile_size'] ) ? $field_settings['turnstile_size'] : 'normal';
         $action           = ! empty( $field_settings['turnstile_type'] ) ? $field_settings['turnstile_type'] : 'non-interactive';
 
-        if ( wpuf_is_checkbox_or_toggle_on( $enable_turnstile ) || empty( $site_key ) ) {
+        if ( ! wpuf_is_checkbox_or_toggle_on( $enable_turnstile ) || empty( $site_key ) ) {
             return;
         }
 

--- a/includes/Traits/FieldableTrait.php
+++ b/includes/Traits/FieldableTrait.php
@@ -236,6 +236,14 @@ trait FieldableTrait {
         if ( $this->search( $post_vars, 'input_type', 'really_simple_captcha' ) ) {
             $this->validate_rs_captcha();
         }
+
+        // check Cloudflare Turnstile
+        $check_turnstile = $this->search( $this->form_fields, 'input_type', 'cloudflare_turnstile' );
+
+        if ( $check_turnstile ) {
+            $this->validate_cloudflare_turnstile();
+        }
+
         $no_captcha = '';
         $invisible_captcha = '';
         $recaptcha_type = '';
@@ -263,6 +271,60 @@ trait FieldableTrait {
                 }
             }
             $this->validate_re_captcha( $no_captcha, $invisible_captcha );
+        }
+    }
+
+    /**
+     * Cloudflare Turnstile validation
+     *
+     * @since 4.0.13
+     *
+     * @return void
+     */
+    public function validate_cloudflare_turnstile() {
+        $enable_turnstile = wpuf_get_option( 'enable_turnstile', 'wpuf_general', 'off' );
+
+        if ( ! wpuf_is_checkbox_or_toggle_on( $enable_turnstile ) ) {
+            return;
+        }
+
+        $secret = wpuf_get_option( 'turnstile_secret_key', 'wpuf_general', '' );
+
+        if ( empty( $secret ) ) {
+            return;
+        }
+
+        $token = ! empty( $_POST['cf-turnstile-response'] ) ? sanitize_text_field( wp_unslash( $_POST['cf-turnstile-response'] ) ) : '';
+
+        if ( empty( $token ) ) {
+            wpuf()->ajax->send_error( __( 'Cloudflare Turnstile verification failed. Please complete the challenge.', 'wp-user-frontend' ) );
+        }
+
+        $remote_addr = ! empty( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+
+        $response = wp_remote_post(
+            'https://challenges.cloudflare.com/turnstile/v0/siteverify',
+            [
+                'body' => [
+                    'secret'   => $secret,
+                    'response' => $token,
+                    'remoteip' => $remote_addr,
+                ],
+            ]
+        );
+
+        $body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+        if ( empty( $body['success'] ) ) {
+            $errors = ! empty( $body['error-codes'] ) ? implode( ', ', $body['error-codes'] ) : '';
+
+            wpuf()->ajax->send_error(
+                sprintf(
+                    // translators: %s is the error codes from Cloudflare
+                    __( 'Cloudflare Turnstile verification failed. Reasons: [%s]', 'wp-user-frontend' ),
+                    $errors
+                )
+            );
         }
     }
 


### PR DESCRIPTION
## Fix: Cloudflare Turnstile not working on post forms Close [1417](https://github.com/weDevsOfficial/wpuf-pro/issues/1417)

### Problem
Cloudflare Turnstile was not visible or functional on frontend post forms, even when configured in WP UF >> Settings with valid site/secret keys.

### Root Cause
Two bugs were identified:

1. **Inverted render condition** (`Form_Field_Cloudflare_Turnstile.php:34`) — The condition used `wpuf_is_checkbox_or_toggle_on()` without negation, causing the widget to be hidden when Turnstile was enabled and shown when disabled.

2. **Missing server-side validation** (`FieldableTrait.php`) — The `on_edit_no_check_recaptcha()` method only validated reCaptcha and Really Simple Captcha. Cloudflare Turnstile tokens were never verified against the Cloudflare API during post form submission.

### Changes
- **`includes/Fields/Form_Field_Cloudflare_Turnstile.php`** — Added `!` to the `wpuf_is_checkbox_or_toggle_on()` check so the widget renders when Turnstile is enabled.
- **`includes/Traits/FieldableTrait.php`** — Added `cloudflare_turnstile` detection in `on_edit_no_check_recaptcha()` and a new `validate_cloudflare_turnstile()` method that verifies the `cf-turnstile-response` token via the Cloudflare `siteverify` API (same pattern used in `Simple_Login.php` for login forms).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Cloudflare Turnstile rendering on forms.

* **New Features**
  * Added Cloudflare Turnstile validation to form submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->