### PR TITLE
fix: PayPal recurring subscription activated before payment confirmed

### DIFF
--- a/Lib/Gateway/Paypal.php
+++ b/Lib/Gateway/Paypal.php
@@ -683,13 +683,13 @@ class Paypal {
             $period = isset( $pack_meta['_cycle_period'] ) ? $pack_meta['_cycle_period'] : 'month';
             $interval = isset( $pack_meta['_billing_cycle_number'] ) ? intval( $pack_meta['_billing_cycle_number'] ) : 1;
 
-            // Create subscription data structure with all necessary meta
+            // 'pending' — BILLING.SUBSCRIPTION.CREATED fires before first payment; ACTIVATED event promotes to 'completed'.
             $subscription_data = [
                 'pack_id' => $custom_data['item_number'],
                 'posts' => isset( $pack_meta['_post_types'] ) ? $pack_meta['_post_types'] : [],
                 'total_feature_item' => isset( $pack_meta['_total_feature_item'] ) ? $pack_meta['_total_feature_item'] : '-1',
                 'remove_feature_item' => isset( $pack_meta['_remove_feature_item'] ) ? $pack_meta['_remove_feature_item'] : '-1',
-                'status' => 'completed',
+                'status' => 'pending',
                 'expire' => isset( $pack_meta['expire'] ) ? $pack_meta['expire'] : '',
                 'profile_id' => $subscription_id,
                 'recurring' => 'yes',
@@ -855,12 +855,11 @@ class Paypal {
                 }
             }
 
-            // Update local subscription status regardless of PayPal API result
-            $updated_subscription = [
-                'profile_id' => $subscription_id,
-                'status' => 'cancel',
-                'updated' => gmdate( 'Y-m-d H:i:s' ),
-            ];
+            // Merge status into existing subscription data to preserve pack_id, posts, recurring, etc.
+            $existing             = get_user_meta( $user_id, '_wpuf_subscription_pack', true );
+            $updated_subscription = is_array( $existing ) ? $existing : [];
+            $updated_subscription['status']  = 'cancel';
+            $updated_subscription['updated'] = gmdate( 'Y-m-d H:i:s' );
 
             update_user_meta( $user_id, '_wpuf_subscription_pack', $updated_subscription );
             update_user_meta( $user_id, '_wpuf_paypal_subscription_status', 'cancel' );
@@ -2216,12 +2215,12 @@ class Paypal {
             $user_id = $custom_data['user_id'];
             $subscription_id = $subscription['id'];
 
-            // Update subscription status in user meta
-            $subscription_data = [
-                'profile_id' => $subscription_id,
-                'status' => 'cancel',
-                'updated' => gmdate( 'Y-m-d H:i:s' ),
-            ];
+            // Merge status into existing subscription data to preserve pack_id, posts, recurring, etc.
+            $existing          = get_user_meta( $user_id, '_wpuf_subscription_pack', true );
+            $subscription_data = is_array( $existing ) ? $existing : [];
+            $subscription_data['profile_id'] = $subscription_id;
+            $subscription_data['status']     = 'cancel';
+            $subscription_data['updated']    = gmdate( 'Y-m-d H:i:s' );
 
             update_user_meta( $user_id, '_wpuf_subscription_pack', $subscription_data );
 


### PR DESCRIPTION
## Summary

Two bugs in `Lib/Gateway/Paypal.php` reported in weDevsOfficial/wpuf-pro#1443.

### Bug 1 — Subscription activated before payment

`handle_subscription_created()` fires on `BILLING.SUBSCRIPTION.CREATED`. PayPal sends this event when the user approves the subscription on PayPal's site — **before the first payment is captured**. The handler was storing `status = 'completed'`, granting the user immediate subscription access without any payment.

**Fix:** Store `status = 'pending'` on `BILLING.SUBSCRIPTION.CREATED`. `handle_subscription_activated()` already promotes to `'completed'` on `BILLING.SUBSCRIPTION.ACTIVATED`, which fires only after the first payment succeeds.

### Bug 2 — Cancellation destroys subscription meta

Both `handle_subscription_cancelled()` (webhook) and `cancel_subscription()` (user-triggered) called `update_user_meta()` with a sparse 3-key array `['profile_id', 'status', 'updated']`, overwriting the entire `_wpuf_subscription_pack` meta and destroying `pack_id`, `posts`, `recurring`, `cycle_period`, and all other stored subscription fields.

**Fix:** Both paths now read existing meta first and merge only `status = 'cancel'` and `updated` into it.

## Test plan

- [ ] Create a recurring PayPal subscription plan
- [ ] Begin checkout — approve subscription on PayPal but do not complete payment
- [ ] Confirm user does **not** have active subscription in WordPress
- [ ] Complete payment — confirm `BILLING.SUBSCRIPTION.ACTIVATED` fires and subscription becomes active
- [ ] Cancel subscription from plugin frontend — confirm `_wpuf_subscription_pack` meta still contains `pack_id`, `posts`, `recurring`, etc. with `status = 'cancel'`
- [ ] Cancel subscription via PayPal dashboard (webhook `BILLING.SUBSCRIPTION.CANCELLED`) — same check as above

🤖 Generated with [Claude Code](https://claude.com/claude-code)