### PR TITLE
Add Elementor compatibility to readme

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -123,6 +123,28 @@ This WordPress Registration Form Plugin also allows you to build user registrati
 
 Custom field data are viewable to visitors on frontend on single post pages. Admins can also disable this if they don’t want to display custom fields to everyone.
 
+<strong>Elementor Compatibility</strong>
+
+WP User Frontend is now fully compatible with <strong>Elementor</strong>, the popular WordPress page builder. You can build and design <strong>frontend forms, user dashboards, and subscription pages</strong> in Elementor without using shortcodes.
+
+This integration combines the power of <strong>WP User Frontend (frontend content management)</strong> with <strong>Elementor (visual page builder)</strong> for a faster and smoother workflow.
+
+<strong>Available Elementor Widgets</strong>
+
+* <strong>Account Widget</strong> – Customize the user account dashboard layout and appearance
+* <strong>Subscription Widget</strong> – Display and organize user subscription plans clearly
+* <strong>Post Form Widget</strong> – Design frontend submission forms visually using Elementor
+
+These widgets help you turn your site into a <strong>frontend content management system</strong> without backend access.
+
+<strong>How Elementor Integration Works</strong>
+
+* Drag and drop User Frontend widgets into Elementor
+* Customize layout, spacing, and design visually
+* Publish pages and display them on the frontend
+
+WP User Frontend handles <strong>form logic, user roles, and permissions</strong>, while Elementor controls <strong>design and layout</strong>.
+
 = How to download and install WPUF FREE =
 
 [youtube https://www.youtube.com/watch?v=rzxdIN8ZMYc]


### PR DESCRIPTION
Adds an "Elementor Compatibility" section to the README explaining that WP User Frontend can be used with Elementor to build frontend forms, dashboards, and subscription pages without shortcodes. Documents available Elementor widgets (Account, Subscription, Post Form), basic integration workflow (drag & drop, customize, publish), and clarifies that WP User Frontend manages form logic, roles, and permissions while Elementor handles layout and design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Elementor Compatibility section to README, documenting comprehensive support for Elementor widgets including Account, Subscription, and Post Form Builder options.
  * Included overview of how Elementor integration works, explaining the separation of concerns between Elementor's design and layout handling versus the plugin's form logic and permission management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/weDevsOfficial/wp-user-frontend/pull/1863)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->