### PR TITLE
fix: tags suggestions are not loading

### DIFF
--- a/includes/Fields/Form_Field_Post_Tags.php
+++ b/includes/Fields/Form_Field_Post_Tags.php
@@ -61,7 +61,7 @@ class Form_Field_Post_Tags extends Field_Contract {
               <script type="text/javascript">
                 ;(function($) {
                     $(document).ready( function(){
-                        $('li.tags input[name=tags]').suggest( wpuf_frontend.ajaxurl + '<?php echo esc_js( $query_string ); ?>', { delay: 500, minchars: 2, multiple: true, multipleSep: ', ' } );
+                        $('li.tags input[name=tags]').suggest( wpuf_frontend.ajaxurl + <?php echo wp_json_encode( $query_string ); ?>, { delay: 500, minchars: 2, multiple: true, multipleSep: ', ' } );
                     });
                 })(jQuery);
             </script>


### PR DESCRIPTION
closes [#823](https://github.com/weDevsOfficial/wpuf-pro/issues/823)

## Summary

Fixes the **Tags** field on frontend forms where the autocomplete suggestion dropdown stopped working — every keystroke returned a "Permission denied" error instead of matching tags. With this fix, users can again type into a Tags field and see live suggestions as expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved data serialization in the tag autocomplete feature to ensure consistent and reliable query handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->