### PR TITLE
fix: showing CSS/JS warning in the setup wizard

### DIFF
--- a/includes/Assets.php
+++ b/includes/Assets.php
@@ -374,11 +374,11 @@ class Assets {
             ],
             'enhanced-select'          => [
                 'src'  => WPUF_ASSET_URI . '/js/admin/wpuf-enhanced-select' . $this->suffix . '.min.js',
-                'deps' => [ 'jquery', 'selectWoo' ],
+                'deps' => [ 'jquery', 'wpuf-selectWoo' ],
             ],
             'setup'                    => [
                 'src'  => WPUF_ASSET_URI . '/js/admin/wpuf-setup' . $this->suffix . '.js',
-                'deps' => [ 'jquery', 'wpuf-enhanced-select', 'jquery-blockui' ],
+                'deps' => [ 'jquery', 'wpuf-enhanced-select', 'wpuf-jquery-blockui' ],
             ],
             'frontend-form'            => [
                 'src'  => WPUF_ASSET_URI . '/js/frontend-form' . $this->suffix . '.js',


### PR DESCRIPTION
fix: showing CSS/JS warning in the setup wizard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal asset dependencies to improve script load-order resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->