### PR TITLE
fix: publish paid post on PayPal return when webhook is missing

### DIFF
--- a/Lib/Gateway/Paypal.php
+++ b/Lib/Gateway/Paypal.php
@@ -2124,7 +2124,16 @@ class Paypal {
                     $this->process_payment_capture( $capture );
                 } catch ( \Exception $e ) {
                     // Do not block the success redirect if local processing
-                    // fails; the webhook remains as a fallback.
+                    // fails; the webhook remains as a fallback. Emit a hook so the
+                    // "paid but not published" path leaves a diagnostic trail.
+                    do_action(
+                        'wpuf_paypal_return_processing_failed',
+                        [
+                            'token'      => $token,
+                            'capture_id' => isset( $capture['id'] ) ? $capture['id'] : '',
+                            'message'    => $e->getMessage(),
+                        ]
+                    );
                 }
             }
 

--- a/Lib/Gateway/Paypal.php
+++ b/Lib/Gateway/Paypal.php
@@ -2105,6 +2105,29 @@ class Paypal {
                 throw new \Exception( 'Payment not completed' );
             }
 
+            // Payment captured. Record the transaction and publish the post
+            // (or activate the pack) synchronously, so it does not depend solely
+            // on the PayPal webhook — which may be blocked or misconfigured on
+            // some hosts. process_payment_capture() is idempotent (it skips when
+            // the transaction already exists), so the webhook can still fire
+            // afterwards without creating a duplicate record.
+            if ( isset( $body['purchase_units'][0]['payments']['captures'][0] ) ) {
+                $capture = $body['purchase_units'][0]['payments']['captures'][0];
+
+                // PayPal usually copies custom_id onto the capture resource;
+                // fall back to the purchase unit's custom_id when it is absent.
+                if ( empty( $capture['custom_id'] ) && ! empty( $body['purchase_units'][0]['custom_id'] ) ) {
+                    $capture['custom_id'] = $body['purchase_units'][0]['custom_id'];
+                }
+
+                try {
+                    $this->process_payment_capture( $capture );
+                } catch ( \Exception $e ) {
+                    // Do not block the success redirect if local processing
+                    // fails; the webhook remains as a fallback.
+                }
+            }
+
             // Redirect to success page
             $success_url = add_query_arg(
                 [


### PR DESCRIPTION
## Problem

Paid posts remain in **Pending Review** after a successful PayPal payment when the PayPal webhook never reaches the site (firewall, missing/incorrect Webhook ID, or an unreachable endpoint). The customer is redirected to the configured Payment Success Page, the money is captured, but the post is never published.

Reported in: weDevsOfficial/wpuf-pro#1471 (https://github.com/weDevsOfficial/wpuf-pro/issues/1471#issuecomment-4679968845)

## Root cause

Since the 4.x PayPal REST/webhook refactor (#1789), the post status transition (`pending` → `publish`) depends **solely** on the `PAYMENT.CAPTURE.COMPLETED` webhook:

`process_webhook()` → `process_payment_capture()` → `Payment::insert_payment()` → `wpuf_payment_received` → `Subscription::handle_post_publish()` → `set_post_status()`.

The synchronous return handler `handle_paypal_return()` captures the payment via `/v2/checkout/orders/{id}/capture` and then **only redirects** to the success page — it never records the transaction or publishes the post. If the webhook is blocked or misconfigured, the post is stuck in Pending forever despite the payment being captured. (Pre-4.x, the IPN/return flow published the post synchronously, so this is a regression.)

## Fix

After a `COMPLETED` capture, `handle_paypal_return()` now processes the capture inline through the **existing** `process_payment_capture()` — the same method the webhook uses — so it records the transaction and fires `wpuf_payment_received` (publishing the post / activating the pack).

- **Idempotent:** `process_payment_capture()` skips when the transaction already exists. The capture id is the same value the webhook uses as `transaction_id`, so the webhook can still fire afterwards without creating a duplicate.
- **`custom_id` fallback:** uses the capture's `custom_id`, falling back to the purchase unit's `custom_id` when absent.
- **Non-blocking:** local processing errors are swallowed so the success redirect is never blocked after the money has been captured — the webhook remains a fallback.
- **Scope:** affects one-time `post` and `pack` returns only. Recurring subscriptions use `handle_subscription_return()` and are untouched.

## Testing

1. Configure a post form requiring PayPal payment, Post Status = Published.
2. **Without** a working PayPal webhook, submit a post and complete payment.
3. After the success redirect the post is **Published** (was Pending before this fix).
4. With a working webhook, confirm no duplicate transaction is recorded.

Fixes weDevsOfficial/wpuf-pro#1471

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PayPal payment confirmation reliability by immediately recording payments upon successful order capture, ensuring faster and more consistent payment processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->