### PR TITLE
Sanitize file IDs with absint and remove debug logs

### DIFF
--- a/class/render-form.php
+++ b/class/render-form.php
@@ -228,10 +228,11 @@ class WPUF_Render_Form {
         foreach ( $meta_vars as $key => $value ) {
             $value_name = isset( $_POST[$value['name']] ) ? sanitize_text_field( wp_unslash( $_POST[$value['name']] ) ) : '';
             if ( isset( $_POST['wpuf_files'][$value['name']] ) ) {
-                $wpuf_files = isset( $_POST['wpuf_files'] ) ? sanitize_text_field( wp_unslash( $_POST['wpuf_files'][$value['name']] ) ) : [];
-            } else {
-                $wpuf_files = [];
-            }
+            $raw_files = wp_unslash( $_POST['wpuf_files'][$value['name']] );
+            $wpuf_files = absint( $raw_files );
+        } else {
+            $wpuf_files = [];
+        }
             switch ( $value['input_type'] ) {
 
                 // put files in a separate array, we'll process it later

--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -267,10 +267,7 @@ class Admin {
             $localize_data
         );
 
-        // Debug: Output form type as HTML comment for verification
-        add_action( 'admin_footer', function() use ( $form_type ) {
-            echo "\n<!-- WPUF AI Form Builder Debug: formType = " . esc_html( $form_type ) . " -->\n";
-        } );
+
     }
 
     /**

--- a/includes/Fields/Form_Field_Featured_Image.php
+++ b/includes/Fields/Form_Field_Featured_Image.php
@@ -166,7 +166,8 @@ class Form_Field_Featured_Image extends Field_Contract {
     public function prepare_entry( $field ) {
         check_ajax_referer( 'wpuf_form_add' );
 
-        $wpuf_files = isset( $_POST['wpuf_files'] ) ? array_map( 'sanitize_text_field', wp_unslash( $_POST['wpuf_files'] ) ) : [];
+        $raw_files = isset( $_POST['wpuf_files'] ) ? wp_unslash( $_POST['wpuf_files'] ) : [];
+        $wpuf_files = array_map( 'absint', $raw_files );
 
         return isset( $wpuf_files[$field['name']] ) ? $wpuf_files[$field['name']] : [];
     }

--- a/includes/Fields/Form_Field_Image.php
+++ b/includes/Fields/Form_Field_Image.php
@@ -161,7 +161,8 @@ class Form_Field_Image extends Field_Contract {
     public function prepare_entry( $field ) {
         check_ajax_referer( 'wpuf_form_add' );
 
-        $wpuf_files = isset( $_POST['wpuf_files'] ) ? array_map( 'sanitize_text_field', wp_unslash( $_POST['wpuf_files'] ) ) : [];
+        $raw_files = isset( $_POST['wpuf_files'] ) ? wp_unslash( $_POST['wpuf_files'] ) : [];
+        $wpuf_files = array_map( 'absint', $raw_files );
 
         return isset( $wpuf_files[ $field['name'] ] ) ? $wpuf_files[ $field['name'] ] : [];
     }

--- a/includes/Integrations/Events_Calendar/Compatibility/TEC_V6_Compatibility.php
+++ b/includes/Integrations/Events_Calendar/Compatibility/TEC_V6_Compatibility.php
@@ -43,13 +43,7 @@ class TEC_V6_Compatibility {
             $all_data['tags'] = sanitize_text_field( $_POST['tags'] );
         }
 
-        // Debug logging
-        if ( defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG ) {
-            error_log( 'WPUF TEC Debug - form_data keys: ' . print_r( array_keys( $form_data ), true ) );
-            error_log( 'WPUF TEC Debug - all_data tags: ' . print_r( isset($all_data['tags']) ? $all_data['tags'] : 'not set', true ) );
-            error_log( 'WPUF TEC Debug - all_data tags_input: ' . print_r( isset($all_data['tags_input']) ? $all_data['tags_input'] : 'not set', true ) );
-            error_log( 'WPUF TEC Debug - $_POST tags: ' . print_r( isset($_POST['tags']) ? $_POST['tags'] : 'not set', true ) );
-        }
+
 
 
         /**

--- a/includes/Traits/FieldableTrait.php
+++ b/includes/Traits/FieldableTrait.php
@@ -69,22 +69,22 @@ trait FieldableTrait {
     public function set_wp_post_types() {
         $args = [ '_builtin' => true ];
         $wpuf_post_types = wpuf_get_post_types( $args );
-        
+
         // Add tribe_events if The Events Calendar post type is registered
         if ( post_type_exists( 'tribe_events' ) && ! in_array( 'tribe_events', $wpuf_post_types, true ) ) {
             $wpuf_post_types[] = 'tribe_events';
         }
-        
+
         // Add product if WooCommerce post type is registered
         if ( post_type_exists( 'product' ) && ! in_array( 'product', $wpuf_post_types, true ) ) {
             $wpuf_post_types[] = 'product';
         }
-        
+
         // Add download if Easy Digital Downloads post type is registered
         if ( post_type_exists( 'download' ) && ! in_array( 'download', $wpuf_post_types, true ) ) {
             $wpuf_post_types[] = 'download';
         }
-        
+
         $ignore_taxonomies = apply_filters( 'wpuf-ignore-taxonomies', [
             'post_format',
         ] );
@@ -103,7 +103,7 @@ trait FieldableTrait {
                     ] );
                 }
             }
-            
+
             // Special handling for tribe_events to include post_tag in free version
             if ( 'tribe_events' === $post_type && ! isset( $this->wp_post_types[ $post_type ]['post_tag'] ) ) {
                 // Add post_tag as a canonical field for Event Calendar forms
@@ -113,7 +113,7 @@ trait FieldableTrait {
                     'terms'        => [],
                 ];
             }
-            
+
             // Special handling for product to include product_tag in free version
             if ( 'product' === $post_type && ! isset( $this->wp_post_types[ $post_type ]['product_tag'] ) ) {
                 // Add product_tag as a canonical field for WooCommerce forms
@@ -123,7 +123,7 @@ trait FieldableTrait {
                     'terms'        => [],
                 ];
             }
-            
+
             // Special handling for download to include download_tag in free version
             if ( 'download' === $post_type && ! isset( $this->wp_post_types[ $post_type ]['download_tag'] ) ) {
                 // Add download_tag as a canonical field for EDD forms
@@ -416,7 +416,14 @@ trait FieldableTrait {
      * @return array
      */
     private function adjust_thumbnail_id( $postarr ) {
-        $wpuf_files = ! empty( $_POST['wpuf_files'] ) ? wp_unslash( $_POST['wpuf_files'] ) : [];
+        $wpuf_files_raw = ! empty( $_POST['wpuf_files'] ) ? wp_unslash( $_POST['wpuf_files'] ) : [];
+        $wpuf_files = [];
+
+        if ( ! empty( $wpuf_files_raw ) ) {
+            foreach ( $wpuf_files_raw as $key => $value ) {
+                $wpuf_files[ $key ] = array_map( 'absint', (array) $value );
+            }
+        }
 
         if ( ! empty( $wpuf_files['featured_image'] ) ) {
             $attachment_id            = reset( $wpuf_files['featured_image'] );
@@ -443,15 +450,22 @@ trait FieldableTrait {
         do_action( 'wpuf_before_updating_post_meta_fields', $post_id, $meta_key_value, $multi_repeated, $files );
 
         // @codingStandardsIgnoreStart
-        $wpuf_files = isset( $_POST['wpuf_files'] ) ? $_POST['wpuf_files'] : [];
+        $wpuf_files_raw = isset( $_POST['wpuf_files'] ) ? wp_unslash( $_POST['wpuf_files'] ) : [];
+        $wpuf_files = [];
+
+        if ( ! empty( $wpuf_files_raw ) ) {
+            foreach ( $wpuf_files_raw as $key => $value ) {
+                $wpuf_files[ $key ] = array_map( 'absint', (array) $value );
+            }
+        }
 
         if ( isset( $wpuf_files['featured_image'] ) ) {
-            $attachment_id = $wpuf_files['featured_image'][0];
+                $attachment_id = reset( $wpuf_files['featured_image'] );
 
-            wpuf_associate_attachment( $attachment_id, $post_id );
-            set_post_thumbnail( $post_id, $attachment_id );
+                wpuf_associate_attachment( $attachment_id, $post_id );
+                set_post_thumbnail( $post_id, $attachment_id );
 
-            $file_data = isset( $_POST['wpuf_files_data'][ $attachment_id ] ) ? $_POST['wpuf_files_data'][ $attachment_id ] : false;
+                $file_data = isset( $_POST['wpuf_files_data'][ $attachment_id ] ) ? $_POST['wpuf_files_data'][ $attachment_id ] : false;
 
             // @codingStandardsIgnoreEnd
             if ( $file_data ) {
@@ -519,7 +533,8 @@ trait FieldableTrait {
                 // file title, caption, desc update
 
                 // @codingStandardsIgnoreStart
-                $file_data = isset( $_POST['wpuf_files_data'][ $attachment_id ] ) ? wp_unslash( $_POST['wpuf_files_data'][ $attachment_id ] ) : false;
+                $file_data = isset( $_POST['wpuf_files_data'][ $attachment_id ] ) ?
+                    array_map( 'sanitize_text_field', wp_unslash( $_POST['wpuf_files_data'][ $attachment_id ] ) ) : false;
 
                 // @codingStandardsIgnoreEnd
                 if ( $file_data ) {
@@ -584,26 +599,26 @@ trait FieldableTrait {
             // At this point $taxonomy_name should be a single id or array of ids
             if ( isset( $taxonomy_name ) && $taxonomy_name != 0 && $taxonomy_name != -1 ) {
                 // Auto-register post_tag taxonomy for tribe_events if not already registered
-                if ( 'tribe_events' === $this->form_settings['post_type'] && 
-                     'post_tag' === $taxonomy['name'] && 
+                if ( 'tribe_events' === $this->form_settings['post_type'] &&
+                     'post_tag' === $taxonomy['name'] &&
                      ! is_object_in_taxonomy( $this->form_settings['post_type'], $taxonomy['name'] ) ) {
                     register_taxonomy_for_object_type( 'post_tag', 'tribe_events' );
                 }
-                
+
                 // Auto-register product_tag taxonomy for product if not already registered
-                if ( 'product' === $this->form_settings['post_type'] && 
-                     'product_tag' === $taxonomy['name'] && 
+                if ( 'product' === $this->form_settings['post_type'] &&
+                     'product_tag' === $taxonomy['name'] &&
                      ! is_object_in_taxonomy( $this->form_settings['post_type'], $taxonomy['name'] ) ) {
                     register_taxonomy_for_object_type( 'product_tag', 'product' );
                 }
-                
+
                 // Auto-register download_tag taxonomy for download if not already registered
-                if ( 'download' === $this->form_settings['post_type'] && 
-                     'download_tag' === $taxonomy['name'] && 
+                if ( 'download' === $this->form_settings['post_type'] &&
+                     'download_tag' === $taxonomy['name'] &&
                      ! is_object_in_taxonomy( $this->form_settings['post_type'], $taxonomy['name'] ) ) {
                     register_taxonomy_for_object_type( 'download_tag', 'download' );
                 }
-                
+
                 if ( is_object_in_taxonomy( $this->form_settings['post_type'], $taxonomy['name'] ) ) {
                     $tax = $taxonomy_name;
                     // if it's not an array, make it one
@@ -701,7 +716,7 @@ trait FieldableTrait {
             }
 
             if ( isset( $post_data['wpuf_files'][ $value['name'] ] ) ) {
-                $wpuf_files = isset( $post_data['wpuf_files'] ) ? array_map( 'sanitize_text_field', wp_unslash( $post_data['wpuf_files'][ $value['name'] ] ) ) : [];
+                $wpuf_files = isset( $post_data['wpuf_files'] ) ? array_map( 'absint', wp_unslash( $post_data['wpuf_files'][ $value['name'] ] ) ) : [];
             } else {
                 $wpuf_files = [];
             }
@@ -725,7 +740,7 @@ trait FieldableTrait {
 
                 case 'repeat':
                     $repeater_value = isset( $_POST[ $value['name'] ] ) ? wp_unslash( $_POST[ $value['name'] ] ) : [];
-                    
+
                     // If this repeat field has inner_fields and the value is an array of rows (ACF-style)
                     if ( ! empty( $value['inner_fields'] ) && is_array(
                             $repeater_value
@@ -735,7 +750,7 @@ trait FieldableTrait {
                             $sanitized_row = [];
                             foreach ( $value['inner_fields'] as $inner_field ) {
                                 $fname = $inner_field['name'];
-                                
+
                                 // Handle different field types appropriately
                                 if ( isset( $row[ $fname ] ) ) {
                                     if ( in_array( $inner_field['template'], [ 'checkbox_field', 'multiple_select' ] ) ) {

--- a/includes/class-frontend-render-form.php
+++ b/includes/class-frontend-render-form.php
@@ -761,7 +761,8 @@ class WPUF_Frontend_Render_Form {
             }
 
             if ( isset( $post_data['wpuf_files'][ $value['name'] ] ) ) {
-                $wpuf_files = isset( $post_data['wpuf_files'] ) ? array_map( 'sanitize_text_field', wp_unslash( $post_data['wpuf_files'][ $value['name'] ] ) ) : [];
+                $raw_files = wp_unslash( $post_data['wpuf_files'][ $value['name'] ] );
+                $wpuf_files = isset( $post_data['wpuf_files'] ) ? array_map( 'absint', $raw_files ) : [];
             } else {
                 $wpuf_files = [];
             }
@@ -930,12 +931,12 @@ class WPUF_Frontend_Render_Form {
                 <div >
                     <label >
                          <input type="checkbox" class="wpuf_is_featured" name="is_featured_item" value="1" <?php echo $is_featured ? 'checked' : ''; ?> >
-                         <span class="wpuf-message-box" id="remaining-feature-item"> <?php 
+                         <span class="wpuf-message-box" id="remaining-feature-item"> <?php
                             // translators: %1$s is Post type and %2$s is total feature item
-                            printf( 
-                                wp_kses_post( __( 'Mark the %1$s as featured (remaining %2$d)', 'wp-user-frontend' ) ), 
-                                esc_html( $this->form_settings['post_type'] ), 
-                                esc_html( isset( $user_sub['total_feature_item'] ) ? $user_sub['total_feature_item'] : 0 ) 
+                            printf(
+                                wp_kses_post( __( 'Mark the %1$s as featured (remaining %2$d)', 'wp-user-frontend' ) ),
+                                esc_html( $this->form_settings['post_type'] ),
+                                esc_html( isset( $user_sub['total_feature_item'] ) ? $user_sub['total_feature_item'] : 0 )
                             ); ?></span>
                     </label>
                 </div>


### PR DESCRIPTION
closes [#1475](https://github.com/weDevsOfficial/wpuf-pro/issues/1475)
related PR [#1477](https://github.com/weDevsOfficial/wpuf-pro/pull/1477)

Replace string sanitization of wpuf_files with integer casting (absint) and consistent wp_unslash handling across render, frontend, featured/image fields and FieldableTrait to ensure file/attachment IDs are numeric and processed safely. Normalize raw variable names (raw_files/wpuf_files_raw), map absint over arrays, and handle nested file arrays when adjusting thumbnail IDs and associating attachments. Also sanitize wpuf_files_data with array_map(sanitize_text_field). Remove transient debug outputs: admin footer formType comment and TEC compatibility debug logging. Misc: whitespace and minor formatting cleanups in taxonomy handling and frontend label printf formatting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unnecessary debug output from the admin interface
  * Removed debug logging from the Events Calendar integration

* **Refactor**
  * Enhanced file upload data handling for improved consistency across image and featured image field types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->