### PR TITLE
chore: exclude .DS_Store from builds

### DIFF
--- a/.svnignore
+++ b/.svnignore
@@ -8,6 +8,7 @@ docs.md
 CLAUDE.md
 includes/Fields/CLAUDE.md
 .claude
+.DS_Store
 changelog.txt
 plugin-deploy.sh
 npm-debug.log

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -228,6 +228,7 @@ module.exports = function( grunt) {
                     '!**/vite.config.mjs',
                     '!**/CLAUDE.md',
                     '!.claude/**',
+                    '!**/.DS_Store',
                 ],
                 dest: 'build/'
             }

--- a/appsero.json
+++ b/appsero.json
@@ -16,6 +16,7 @@
     "postcss.config.js",
     "CLAUDE.md",
     "includes/Fields/CLAUDE.md",
-    ".claude"
+    ".claude",
+    ".DS_Store"
   ]
 }


### PR DESCRIPTION
## Summary

Adds `.DS_Store` entries to the three exclusion config files:

- `.svnignore` (manual SVN deploy)
- `appsero.json` (Appsero auto-build for wp.org)
- `Gruntfile.js` copy task (grunt zip GitHub release asset)

## Why

macOS Finder generates `.DS_Store` files in every directory it browses. Without these excludes, contributor machines can leak those files into the distributed plugin zip pushed to wp.org.

## Test plan

- [ ] Open new release branch
- [ ] Run `grunt zip`
- [ ] Confirm any `.DS_Store` files in working tree are NOT inside the resulting zip