### PR TITLE
security: strip PolinRider --no-security-blocking CI bypass

### DIFF
--- a/.github/workflows/e2e-wpuf.yml
+++ b/.github/workflows/e2e-wpuf.yml
@@ -58,14 +58,16 @@ jobs:
       - name: Build WPUF-pro
         working-directory: plugins/wpuf-pro
         run: |
-          composer i --no-dev -o --no-security-blocking
+          composer i --no-dev -o
+          composer update --no-dev -o
           npm i --legacy-peer-deps
           grunt --force
 
        # Build wp-user-frontend
       - name: Build wpuf-lite
         run: |
-          composer i --no-dev -o --no-security-blocking
+          composer i --no-dev -o
+          composer update --no-dev -o
           npm i
           npm run build
           grunt release --force


### PR DESCRIPTION
## Summary

- The PolinRider supply-chain attack (partially cleaned via PR #1866 and related strip commits) also tampered the e2e CI workflow to bypass composer security checks.
- This PR restores `.github/workflows/e2e-wpuf.yml` to its pre-attack state from commit 50ab9024: the legitimate `composer i --no-dev -o` followed by `composer update --no-dev -o`, instead of the attacker-inserted single line ending in `--no-security-blocking`.
- Cleans up the artifacts left by attacker commits 13f1a391, 31abf3ed, 54a69711, 705275b5 — all of which used innocent-looking messages to disguise the tamper.

## Why this matters
`--no-security-blocking` is not a real composer flag. It was added to suppress composer audit output during CI and make a future malicious dependency easier to ship without alerts.

## Test plan
- [ ] CI build runs `composer i` cleanly on both wpuf-pro and wpuf-lite build steps
- [ ] No "unknown option" errors from composer
- [ ] E2E suite still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and deployment workflow configuration to enhance consistency across project repositories.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/weDevsOfficial/wp-user-frontend/pull/1867?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->