### PR TITLE
feat: track coupon discount and coupon ID per transaction

### DIFF
--- a/Lib/Gateway/Bank.php
+++ b/Lib/Gateway/Bank.php
@@ -61,8 +61,16 @@ class Bank {
 
         $data['price'] = isset( $data['price'] ) ? empty( $data['price'] ) ? 0 : $data['price'] : 0;
 
-        if ( isset( $_POST['coupon_id'] ) && !empty( $_POST['coupon_id'] ) ) {
-            $data['price'] = (new Coupons())->discount( $data['price'], $_POST['coupon_id'], $data['item_number'] );
+        $original_price    = floatval( $data['price'] );
+        $data['discount']  = 0;
+        $data['coupon_id'] = 0;
+
+        if ( isset( $_POST['coupon_id'] ) && ! empty( $_POST['coupon_id'] ) ) {
+            $coupon_id         = absint( wp_unslash( $_POST['coupon_id'] ) );
+            $discounted_price  = floatval( (new Coupons())->discount( $data['price'], $coupon_id, $data['item_number'] ) );
+            $data['discount']  = $original_price - $discounted_price;
+            $data['coupon_id'] = $coupon_id;
+            $data['price']     = $discounted_price;
         }
 
         $post_id = isset( $data['item_number'] ) && $data['type'] === 'post' ? $data['item_number'] : 0;
@@ -83,8 +91,8 @@ class Bank {
         }
 
         $data['cost']     = apply_filters( 'wpuf_payment_amount', $data['price'], $post_id ); //price with tax from pro
-        $data['tax']      = floatval( $data['cost'] ) -  floatval( $data['price'] );
-        $data['subtotal'] = $data['price'];
+        $data['tax']      = floatval( $data['cost'] ) - floatval( $data['price'] );
+        $data['subtotal'] = $original_price;
 
         if ( $order_id ) {
             update_post_meta( $order_id, '_data', $data );

--- a/Lib/Gateway/Bank.php
+++ b/Lib/Gateway/Bank.php
@@ -61,17 +61,8 @@ class Bank {
 
         $data['price'] = isset( $data['price'] ) ? empty( $data['price'] ) ? 0 : $data['price'] : 0;
 
-        $original_price    = floatval( $data['price'] );
         $data['discount']  = 0;
         $data['coupon_id'] = 0;
-
-        if ( isset( $_POST['coupon_id'] ) && ! empty( $_POST['coupon_id'] ) ) {
-            $coupon_id         = absint( wp_unslash( $_POST['coupon_id'] ) );
-            $discounted_price  = floatval( (new Coupons())->discount( $data['price'], $coupon_id, $data['item_number'] ) );
-            $data['discount']  = $original_price - $discounted_price;
-            $data['coupon_id'] = $coupon_id;
-            $data['price']     = $discounted_price;
-        }
 
         $post_id = isset( $data['item_number'] ) && $data['type'] === 'post' ? $data['item_number'] : 0;
 
@@ -88,6 +79,19 @@ class Bank {
                     }
                 }
             }
+        }
+
+        // Resolve the base price after any pricing-field override, then apply the coupon.
+        $original_price = floatval( $data['price'] );
+
+        $coupon_id = isset( $_POST['coupon_id'] ) ? absint( wp_unslash( $_POST['coupon_id'] ) ) : 0;
+
+        // Coupons are a Pro feature; only run when Pro is active to avoid a fatal in free-only installs.
+        if ( $coupon_id > 0 && class_exists( Coupons::class ) ) {
+            $discounted_price  = floatval( ( new Coupons() )->discount( $data['price'], $coupon_id, $data['item_number'] ) );
+            $data['discount']  = $original_price - $discounted_price;
+            $data['coupon_id'] = $coupon_id;
+            $data['price']     = $discounted_price;
         }
 
         $data['cost']     = apply_filters( 'wpuf_payment_amount', $data['price'], $post_id ); //price with tax from pro

--- a/Lib/Gateway/Paypal.php
+++ b/Lib/Gateway/Paypal.php
@@ -405,7 +405,7 @@ class Paypal {
                 'status'           => 'completed',
                 'subtotal'         => $subtotal,
                 'discount'         => ! empty( $custom_data['discount'] ) ? floatval( $custom_data['discount'] ) : 0,
-                'coupon_id'        => ! empty( $custom_data['coupon_id'] ) ? absint( $custom_data['coupon_id'] ) : 0,
+                'coupon_id'        => ! empty( $custom_data['coupon_id'] ) ? absint( $custom_data['coupon_id'] ) : null,
                 'tax'              => $tax,
                 'cost'             => $cost,
                 'post_id'          => ( 'post' === $custom_data['type'] ) ? $custom_data['item_number'] : 0,
@@ -1439,9 +1439,11 @@ class Paypal {
                 }
             }
 
-            // Handle coupon if present
+            // Handle coupon if present. Coupons are a Pro feature, so only run when Pro is
+            // available to avoid a fatal on wpuf_pro() in free-only installs.
             $coupon_discount = 0;
-            if ( isset( $_POST['coupon_id'] ) && ! empty( $_POST['coupon_id'] ) &&
+            if ( function_exists( 'wpuf_pro' ) && wpuf_pro() &&
+                isset( $_POST['coupon_id'] ) && ! empty( $_POST['coupon_id'] ) &&
                 isset( $_POST['_wpnonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) ), 'wpuf_payment_coupon' ) &&
                 is_numeric( sanitize_text_field( wp_unslash( $_POST['coupon_id'] ) ) ) ) {
                 $coupon_id       = absint( sanitize_text_field( wp_unslash( $_POST['coupon_id'] ) ) );

--- a/Lib/Gateway/Paypal.php
+++ b/Lib/Gateway/Paypal.php
@@ -401,19 +401,21 @@ class Paypal {
 
             // Create payment record
             $data = [
-                'user_id' => $custom_data['user_id'],
-                'status' => 'completed',
-                'subtotal' => $subtotal,
-                'tax' => $tax,
-                'cost' => $cost,
-                'post_id' => ( 'post' === $custom_data['type'] ) ? $custom_data['item_number'] : 0,
-                'pack_id' => ( 'pack' === $custom_data['type'] ) ? $custom_data['item_number'] : 0,
+                'user_id'          => $custom_data['user_id'],
+                'status'           => 'completed',
+                'subtotal'         => $subtotal,
+                'discount'         => ! empty( $custom_data['discount'] ) ? floatval( $custom_data['discount'] ) : 0,
+                'coupon_id'        => ! empty( $custom_data['coupon_id'] ) ? absint( $custom_data['coupon_id'] ) : 0,
+                'tax'              => $tax,
+                'cost'             => $cost,
+                'post_id'          => ( 'post' === $custom_data['type'] ) ? $custom_data['item_number'] : 0,
+                'pack_id'          => ( 'pack' === $custom_data['type'] ) ? $custom_data['item_number'] : 0,
                 'payer_first_name' => $user->first_name,
-                'payer_last_name' => $user->last_name,
-                'payer_email' => $user->user_email,
-                'payment_type' => 'paypal',
-                'transaction_id' => $payment['id'],
-                'created' => gmdate( 'Y-m-d H:i:s' ),
+                'payer_last_name'  => $user->last_name,
+                'payer_email'      => $user->user_email,
+                'payment_type'     => 'paypal',
+                'transaction_id'   => $payment['id'],
+                'created'          => gmdate( 'Y-m-d H:i:s' ),
             ];
 
             // Insert payment record
@@ -1438,11 +1440,14 @@ class Paypal {
             }
 
             // Handle coupon if present
+            $coupon_discount = 0;
             if ( isset( $_POST['coupon_id'] ) && ! empty( $_POST['coupon_id'] ) &&
                 isset( $_POST['_wpnonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_wpnonce'] ) ), 'wpuf_payment_coupon' ) &&
                 is_numeric( sanitize_text_field( wp_unslash( $_POST['coupon_id'] ) ) ) ) {
-                $coupon_id = absint( sanitize_text_field( wp_unslash( $_POST['coupon_id'] ) ) );
-                $billing_amount = wpuf_pro()->coupon->discount( $billing_amount, $coupon_id, $data['item_number'] );
+                $coupon_id       = absint( sanitize_text_field( wp_unslash( $_POST['coupon_id'] ) ) );
+                $original_amount = floatval( $billing_amount );
+                $billing_amount  = wpuf_pro()->coupon->discount( $billing_amount, $coupon_id, $data['item_number'] );
+                $coupon_discount = $original_amount - floatval( $billing_amount );
             } else {
                 $coupon_id = '';
             }
@@ -1580,10 +1585,11 @@ class Paypal {
                     ],
                     'custom_id' => wp_json_encode(
                         [
-							'type' => $data['type'],
-							'user_id' => $user_id,
+							'type'        => $data['type'],
+							'user_id'     => $user_id,
 							'item_number' => $data['item_number'],
-							'coupon_id' => $coupon_id,
+							'coupon_id'   => $coupon_id,
+							'discount'    => $coupon_discount,
 						]
                     ),
                 ];
@@ -1694,12 +1700,13 @@ class Paypal {
 							'description' => isset( $data['custom']['post_title'] ) ? $data['custom']['post_title'] : $data['item_name'],
 							'custom_id' => wp_json_encode(
                                 [
-									'type' => $payment_data['type'],
-									'user_id' => $payment_data['user_id'],
-									'coupon_id' => $payment_data['coupon_id'],
+									'type'        => $payment_data['type'],
+									'user_id'     => $payment_data['user_id'],
+									'coupon_id'   => $payment_data['coupon_id'],
 									'item_number' => $payment_data['item_number'],
-									'subtotal' => isset( $payment_data['breakdown']['item_total'] ) ? $payment_data['breakdown']['item_total'] : $payment_data['amount'],
-									'tax' => isset( $payment_data['breakdown']['tax_total'] ) ? $payment_data['breakdown']['tax_total'] : 0,
+									'subtotal'    => ( isset( $payment_data['breakdown']['item_total'] ) ? floatval( $payment_data['breakdown']['item_total'] ) : floatval( $payment_data['amount'] ) ) + $coupon_discount,
+									'tax'         => isset( $payment_data['breakdown']['tax_total'] ) ? $payment_data['breakdown']['tax_total'] : 0,
+									'discount'    => $coupon_discount,
 								]
                             ),
 						],

--- a/includes/Admin/List_Table_Transactions.php
+++ b/includes/Admin/List_Table_Transactions.php
@@ -48,6 +48,7 @@ class List_Table_Transactions extends WP_List_Table {
             'user'           => __( 'User', 'wp-user-frontend' ),
             'subtotal'       => __( 'Subtotal', 'wp-user-frontend' ),
             'cost'           => __( 'Cost', 'wp-user-frontend' ),
+            'discount'       => __( 'Coupon', 'wp-user-frontend' ),
             'tax'            => __( 'Tax', 'wp-user-frontend' ),
             'post_id'        => __( 'Post ID', 'wp-user-frontend' ),
             'pack_id'        => __( 'Pack ID', 'wp-user-frontend' ),
@@ -170,6 +171,21 @@ class List_Table_Transactions extends WP_List_Table {
 
             case 'cost':
                 return wpuf_format_price( $item->cost );
+
+            case 'discount':
+                if ( empty( $item->discount ) && empty( $item->coupon_id ) ) {
+                    return '-';
+                }
+                $output = '';
+                if ( ! empty( $item->coupon_id ) ) {
+                    $coupon_code = get_the_title( absint( $item->coupon_id ) );
+                    $coupon_url  = admin_url( 'post.php?post=' . absint( $item->coupon_id ) . '&action=edit' );
+                    $output     .= sprintf( '<a href="%s">%s</a>', esc_url( $coupon_url ), esc_html( $coupon_code ) );
+                }
+                if ( ! empty( $item->discount ) ) {
+                    $output .= ( $output ? '<br>' : '' ) . esc_html( wpuf_format_price( $item->discount ) );
+                }
+                return $output;
 
             case 'tax':
                 return wpuf_format_price( $item->tax );
@@ -365,6 +381,8 @@ class List_Table_Transactions extends WP_List_Table {
                     'user_id'          => $info['user_info']['id'],
                     'status'           => 'completed',
                     'subtotal'         => $info['subtotal'],
+                    'discount'         => ! empty( $info['discount'] ) ? $info['discount'] : 0,
+                    'coupon_id'        => ! empty( $info['post_data']['coupon_id'] ) ? absint( $info['post_data']['coupon_id'] ) : 0,
                     'tax'              => $info['tax'],
                     'cost'             => $info['price'],
                     'post_id'          => $post_id,
@@ -420,6 +438,8 @@ class List_Table_Transactions extends WP_List_Table {
                         'user_id'          => $info['user_info']['id'],
                         'status'           => 'completed',
                         'subtotal'         => $info['subtotal'],
+                        'discount'         => ! empty( $info['discount'] ) ? $info['discount'] : 0,
+                        'coupon_id'        => ! empty( $info['post_data']['coupon_id'] ) ? absint( $info['post_data']['coupon_id'] ) : 0,
                         'tax'              => $info['tax'],
                         'cost'             => $info['price'],
                         'post_id'          => $post_id,

--- a/includes/Admin/Upgrades.php
+++ b/includes/Admin/Upgrades.php
@@ -28,6 +28,7 @@ class Upgrades {
         '4.0.11' => 'upgrades/upgrade-4.0.11.php',
         '4.1.0'  => 'upgrades/upgrade-4.1.0.php',
         '4.1.7'  => 'upgrades/upgrade-4.1.7.php',
+        '4.3.8'  => 'upgrades/upgrade-4.3.8.php',
     ];
 
     /**

--- a/includes/Installer.php
+++ b/includes/Installer.php
@@ -56,6 +56,8 @@ class Installer {
                 `user_id` bigint(20) DEFAULT NULL,
                 `status` varchar(60) NOT NULL DEFAULT 'pending_payment',
                 `subtotal` varchar(255) DEFAULT '',
+                `discount` varchar(255) DEFAULT '0',
+                `coupon_id` bigint(20) DEFAULT NULL,
                 `tax` varchar(255) DEFAULT '',
                 `cost` varchar(255) DEFAULT '',
                 `post_id` varchar(20) DEFAULT NULL,

--- a/includes/upgrades/upgrade-4.3.8.php
+++ b/includes/upgrades/upgrade-4.3.8.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Upgrade routine for 4.3.8
+ *
+ * Adds the `discount` column to `wpuf_transaction` table so coupon
+ * discount amounts are persisted per transaction.
+ *
+ * @since WPUF_SINCE
+ */
+
+global $wpdb;
+
+require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+$collate = '';
+if ( $wpdb->has_cap( 'collation' ) ) {
+    if ( ! empty( $wpdb->charset ) ) {
+        $collate .= "DEFAULT CHARACTER SET $wpdb->charset";
+    }
+    if ( ! empty( $wpdb->collate ) ) {
+        $collate .= " COLLATE $wpdb->collate";
+    }
+}
+
+$table_name = $wpdb->prefix . 'wpuf_transaction';
+
+$sql = "CREATE TABLE IF NOT EXISTS `{$table_name}` (
+    `id` int(11) NOT NULL AUTO_INCREMENT,
+    `user_id` bigint(20) DEFAULT NULL,
+    `status` varchar(60) NOT NULL DEFAULT 'pending_payment',
+    `subtotal` varchar(255) DEFAULT '',
+    `discount` varchar(255) DEFAULT '0',
+    `coupon_id` bigint(20) DEFAULT NULL,
+    `tax` varchar(255) DEFAULT '',
+    `cost` varchar(255) DEFAULT '',
+    `post_id` varchar(20) DEFAULT NULL,
+    `pack_id` bigint(20) DEFAULT NULL,
+    `payer_first_name` varchar(60),
+    `payer_last_name` varchar(60),
+    `payer_email` varchar(100),
+    `payment_type` varchar(20),
+    `payer_address` longtext,
+    `transaction_id` varchar(60),
+    `created` datetime NOT NULL,
+    PRIMARY KEY (`id`),
+    key `user_id` (`user_id`),
+    key `post_id` (`post_id`),
+    key `pack_id` (`pack_id`),
+    key `payer_email` (`payer_email`)
+) $collate;";
+
+dbDelta( $sql );

--- a/wpuf-functions.php
+++ b/wpuf-functions.php
@@ -2442,14 +2442,16 @@ function wpuf_get_pending_transactions( $args = [] ) {
         }
 
         $tax      = ! empty( $info['tax'] ) ? $info['tax'] : 0;
-        $subtotal = ! empty( $info['cost'] ) ? $info['cost'] : $info['price'];
+        $subtotal = ! empty( $info['subtotal'] ) ? $info['subtotal'] : ( ! empty( $info['cost'] ) ? $info['cost'] : $info['price'] );
 
         $items[] = (object) [
             'id'               => $transaction->ID,
             'user_id'          => $info['user_info']['id'],
             'status'           => 'pending',
             'subtotal'         => $subtotal,
-            'cost'             => $subtotal - $tax,
+            'discount'         => ! empty( $info['discount'] ) ? $info['discount'] : 0,
+            'coupon_id'        => ! empty( $info['post_data']['coupon_id'] ) ? absint( $info['post_data']['coupon_id'] ) : 0,
+            'cost'             => ! empty( $info['price'] ) ? floatval( $info['price'] ) : $subtotal - $tax,
             'tax'              => $tax,
             'post_id'          => ( $info['type'] === 'post' ) ? $info['item_number'] : 0,
             'pack_id'          => ( $info['type'] === 'pack' ) ? $info['item_number'] : 0,
@@ -2504,8 +2506,8 @@ function wpuf_get_all_transactions( $args = [] ) {
         );
     }
 
-    $orderby       = in_array( $args['orderby'], $orderby_keys ) ? $args['orderby'] : 'id';
-    $sorting_order = in_array( $args['order'], $order_keys ) ? $args['order'] : 'DESC';
+    $orderby       = in_array( $args['orderby'], $orderby_keys, true ) ? $args['orderby'] : 'id';
+    $sorting_order = in_array( $args['order'], $order_keys, true ) ? $args['order'] : 'DESC';
     $offset        = ( int ) sanitize_key( $args['offset'] );
     $number        = ( int ) sanitize_key( $args['number'] );
 
@@ -2513,9 +2515,9 @@ function wpuf_get_all_transactions( $args = [] ) {
     // and pending transaction from post table
     $transactions = $wpdb->get_results(
         $wpdb->prepare(
-            "(SELECT id, user_id, status, tax, cost, post_id, pack_id, payer_first_name, payer_last_name, payer_email, payment_type, transaction_id, created FROM {$transaction_table})
+            "(SELECT id, user_id, status, subtotal, discount, coupon_id, tax, cost, post_id, pack_id, payer_first_name, payer_last_name, payer_email, payment_type, transaction_id, created FROM {$transaction_table})
             UNION ALL
-            (SELECT ID AS id, post_author AS user_id, null AS status, null AS tax, null AS cost, ID as post_id, null AS pack_id, null AS payer_first_name, null AS payer_last_name, null AS payer_email, null AS payment_type, 0 AS transaction_id, post_date AS created FROM {$wpdb->posts}
+            (SELECT ID AS id, post_author AS user_id, null AS status, null AS subtotal, null AS discount, null AS coupon_id, null AS tax, null AS cost, ID as post_id, null AS pack_id, null AS payer_first_name, null AS payer_last_name, null AS payer_email, null AS payment_type, 0 AS transaction_id, post_date AS created FROM {$wpdb->posts}
             WHERE post_type = %s)
             ORDER BY {$orderby} {$sorting_order}
             LIMIT %d, %d",
@@ -2542,8 +2544,13 @@ function wpuf_get_all_transactions( $args = [] ) {
         // attach data to pending transactions
         $transaction->user_id          = isset( $info['user_info']['id'] ) ? $info['user_info']['id'] : 0;
         $transaction->status           = 'pending';
-        $transaction->cost             = isset( $info['price'] ) ? $info['price'] : 0;
-        $transaction->tax              = isset( $info['tax'] ) ? $info['tax'] : 0;
+        $tax                           = isset( $info['tax'] ) ? $info['tax'] : 0;
+        $subtotal                      = ! empty( $info['subtotal'] ) ? $info['subtotal'] : ( ! empty( $info['cost'] ) ? $info['cost'] : ( $info['price'] ?? 0 ) );
+        $transaction->subtotal         = $subtotal;
+        $transaction->discount         = ! empty( $info['discount'] ) ? $info['discount'] : 0;
+        $transaction->coupon_id        = ! empty( $info['post_data']['coupon_id'] ) ? absint( $info['post_data']['coupon_id'] ) : 0;
+        $transaction->cost             = ! empty( $info['price'] ) ? floatval( $info['price'] ) : $subtotal - $tax;
+        $transaction->tax              = $tax;
         $transaction->post_id          = ( 'post' === $type ) ? $item_number : 0;
         $transaction->pack_id          = ( 'pack' === $type ) ? $item_number : 0;
         $transaction->payer_first_name = isset( $info['user_info']['first_name'] ) ? $info['user_info']['first_name'] : '';

--- a/wpuf-functions.php
+++ b/wpuf-functions.php
@@ -2518,7 +2518,8 @@ function wpuf_get_all_transactions( $args = [] ) {
             "(SELECT id, user_id, status, subtotal, discount, coupon_id, tax, cost, post_id, pack_id, payer_first_name, payer_last_name, payer_email, payment_type, transaction_id, created FROM {$transaction_table})
             UNION ALL
             (SELECT ID AS id, post_author AS user_id, null AS status, null AS subtotal, null AS discount, null AS coupon_id, null AS tax, null AS cost, ID as post_id, null AS pack_id, null AS payer_first_name, null AS payer_last_name, null AS payer_email, null AS payment_type, 0 AS transaction_id, post_date AS created FROM {$wpdb->posts}
-            WHERE post_type = %s)
+            WHERE post_type = %s
+            AND post_status IN ('pending', 'publish'))
             ORDER BY {$orderby} {$sorting_order}
             LIMIT %d, %d",
             'wpuf_order', $offset, $number

--- a/wpuf-functions.php
+++ b/wpuf-functions.php
@@ -2451,7 +2451,7 @@ function wpuf_get_pending_transactions( $args = [] ) {
             'subtotal'         => $subtotal,
             'discount'         => ! empty( $info['discount'] ) ? $info['discount'] : 0,
             'coupon_id'        => ! empty( $info['post_data']['coupon_id'] ) ? absint( $info['post_data']['coupon_id'] ) : 0,
-            'cost'             => ! empty( $info['price'] ) ? floatval( $info['price'] ) : $subtotal - $tax,
+            'cost'             => ! empty( $info['cost'] ) ? floatval( $info['cost'] ) : ( ! empty( $info['price'] ) ? floatval( $info['price'] ) + floatval( $tax ) : $subtotal ),
             'tax'              => $tax,
             'post_id'          => ( $info['type'] === 'post' ) ? $info['item_number'] : 0,
             'pack_id'          => ( $info['type'] === 'pack' ) ? $info['item_number'] : 0,
@@ -2549,7 +2549,7 @@ function wpuf_get_all_transactions( $args = [] ) {
         $transaction->subtotal         = $subtotal;
         $transaction->discount         = ! empty( $info['discount'] ) ? $info['discount'] : 0;
         $transaction->coupon_id        = ! empty( $info['post_data']['coupon_id'] ) ? absint( $info['post_data']['coupon_id'] ) : 0;
-        $transaction->cost             = ! empty( $info['price'] ) ? floatval( $info['price'] ) : $subtotal - $tax;
+        $transaction->cost             = ! empty( $info['cost'] ) ? floatval( $info['cost'] ) : ( ! empty( $info['price'] ) ? floatval( $info['price'] ) + floatval( $tax ) : $subtotal );
         $transaction->tax              = $tax;
         $transaction->post_id          = ( 'post' === $type ) ? $item_number : 0;
         $transaction->pack_id          = ( 'pack' === $type ) ? $item_number : 0;


### PR DESCRIPTION
## Summary

Coupons were applied correctly at checkout but the discount amount and coupon identifier were never persisted to `wpuf_transaction`. This PR closes that gap across all three payment gateways and the admin transaction list table.

### Root causes fixed

- **DB schema** — `wpuf_transaction` had no `discount` or `coupon_id` columns. Added via `Installer.php` (`dbDelta`) and `includes/upgrades/upgrade-4.3.8.php` for existing installs.
- **Bank gateway** — coupon discount was applied to price but the delta was discarded; `subtotal` was set to the already-discounted price instead of the original.
- **PayPal gateway** — `custom_id` JSON passed to PayPal webhook didn't include `discount`; webhook completion path therefore always stored `discount = 0`.
- **Admin list table** — `wpuf_get_all_transactions()` UNION SQL selected only ~14 columns, omitting `subtotal`, `discount`, `coupon_id` — so all completed rows showed `-` in the Coupon column despite correct DB data. Pending transaction augmentation block also never set these three properties.
- **`in_array()` strict mode** — two calls in `wpuf_get_all_transactions()` were missing the `true` strict arg (PHPCS error).

### Changes

| File | What changed |
|---|---|
| `includes/Installer.php` | Add `discount varchar(255) DEFAULT '0'` and `coupon_id bigint(20) DEFAULT NULL` to `wpuf_transaction` schema |
| `includes/upgrades/upgrade-4.3.8.php` | `dbDelta` migration for existing installs |
| `includes/Admin/Upgrades.php` | Register `4.3.8` upgrade routine |
| `Lib/Gateway/Bank.php` | Capture `original_price` before coupon; compute `discount` delta; set `subtotal = original_price`; persist `discount` and `coupon_id` in order meta and payment data |
| `Lib/Gateway/Paypal.php` | Compute `coupon_discount` at checkout; pass through `custom_id` JSON; use in payment record on webhook completion |
| `includes/Admin/List_Table_Transactions.php` | Add **Coupon** column (code link + discount amount); persist `discount`/`coupon_id` when manually completing pending orders |
| `wpuf-functions.php` | Fix UNION SQL to include `subtotal`, `discount`, `coupon_id`; augment pending transaction objects with coupon fields; fix `in_array()` strict mode |

### Related

Stripe gateway changes are in a companion PR on `wpuf-pro`: `arifulhoque7:feature/coupon-discount-transaction-tracking`.

## Test plan

- [ ] Fresh install: activate plugin, confirm `wpuf_transaction` has `discount` and `coupon_id` columns
- [ ] Existing install: run upgrade, confirm columns added via `dbDelta`
- [ ] Bank transfer checkout with coupon: confirm pending order meta has `discount` > 0 and `coupon_id` set; after manual completion confirm `wpuf_transaction` row has correct values
- [ ] PayPal checkout with coupon: confirm `custom_id` JSON contains `discount`; after PayPal webhook fires confirm `wpuf_transaction` row has correct `discount` and `coupon_id`
- [ ] Admin Transactions list → All tab: Coupon column shows coupon code link and discount amount for completed transactions
- [ ] Admin Transactions list → Pending tab: Coupon column shows coupon data for pending orders that had a coupon applied
- [ ] Checkout without coupon: `discount = 0`, `coupon_id = NULL` — no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added coupon and discount column to the transactions list table for better visibility.

* **Bug Fixes**
  * Improved discount and coupon tracking across payment gateways to accurately separate original and discounted amounts.
  * Fixed discount calculation logic in transaction records to ensure accurate financial reporting.

* **Chores**
  * Updated database schema to support enhanced coupon and discount fields in transaction records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->