### PR TITLE
Default field settings & daisyUI config cleanup

### DIFF
--- a/includes/AI/Field_Templates.php
+++ b/includes/AI/Field_Templates.php
@@ -299,6 +299,7 @@ class Field_Templates {
             'default' => '',
             'rows' => '5',
             'cols' => '25',
+            'rich' => 'no',
             'readonly' => 'no',
             'width' => 'large',
         ], self::get_common() );
@@ -317,6 +318,9 @@ class Field_Templates {
             'help' => '',
             'css' => '',
             'show_icon' => 'no',
+            'placeholder' => '',
+            'default' => '',
+            'size' => '40',
             'width' => 'large',
         ], self::get_common() );
     }

--- a/includes/Fields/Form_Field_Post_Excerpt.php
+++ b/includes/Fields/Form_Field_Post_Excerpt.php
@@ -38,7 +38,7 @@ class Form_Field_Post_Excerpt extends Field_Contract {
         <li <?php $this->print_list_attributes( $field_settings ); ?>>
             <?php $this->print_label( $field_settings, $form_id ); ?>
 
-            <?php if ( in_array( $field_settings['rich'], [ 'yes', 'teeny' ] ) ) { ?>
+            <?php if ( ! empty( $field_settings['rich'] ) && in_array( $field_settings['rich'], [ 'yes', 'teeny' ] ) ) { ?>
                 <div class="wpuf-fields wpuf-rich-validation <?php printf( 'wpuf_%s_%s', esc_attr( $field_settings['name'] ), esc_attr( $form_id ) ); ?>" data-type="rich" data-required="<?php echo esc_attr( $field_settings['required'] ); ?>" data-id="<?php echo esc_attr( $field_settings['name'] ) . '_' . esc_attr( $form_id ); ?>" data-name="<?php echo esc_attr( $field_settings['name'] ); ?>">
             <?php } else { ?>
                 <div class="wpuf-fields">
@@ -46,7 +46,7 @@ class Form_Field_Post_Excerpt extends Field_Contract {
 
                 <?php
 
-                if ( $field_settings['rich'] == 'yes' ) {
+                if ( ! empty( $field_settings['rich'] ) && $field_settings['rich'] == 'yes' ) {
                     $editor_settings = [
                         // 'textarea_rows' => $field_settings['rows'],
                         'quicktags'     => false,
@@ -57,7 +57,7 @@ class Form_Field_Post_Excerpt extends Field_Contract {
 
                     $editor_settings = apply_filters( 'wpuf_textarea_editor_args', $editor_settings );
                     wp_editor( $value, $textarea_id, $editor_settings );
-                } elseif ( $field_settings['rich'] == 'teeny' ) {
+                } elseif ( ! empty( $field_settings['rich'] ) && $field_settings['rich'] == 'teeny' ) {
                     $editor_settings = [
                         'textarea_rows' => $field_settings['rows'],
                         'quicktags'     => false,

--- a/includes/Fields/Form_Field_Post_Tags.php
+++ b/includes/Fields/Form_Field_Post_Tags.php
@@ -31,7 +31,7 @@ class Form_Field_Post_Tags extends Field_Contract {
             }
             $value = implode( ', ', $tagsarray );
         } else {
-            $value = $field_settings['default'];
+            $value = ! empty( $field_settings['default'] ) ? $field_settings['default'] : '';
         }
 
         $query_string = '?action=wpuf_ajax_tag_search&tax=post_tag';
@@ -49,9 +49,9 @@ class Form_Field_Post_Tags extends Field_Contract {
                     type="text"
                     data-required="<?php echo esc_attr( $field_settings['required'] ); ?>"
                     data-type="text" name="<?php echo esc_attr( $field_settings['name'] ); ?>"
-                    placeholder="<?php echo esc_attr( $field_settings['placeholder'] ); ?>"
+                    placeholder="<?php echo esc_attr( ! empty( $field_settings['placeholder'] ) ? $field_settings['placeholder'] : '' ); ?>"
                     value="<?php echo esc_attr( $value ); ?>"
-                    size="<?php echo esc_attr( $field_settings['size'] ); ?>"
+                    size="<?php echo esc_attr( ! empty( $field_settings['size'] ) ? $field_settings['size'] : 40 ); ?>"
                 />
 
                 <span class="wpuf-wordlimit-message wpuf-help"></span>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -50,11 +50,6 @@ module.exports = {
         } ),
     ],
     daisyui: {
-        themes: [],
-        base: false,
-        styled: true,
-        utils: true,
-        prefix: 'wpuf-',
-        logs: false,
+        themes: []
     },
 }


### PR DESCRIPTION
Add safe defaults and defensive checks for form field templates and inputs. Field_Templates.php now defines 'rich', 'placeholder', 'default', and 'size' defaults to avoid undefined indexes. Post excerpt field rendering (Form_Field_Post_Excerpt.php) uses !empty() guards before reading 'rich' to prevent warnings; editor selection logic also uses the same defensive checks. Post tags field (Form_Field_Post_Tags.php) falls back to an empty string for default, and guards placeholder and size with !empty() checks to ensure valid attributes. Tailwind config simplified: removed several daisyUI overrides and left only themes: [] to reduce custom config surface. These changes prevent PHP notices and ensure consistent behavior when settings are missing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and validation for post excerpt and post tags fields to prevent configuration-related issues and undefined property errors.
  * Enhanced default value, placeholder, and size attribute configuration for post tags fields for improved consistency.

* **Chores**
  * Simplified DaisyUI configuration settings by removing unnecessary styling, utility, and logging customizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->