### PR TITLE
Ignore nested node_modules and delete postcss

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -190,7 +190,6 @@ module.exports = function( grunt) {
             main: {
                 src: [
                     '**',
-                    '!node_modules/**',
                     '!**/node_modules/**',
                     '!build/**',
                     '!admin/form-builder/assets/**',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -191,6 +191,7 @@ module.exports = function( grunt) {
                 src: [
                     '**',
                     '!node_modules/**',
+                    '!**/node_modules/**',
                     '!build/**',
                     '!admin/form-builder/assets/**',
                     '!assets/css/*.less',

--- a/modules/user-directory/postcss.config.js
+++ b/modules/user-directory/postcss.config.js
@@ -1,6 +1,0 @@
-module.exports = {
-    plugins: {
-        tailwindcss: {},
-        autoprefixer: {},
-    },
-};


### PR DESCRIPTION
Add an explicit '!**/node_modules/**' ignore pattern in Gruntfile.js so nested node_modules folders are excluded from file sets. Remove modules/user-directory/postcss.config.js (Tailwind + Autoprefixer) as the per-module PostCSS config is no longer required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Broadened exclusion of nested dependency directories during the build copy step to avoid including unnecessary files.
  * Removed PostCSS plugin configuration from the user-directory module, simplifying its build setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->