### PR TITLE
Bind cancel nonce to user and enforce ownership

### DIFF
--- a/class/subscription.php
+++ b/class/subscription.php
@@ -83,7 +83,12 @@ class WPUF_Subscription {
             $gateway     = isset( $_POST['gateway'] ) ? sanitize_text_field( wp_unslash( $_POST['gateway'] ) ) : 0;
             $request_uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 
-            if ( isset( $nonce ) && ! wp_verify_nonce( $nonce, 'wpuf-sub-cancel' ) ) {
+            if ( isset( $nonce ) && ! wp_verify_nonce( $nonce, 'wpuf-sub-cancel-' . $user_id ) ) {
+                return;
+            }
+
+            // Ensure the user can only cancel their own subscription
+            if ( $user_id !== get_current_user_id() && ! current_user_can( wpuf_admin_role() ) ) {
                 return;
             }
 
@@ -893,7 +898,7 @@ class WPUF_Subscription {
             <?php echo '<p><i>' . esc_html__( 'To cancel the pack, press the following cancel button', 'wp-user-frontend' ) . '</i></p>'; ?>
 
             <form action="" id="wpuf_cancel_subscription" method="post">
-                <?php wp_nonce_field( 'wpuf-sub-cancel' ); ?>
+                <?php wp_nonce_field( 'wpuf-sub-cancel-' . get_current_user_id() ); ?>
                 <input type="hidden" name="user_id" value="<?php echo esc_attr( get_current_user_id() ); ?>">
                 <input type="hidden" name="gateway" value="<?php echo esc_attr( $payment_gateway ); ?>">
                 <input type="hidden" name="wpuf_cancel_subscription" value="Cancel">

--- a/class/subscription.php
+++ b/class/subscription.php
@@ -84,10 +84,15 @@ class WPUF_Subscription {
             $request_uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 
             if ( isset( $nonce ) && ! wp_verify_nonce( $nonce, 'wpuf-sub-cancel-' . $user_id ) ) {
-                return;
+                // Legacy nonce compat for theme-overridden templates; self-cancel only.
+                if (
+                    $user_id !== get_current_user_id()
+                    || ! wp_verify_nonce( $nonce, 'wpuf-sub-cancel' )
+                ) {
+                    return;
+                }
             }
 
-            // Ensure the user can only cancel their own subscription
             if ( $user_id !== get_current_user_id() && ! current_user_can( wpuf_admin_role() ) ) {
                 return;
             }

--- a/class/subscription.php
+++ b/class/subscription.php
@@ -83,12 +83,17 @@ class WPUF_Subscription {
             $gateway     = isset( $_POST['gateway'] ) ? sanitize_text_field( wp_unslash( $_POST['gateway'] ) ) : 0;
             $request_uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 
-            if ( isset( $nonce ) && ! wp_verify_nonce( $nonce, 'wpuf-sub-cancel-' . $user_id ) ) {
+            if ( empty( $nonce ) ) {
+                return;
+            }
+
+            if ( ! wp_verify_nonce( $nonce, 'wpuf-sub-cancel-' . $user_id ) ) {
                 // Legacy nonce compat for theme-overridden templates; self-cancel only.
-                if (
-                    $user_id !== get_current_user_id()
-                    || ! wp_verify_nonce( $nonce, 'wpuf-sub-cancel' )
-                ) {
+                if ( $user_id !== get_current_user_id() ) {
+                    return;
+                }
+
+                if ( ! wp_verify_nonce( $nonce, 'wpuf-sub-cancel' ) ) {
                     return;
                 }
             }

--- a/includes/Admin/Subscription.php
+++ b/includes/Admin/Subscription.php
@@ -87,10 +87,15 @@ class Subscription {
             $request_uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 
             if ( isset( $nonce ) && ! wp_verify_nonce( $nonce, 'wpuf-sub-cancel-' . $user_id ) ) {
-                return false;
+                // Legacy nonce compat for theme-overridden templates; self-cancel only.
+                if (
+                    $user_id !== get_current_user_id()
+                    || ! wp_verify_nonce( $nonce, 'wpuf-sub-cancel' )
+                ) {
+                    return false;
+                }
             }
 
-            // Ensure the user can only cancel their own subscription
             if ( $user_id !== get_current_user_id() && ! current_user_can( wpuf_admin_role() ) ) {
                 return false;
             }

--- a/includes/Admin/Subscription.php
+++ b/includes/Admin/Subscription.php
@@ -86,7 +86,12 @@ class Subscription {
             $gateway     = isset( $_POST['gateway'] ) ? sanitize_text_field( wp_unslash( $_POST['gateway'] ) ) : 0;
             $request_uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 
-            if ( isset( $nonce ) && ! wp_verify_nonce( $nonce, 'wpuf-sub-cancel' ) ) {
+            if ( isset( $nonce ) && ! wp_verify_nonce( $nonce, 'wpuf-sub-cancel-' . $user_id ) ) {
+                return false;
+            }
+
+            // Ensure the user can only cancel their own subscription
+            if ( $user_id !== get_current_user_id() && ! current_user_can( wpuf_admin_role() ) ) {
                 return false;
             }
 
@@ -932,7 +937,7 @@ class Subscription {
             <?php echo '<p><i>' . esc_html__( 'To cancel the pack, press the following cancel button', 'wp-user-frontend' ) . '</i></p>'; ?>
 
             <form action="" id="wpuf_cancel_subscription" method="post">
-                <?php wp_nonce_field( 'wpuf-sub-cancel' ); ?>
+                <?php wp_nonce_field( 'wpuf-sub-cancel-' . get_current_user_id() ); ?>
                 <input type="hidden" name="user_id" value="<?php echo esc_attr( get_current_user_id() ); ?>">
                 <input type="hidden" name="gateway" value="<?php echo esc_attr( $payment_gateway ); ?>">
                 <input type="hidden" name="wpuf_cancel_subscription" value="Cancel">

--- a/includes/Admin/Subscription.php
+++ b/includes/Admin/Subscription.php
@@ -86,12 +86,17 @@ class Subscription {
             $gateway     = isset( $_POST['gateway'] ) ? sanitize_text_field( wp_unslash( $_POST['gateway'] ) ) : 0;
             $request_uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 
-            if ( isset( $nonce ) && ! wp_verify_nonce( $nonce, 'wpuf-sub-cancel-' . $user_id ) ) {
+            if ( empty( $nonce ) ) {
+                return false;
+            }
+
+            if ( ! wp_verify_nonce( $nonce, 'wpuf-sub-cancel-' . $user_id ) ) {
                 // Legacy nonce compat for theme-overridden templates; self-cancel only.
-                if (
-                    $user_id !== get_current_user_id()
-                    || ! wp_verify_nonce( $nonce, 'wpuf-sub-cancel' )
-                ) {
+                if ( $user_id !== get_current_user_id() ) {
+                    return false;
+                }
+
+                if ( ! wp_verify_nonce( $nonce, 'wpuf-sub-cancel' ) ) {
                     return false;
                 }
             }

--- a/templates/dashboard/subscription.php
+++ b/templates/dashboard/subscription.php
@@ -91,7 +91,7 @@ function display_subscription_details( $subscription_data ) {
 
         <p><i><?php esc_html_e( 'To cancel the pack, press the following cancel button.', 'wp-user-frontend' ); ?></i></p>
         <form action="" method="post" style="text-align: center;">
-		<?php wp_nonce_field( 'wpuf-sub-cancel' ); ?>
+		<?php wp_nonce_field( 'wpuf-sub-cancel-' . get_current_user_id() ); ?>
             <input type="hidden" name="gateway" value="<?php echo esc_attr( $subscription_data['payment_gateway'] ); ?>">
             <input type="hidden" name="user_id" value="<?php echo esc_attr( get_current_user_id() ); ?>">
             <input type="submit" name="wpuf_cancel_subscription" class="btn btn-sm btn-danger" value="<?php esc_html_e( 'Cancel', 'wp-user-frontend' ); ?>">
@@ -469,7 +469,7 @@ function get_next_billing_html( $subscription_data ) {
         <div class="wpuf-cancel-subscription-section">
             <p class="wpuf-cancel-text"><?php esc_html_e( 'To cancel the pack, press the following cancel button.', 'wp-user-frontend' ); ?></p>
             <form action="" method="post" class="wpuf-cancel-form">
-                <?php wp_nonce_field( 'wpuf-sub-cancel' ); ?>
+                <?php wp_nonce_field( 'wpuf-sub-cancel-' . get_current_user_id() ); ?>
                 <input type="hidden" name="gateway" value="<?php echo esc_attr( $subscription_data['payment_gateway'] ); ?>">
                 <input type="hidden" name="user_id" value="<?php echo esc_attr( get_current_user_id() ); ?>">
                 <button type="submit" name="wpuf_cancel_subscription" class="wpuf-cancel-btn">


### PR DESCRIPTION
## Summary

Fix a Broken Access Control vulnerability in `user_subscription_cancel()` that allows any authenticated user (Subscriber+) to cancel any other user's subscription pack, including administrators.

## Severity

**High** — Authenticated attackers can force-cancel admin or other users' subscription packs, causing unauthorized service disruption.

## Affected Versions

All versions up to and including 4.3.0.

## Root Cause

`user_subscription_cancel()` accepts `user_id` directly from `$_POST` without verifying that the current user owns the subscription being cancelled. The nonce (`wpuf-sub-cancel`) is not user-specific, so any subscriber with an active pack can obtain a valid nonce and replay it against an arbitrary `user_id`.

## Affected Files

| File | Issue |
|------|-------|
| `includes/Admin/Subscription.php` (handler, line 82) | No ownership/capability check on `$_POST['user_id']` |
| `includes/Admin/Subscription.php` (form, line 940) | Non-user-specific nonce |
| `class/subscription.php` (handler, line 79) | Same — legacy copy |
| `class/subscription.php` (form, line 901) | Non-user-specific nonce |
| `templates/dashboard/subscription.php` (line 94) | Non-user-specific nonce |
| `templates/dashboard/subscription.php` (line 472) | Non-user-specific nonce |

## Fix

### 1. Ownership check (both handlers)

Added after nonce verification in `user_subscription_cancel()`:

```php
if ( $user_id !== get_current_user_id() && ! current_user_can( wpuf_admin_role() ) ) {
    return false;
}
```

This ensures only the subscription owner or an admin can cancel a pack.

### 2. User-specific nonce (all 6 references)

Changed nonce action from generic `wpuf-sub-cancel` to user-specific `wpuf-sub-cancel-{user_id}`:

**Generation (forms):**
```php
wp_nonce_field( 'wpuf-sub-cancel-' . get_current_user_id() );
```

**Verification (handlers):**
```php
wp_verify_nonce( $nonce, 'wpuf-sub-cancel-' . $user_id )
```

This ties the nonce to a specific user, preventing cross-user replay.

## Attack Scenario (Before Fix)

1. Attacker (Subscriber) visits the subscription cancellation page and obtains the `wpuf-sub-cancel` nonce.
2. Attacker submits a POST request with `user_id=1` (admin) and the stolen nonce.
3. Admin's subscription pack is cancelled — `_wpuf_subscription_pack` meta deleted, subscriber status set to `cancel`.

## Verification

- Normal self-cancellation flow works as before.
- Attempting to cancel another user's subscription now returns `false` and takes no action.
- Admin users can still cancel any user's subscription via the admin panel (`Admin_Subscription::delete_user_package()` is unaffected — it has its own separate capability check).
- Non-logged-in users fail both the nonce check (`get_current_user_id()` returns `0`) and the ownership check.

Close [1462](https://github.com/weDevsOfficial/wpuf-pro/issues/1462)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Subscription cancellations are now restricted to the subscription owner or administrators, preventing unauthorized users from cancelling others' subscriptions.
  * Validation for cancellation requests has been strengthened to reduce fraudulent or unintended cancellations and improve account security.
  * Cancellation forms updated to include user-specific security tokens while preserving legacy compatibility for existing workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->