### PR TITLE
Add wpuf-form-template-modal to Tailwind safelist

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -44,7 +44,8 @@ module.exports = {
                     '#wpuf-ai-form-builder',
                     '.wpuf-ai-form-wrapper',
                     '.swal2-container',
-                    '.wpuf-account-container'
+                    '.wpuf-account-container',
+                    '.wpuf-form-template-modal'
                 ], {}
             ),
         } ),


### PR DESCRIPTION
Include the '.wpuf-form-template-modal' selector in tailwind.config.js so its utility classes are preserved (e.g., for a dynamically injected form template modal). This prevents Tailwind's purge from removing styles used by the modal at runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated styling configuration to improve scoped style isolation for additional UI components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->