### PR TITLE
fix: prevent unauthenticated attachment deletion & post-overwrite IDOR (#1562, #1563)

### DIFF
--- a/includes/Ajax/Upload_Ajax.php
+++ b/includes/Ajax/Upload_Ajax.php
@@ -168,6 +168,17 @@ class Upload_Ajax {
             $attach_data = wp_generate_attachment_metadata( $attach_id, $file_loc );
             wp_update_attachment_metadata( $attach_id, $attach_data );
 
+            // Mark the attachment as a WPUF upload so it can be safely
+            // identified and removed later through the wpuf_file_del endpoint.
+            update_post_meta( $attach_id, '_wpuf_attachment', 1 );
+
+            // Guests have no author id, so bind the upload to a per-session
+            // token. This prevents one visitor from deleting another visitor's
+            // (or any author-less) attachment via the public delete handler.
+            if ( ! is_user_logged_in() ) {
+                update_post_meta( $attach_id, '_wpuf_guest_token', $this->get_guest_upload_token() );
+            }
+
             return [
                 'success'   => true,
                 'attach_id' => $attach_id,
@@ -253,28 +264,109 @@ class Upload_Ajax {
 
     public function delete_file() {
         check_ajax_referer( 'wpuf_nonce', 'nonce' );
-        $post_data = wp_unslash( $_POST );
+        $post_data     = wp_unslash( $_POST );
         $attachment_id = isset( $post_data['attach_id'] ) ? absint( $post_data['attach_id'] ) : 0;
         if ( empty( $attachment_id ) ) {
             wp_send_json_error( [ 'message' => __( 'attach_id is required.', 'wp-user-frontend' ) ], 422 );
         }
         $attachment = get_post( $attachment_id );
 
-        if ( empty( $attachment ) ) {
+        if ( empty( $attachment ) || 'attachment' !== $attachment->post_type ) {
             wp_send_json_error( [ 'message' => __( 'attachment not found.', 'wp-user-frontend' ) ] );
         }
 
-        // post author or editor role
-        if ( get_current_user_id() == absint( $attachment->post_author ) || current_user_can(
-                'delete_private_pages'
-            ) ) {
-            $deleted = wp_delete_attachment( $attachment_id, true );
-            if ( $deleted ) {
-                wp_send_json_success( [ 'message' => __( 'Attachment deleted successfully.', 'wp-user-frontend' ) ] );
-            }
-            wp_send_json_error( [ 'message' => __( 'Could not deleted the attachment', 'wp-user-frontend' ) ], 422 );
+        if ( ! $this->can_delete_attachment( $attachment ) ) {
+            wp_send_json_error( [ 'message' => __( 'You are not allowed to delete this attachment.', 'wp-user-frontend' ) ], 403 );
         }
-        wp_send_json_error( [ 'message' => __( 'Something went wrong.', 'wp-user-frontend' ) ], 422 );
+
+        $deleted = wp_delete_attachment( $attachment_id, true );
+        if ( $deleted ) {
+            wp_send_json_success( [ 'message' => __( 'Attachment deleted successfully.', 'wp-user-frontend' ) ] );
+        }
+        wp_send_json_error( [ 'message' => __( 'Could not delete the attachment', 'wp-user-frontend' ) ], 422 );
+    }
+
+    /**
+     * Check whether the current request is allowed to delete an attachment
+     *
+     * Closes the unauthenticated arbitrary attachment deletion hole where any
+     * author-less attachment ( post_author = 0 ) could be removed because of a
+     * loose 0 == 0 comparison. Logged-in users may only remove their own
+     * uploads, guests may only remove uploads bound to their own session token,
+     * and users with the editor capability keep full control.
+     *
+     * @since WPUF_SINCE
+     *
+     * @param \WP_Post $attachment Attachment post object.
+     *
+     * @return bool
+     */
+    protected function can_delete_attachment( $attachment ) {
+        // Users able to manage others' content (editors, admins) keep full control.
+        if ( current_user_can( 'delete_private_pages' ) ) {
+            return true;
+        }
+
+        $author_id = (int) $attachment->post_author;
+
+        // Logged-in users can only delete attachments they own. The author of a
+        // real user upload is never 0, so the previous 0 == 0 bypass is gone.
+        if ( is_user_logged_in() ) {
+            return $author_id > 0 && (int) get_current_user_id() === $author_id;
+        }
+
+        // Guests may only remove author-less WPUF uploads bound to their session.
+        if ( 0 !== $author_id ) {
+            return false;
+        }
+
+        // Only WPUF-created uploads carry the marker; arbitrary site media does not.
+        if ( ! get_post_meta( $attachment->ID, '_wpuf_attachment', true ) ) {
+            return false;
+        }
+
+        $stored_token = (string) get_post_meta( $attachment->ID, '_wpuf_guest_token', true );
+        $cookie_token = isset( $_COOKIE['wpuf_guest_upload'] )
+            ? sanitize_text_field( wp_unslash( $_COOKIE['wpuf_guest_upload'] ) )
+            : '';
+
+        return '' !== $stored_token && '' !== $cookie_token && hash_equals( $stored_token, $cookie_token );
+    }
+
+    /**
+     * Get ( or create ) the per-session token used to bind guest uploads
+     *
+     * The token is stored in an http-only cookie and mirrored into attachment
+     * meta on upload so the public delete handler can verify ownership without
+     * relying on the author id, which is always 0 for guests.
+     *
+     * @since WPUF_SINCE
+     *
+     * @return string
+     */
+    protected function get_guest_upload_token() {
+        $token = isset( $_COOKIE['wpuf_guest_upload'] )
+            ? sanitize_text_field( wp_unslash( $_COOKIE['wpuf_guest_upload'] ) )
+            : '';
+
+        if ( empty( $token ) ) {
+            $token = wp_generate_password( 32, false );
+
+            setcookie(
+                'wpuf_guest_upload',
+                $token,
+                time() + DAY_IN_SECONDS,
+                COOKIEPATH ? COOKIEPATH : '/',
+                COOKIE_DOMAIN,
+                is_ssl(),
+                true
+            );
+
+            // Make the token available within the current request as well.
+            $_COOKIE['wpuf_guest_upload'] = $token;
+        }
+
+        return $token;
     }
 
     public function associate_file( $attach_id, $post_id ) {

--- a/includes/Ajax/Upload_Ajax.php
+++ b/includes/Ajax/Upload_Ajax.php
@@ -264,8 +264,7 @@ class Upload_Ajax {
 
     public function delete_file() {
         check_ajax_referer( 'wpuf_nonce', 'nonce' );
-        $post_data     = wp_unslash( $_POST );
-        $attachment_id = isset( $post_data['attach_id'] ) ? absint( $post_data['attach_id'] ) : 0;
+        $attachment_id = isset( $_POST['attach_id'] ) ? absint( wp_unslash( $_POST['attach_id'] ) ) : 0;
         if ( empty( $attachment_id ) ) {
             wp_send_json_error( [ 'message' => __( 'attach_id is required.', 'wp-user-frontend' ) ], 422 );
         }
@@ -352,14 +351,19 @@ class Upload_Ajax {
         if ( empty( $token ) ) {
             $token = wp_generate_password( 32, false );
 
+            // SameSite=Lax keeps the token from being sent on cross-site
+            // requests, adding defense in depth to the delete handler.
             setcookie(
                 'wpuf_guest_upload',
                 $token,
-                time() + DAY_IN_SECONDS,
-                COOKIEPATH ? COOKIEPATH : '/',
-                COOKIE_DOMAIN,
-                is_ssl(),
-                true
+                [
+                    'expires'  => time() + DAY_IN_SECONDS,
+                    'path'     => COOKIEPATH ? COOKIEPATH : '/',
+                    'domain'   => COOKIE_DOMAIN,
+                    'secure'   => is_ssl(),
+                    'httponly' => true,
+                    'samesite' => 'Lax',
+                ]
             );
 
             // Make the token available within the current request as well.

--- a/includes/Traits/FieldableTrait.php
+++ b/includes/Traits/FieldableTrait.php
@@ -426,8 +426,19 @@ trait FieldableTrait {
         }
 
         if ( ! empty( $wpuf_files['featured_image'] ) ) {
-            $attachment_id            = reset( $wpuf_files['featured_image'] );
-            $postarr['_thumbnail_id'] = $attachment_id;
+            $attachment_id = absint( reset( $wpuf_files['featured_image'] ) );
+            $attachment    = $attachment_id ? get_post( $attachment_id ) : null;
+
+            // Only set the thumbnail from a real attachment owned by the current
+            // requester. Otherwise an attacker could set _thumbnail_id to an
+            // arbitrary attachment, bypassing the guarded featured-image path.
+            if (
+                $attachment
+                && 'attachment' === $attachment->post_type
+                && self::current_user_owns_attachment( $attachment )
+            ) {
+                $postarr['_thumbnail_id'] = $attachment_id;
+            }
         }
 
         return $postarr;
@@ -470,10 +481,7 @@ trait FieldableTrait {
                 wpuf_associate_attachment( $attachment_id, $post_id );
                 set_post_thumbnail( $post_id, $attachment_id );
 
-                // @codingStandardsIgnoreStart
-                $file_data = isset( $_POST['wpuf_files_data'][ $attachment_id ] ) ?
-                    array_map( 'sanitize_text_field', wp_unslash( $_POST['wpuf_files_data'][ $attachment_id ] ) ) : false;
-                // @codingStandardsIgnoreEnd
+                $file_data = self::get_sanitized_file_data( $attachment_id );
 
                 if ( $file_data ) {
                     $args = [
@@ -512,6 +520,21 @@ trait FieldableTrait {
 
             $image_ids = '';
 
+            // Reject ids that are not attachments owned by / attachable to this
+            // post BEFORE storing them, so a crafted wpuf_files value cannot
+            // hijack, overwrite, delete or get persisted against an arbitrary post.
+            $valid_ids = [];
+
+            foreach ( $file_input['value'] as $attachment_id ) {
+                $attachment_id = absint( $attachment_id );
+
+                if ( self::is_attachment_associable( $attachment_id, $post_id ) ) {
+                    $valid_ids[] = $attachment_id;
+                }
+            }
+
+            $file_input['value'] = $valid_ids;
+
             if ( count( $file_input['value'] ) > 1 ) {
                 $image_ids = $file_input['value'];
             }
@@ -529,13 +552,6 @@ trait FieldableTrait {
 
             foreach ( $file_input['value'] as $attachment_id ) {
 
-                // Reject ids that are not attachments owned by / attachable to
-                // this post, so a crafted wpuf_files value cannot hijack,
-                // overwrite or delete an arbitrary post.
-                if ( ! self::is_attachment_associable( $attachment_id, $post_id ) ) {
-                    continue;
-                }
-
                 //if file numbers are greated than allowed number, prevent it from being uploaded
                 if ( $file_numbers >= $file_input['count'] ) {
                     wp_delete_attachment( $attachment_id );
@@ -546,12 +562,8 @@ trait FieldableTrait {
                 //add_post_meta( $post_id, $file_input['name'], $attachment_id );
 
                 // file title, caption, desc update
+                $file_data = self::get_sanitized_file_data( $attachment_id );
 
-                // @codingStandardsIgnoreStart
-                $file_data = isset( $_POST['wpuf_files_data'][ $attachment_id ] ) ?
-                    array_map( 'sanitize_text_field', wp_unslash( $_POST['wpuf_files_data'][ $attachment_id ] ) ) : false;
-
-                // @codingStandardsIgnoreEnd
                 if ( $file_data ) {
                     $args = [
                         'ID'           => $attachment_id,
@@ -573,8 +585,8 @@ trait FieldableTrait {
      *
      * Guards against an IDOR where a crafted wpuf_files value points to an
      * arbitrary post id or another user's attachment. Only real attachments
-     * that are unattached ( freshly uploaded ) or already belong to the given
-     * post are allowed.
+     * that already belong to the given post, or that are unattached AND owned
+     * by the current requester, are allowed.
      *
      * @since WPUF_SINCE
      *
@@ -599,12 +611,77 @@ trait FieldableTrait {
 
         $parent = (int) $attachment->post_parent;
 
-        // Allow only unattached uploads or files already belonging to this post.
-        if ( $parent && $parent !== $post_id ) {
+        // Already belongs to this post (e.g. editing an existing submission).
+        if ( $parent === $post_id ) {
+            return true;
+        }
+
+        // Attached to a different post — never allow hijacking it.
+        if ( $parent ) {
             return false;
         }
 
-        return true;
+        // Unattached: only the owner may associate it, otherwise an attacker
+        // could target another user's freshly-uploaded or library media.
+        return self::current_user_owns_attachment( $attachment );
+    }
+
+    /**
+     * Check whether the current request owns an unattached attachment
+     *
+     * @since WPUF_SINCE
+     *
+     * @param \WP_Post $attachment Attachment post object.
+     *
+     * @return bool
+     */
+    protected static function current_user_owns_attachment( $attachment ) {
+        $author_id = (int) $attachment->post_author;
+
+        if ( is_user_logged_in() ) {
+            if ( $author_id > 0 && get_current_user_id() === $author_id ) {
+                return true;
+            }
+
+            return current_user_can( 'edit_post', $attachment->ID );
+        }
+
+        // Guests: only author-less WPUF uploads bound to their session token.
+        if ( 0 !== $author_id || ! get_post_meta( $attachment->ID, '_wpuf_attachment', true ) ) {
+            return false;
+        }
+
+        $stored_token = (string) get_post_meta( $attachment->ID, '_wpuf_guest_token', true );
+        $cookie_token = isset( $_COOKIE['wpuf_guest_upload'] )
+            ? sanitize_text_field( wp_unslash( $_COOKIE['wpuf_guest_upload'] ) )
+            : '';
+
+        return '' !== $stored_token && '' !== $cookie_token && hash_equals( $stored_token, $cookie_token );
+    }
+
+    /**
+     * Get sanitized, validated file meta (title/desc/caption) for an attachment
+     *
+     * @since WPUF_SINCE
+     *
+     * @param int $attachment_id
+     *
+     * @return array|false
+     */
+    protected static function get_sanitized_file_data( $attachment_id ) {
+        // @codingStandardsIgnoreStart
+        if ( empty( $_POST['wpuf_files_data'][ $attachment_id ] ) || ! is_array( $_POST['wpuf_files_data'][ $attachment_id ] ) ) {
+            return false;
+        }
+
+        $raw = array_map( 'sanitize_text_field', wp_unslash( $_POST['wpuf_files_data'][ $attachment_id ] ) );
+        // @codingStandardsIgnoreEnd
+
+        return [
+            'title'   => isset( $raw['title'] ) ? $raw['title'] : '',
+            'desc'    => isset( $raw['desc'] ) ? $raw['desc'] : '',
+            'caption' => isset( $raw['caption'] ) ? $raw['caption'] : '',
+        ];
     }
 
     /**

--- a/includes/Traits/FieldableTrait.php
+++ b/includes/Traits/FieldableTrait.php
@@ -462,22 +462,30 @@ trait FieldableTrait {
         if ( isset( $wpuf_files['featured_image'] ) ) {
                 $attachment_id = reset( $wpuf_files['featured_image'] );
 
+            // @codingStandardsIgnoreEnd
+            // Make sure the supplied id is really an attachment that belongs to
+            // this post. Without this an attacker could point featured_image at
+            // an arbitrary post id and overwrite its title/content/excerpt.
+            if ( self::is_attachment_associable( $attachment_id, $post_id ) ) {
                 wpuf_associate_attachment( $attachment_id, $post_id );
                 set_post_thumbnail( $post_id, $attachment_id );
 
-                $file_data = isset( $_POST['wpuf_files_data'][ $attachment_id ] ) ? $_POST['wpuf_files_data'][ $attachment_id ] : false;
+                // @codingStandardsIgnoreStart
+                $file_data = isset( $_POST['wpuf_files_data'][ $attachment_id ] ) ?
+                    array_map( 'sanitize_text_field', wp_unslash( $_POST['wpuf_files_data'][ $attachment_id ] ) ) : false;
+                // @codingStandardsIgnoreEnd
 
-            // @codingStandardsIgnoreEnd
-            if ( $file_data ) {
-                $args = [
-                    'ID'           => $attachment_id,
-                    'post_title'   => $file_data['title'],
-                    'post_content' => $file_data['desc'],
-                    'post_excerpt' => $file_data['caption'],
-                ];
-                wpuf_update_post( $args );
+                if ( $file_data ) {
+                    $args = [
+                        'ID'           => $attachment_id,
+                        'post_title'   => $file_data['title'],
+                        'post_content' => $file_data['desc'],
+                        'post_excerpt' => $file_data['caption'],
+                    ];
+                    wpuf_update_post( $args );
 
-                update_post_meta( $attachment_id, '_wp_attachment_image_alt', $file_data['title'] );
+                    update_post_meta( $attachment_id, '_wp_attachment_image_alt', $file_data['title'] );
+                }
             }
         }
 
@@ -521,6 +529,13 @@ trait FieldableTrait {
 
             foreach ( $file_input['value'] as $attachment_id ) {
 
+                // Reject ids that are not attachments owned by / attachable to
+                // this post, so a crafted wpuf_files value cannot hijack,
+                // overwrite or delete an arbitrary post.
+                if ( ! self::is_attachment_associable( $attachment_id, $post_id ) ) {
+                    continue;
+                }
+
                 //if file numbers are greated than allowed number, prevent it from being uploaded
                 if ( $file_numbers >= $file_input['count'] ) {
                     wp_delete_attachment( $attachment_id );
@@ -551,6 +566,45 @@ trait FieldableTrait {
                 $file_numbers++;
             }
         }
+    }
+
+    /**
+     * Check whether an attachment may be associated with / edited for a post
+     *
+     * Guards against an IDOR where a crafted wpuf_files value points to an
+     * arbitrary post id or another user's attachment. Only real attachments
+     * that are unattached ( freshly uploaded ) or already belong to the given
+     * post are allowed.
+     *
+     * @since WPUF_SINCE
+     *
+     * @param int $attachment_id
+     * @param int $post_id
+     *
+     * @return bool
+     */
+    protected static function is_attachment_associable( $attachment_id, $post_id ) {
+        $attachment_id = absint( $attachment_id );
+        $post_id       = absint( $post_id );
+
+        if ( ! $attachment_id || ! $post_id ) {
+            return false;
+        }
+
+        $attachment = get_post( $attachment_id );
+
+        if ( ! $attachment || 'attachment' !== $attachment->post_type ) {
+            return false;
+        }
+
+        $parent = (int) $attachment->post_parent;
+
+        // Allow only unattached uploads or files already belonging to this post.
+        if ( $parent && $parent !== $post_id ) {
+            return false;
+        }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes two authorization vulnerabilities reported against WPUF <= 4.3.7 (issues weDevsOfficial/wpuf-pro#1562 and weDevsOfficial/wpuf-pro#1563 — the vulnerable code lives in the free plugin).

### #1562 — Unauthenticated arbitrary attachment deletion (`wpuf_file_del`)
`delete_file()` gated deletion with a loose `get_current_user_id() == $attachment->post_author` check. Unauthenticated requests have user id `0`, and guest/registration uploads (and any author-less media) have `post_author = 0`, so `0 == 0` let any unauthenticated visitor delete those attachments. The required `wpuf_nonce` is publicly localized on every front-end page with a WPUF shortcode.

**Fix** — `can_delete_attachment()`:
- Editors (`delete_private_pages`) keep full control.
- Logged-in users may delete only their own uploads (strict `===`; author `0` no longer matches).
- Guests may delete only WPUF-created uploads (`_wpuf_attachment` marker) bound to their own session via a per-upload token stored in an http-only cookie + attachment meta at upload time (`hash_equals`).
- Endpoint now also rejects non-attachment post types.

The legitimate guest "remove file before submit" flow is preserved.

### #1563 — IDOR arbitrary post overwrite (`wpuf_files` / `wpuf_files_data`)
`update_post_meta()` passed a user-controlled id straight into `wpuf_associate_attachment()`, `set_post_thumbnail()` and `wpuf_update_post()`. A crafted `featured_image` / file value could point at an arbitrary post and overwrite its `post_title` / `post_content` / `post_excerpt` (or delete it via the over-limit cleanup).

**Fix** — `is_attachment_associable()` requires the id to be a real `attachment` that is unattached or already belongs to the post being edited, before any associate / thumbnail / update / over-limit-delete. The featured-image `wpuf_files_data` branch is now sanitized too.

## Testing
Reproduced both on a 4.3.7 install (real plugin code), then verified the fix:

| | Before | After |
|---|---|---|
| #1562 unauth delete | `success:true`, attachment deleted | HTTP 403, attachment intact |
| #1563 IDOR overwrite | admin post overwritten | admin post unchanged |

Regression (fixed code, live): guest with correct session cookie deletes own upload ✓; another guest's cookie → 403 ✓; logged-in owner deletes own ✓; editor cap ✓. Plus standalone unit cases for both gates.

`phpcs --standard=phpcs.xml.dist` on the changed lines: 0 violations.

> Note: `@since WPUF_SINCE` placeholders to be bumped to the release version on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened security for guest file uploads by using per-session, http-only tokens to validate attachment ownership.
  * Improved authorization for attachment deletion: requests are now validated, and only the correct owners/eligible attachments can be removed.
  * Hardened featured image handling to prevent crafted file IDs from being attached or used as thumbnails improperly.
  * Sanitized and validated attachment data before applying metadata and thumbnail/featured-image updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->