### PR TITLE
fix: Credit Card payment gateway preview broken when Pro is off

### DIFF
--- a/Lib/WeDevs_Settings_API.php
+++ b/Lib/WeDevs_Settings_API.php
@@ -413,6 +413,11 @@ class WeDevs_Settings_API {
 
                         <div class="wpuf-gateway-card__name">
                             <?php echo esc_html( $admin_label ); ?>
+                            <?php if ( $is_pro ) : ?>
+                                <span class="wpuf-gateway-card__pro">
+                                    <img src="<?php echo esc_url( WPUF_ASSET_URI . '/images/pro-badge.svg' ); ?>" alt="<?php esc_attr_e( 'PRO', 'wp-user-frontend' ); ?>" />
+                                </span>
+                            <?php endif; ?>
                         </div>
                     </div>
                 <?php endforeach; ?>

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -1539,12 +1539,20 @@ body.wpuf-modal-open {
   opacity: 0.6;
   cursor: not-allowed;
 }
-.wpuf-gateway-card__checkbox {
+.wpuf-gateway-cards .wpuf-gateway-card__checkbox {
   position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: 0;
+  padding: 0;
+  border: 0;
   opacity: 0;
-  width: 0;
-  height: 0;
   pointer-events: none;
+  -webkit-appearance: none;
+  appearance: none;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  overflow: hidden;
 }
 .wpuf-gateway-card__toggle {
   position: absolute;
@@ -1593,6 +1601,18 @@ body.wpuf-modal-open {
   color: #1d2327;
   text-align: center;
   line-height: 1.3;
+  word-break: break-word;
+  overflow-wrap: anywhere;
+}
+.wpuf-gateway-card__pro {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 4px;
+  vertical-align: middle;
+}
+.wpuf-gateway-card__pro img {
+  height: 14px;
+  width: auto;
 }
 tr.wpuf-gateway-setting-row {
   transition: opacity 0.15s ease;

--- a/assets/less/admin.less
+++ b/assets/less/admin.less
@@ -1582,12 +1582,23 @@ body.wpuf-modal-open {
         cursor: not-allowed;
     }
 
-    &__checkbox {
+    // Hide the native checkbox robustly. The extra container class beats WP
+    // core's input[type=checkbox] rule, which would otherwise re-size it and
+    // render a second checkmark next to the custom toggle.
+    .wpuf-gateway-cards &__checkbox {
         position: absolute;
+        width: 1px;
+        height: 1px;
+        margin: 0;
+        padding: 0;
+        border: 0;
         opacity: 0;
-        width: 0;
-        height: 0;
         pointer-events: none;
+        -webkit-appearance: none;
+        appearance: none;
+        clip: rect(0 0 0 0);
+        clip-path: inset(50%);
+        overflow: hidden;
     }
 
     &__toggle {
@@ -1646,6 +1657,20 @@ body.wpuf-modal-open {
         color: #1d2327;
         text-align: center;
         line-height: 1.3;
+        word-break: break-word;
+        overflow-wrap: anywhere;
+    }
+
+    &__pro {
+        display: inline-flex;
+        align-items: center;
+        margin-left: 4px;
+        vertical-align: middle;
+
+        img {
+            height: 14px;
+            width: auto;
+        }
     }
 }
 

--- a/includes/Free/Free_Loader.php
+++ b/includes/Free/Free_Loader.php
@@ -1475,21 +1475,14 @@ class Free_Loader extends Pro_Prompt {
      * @return void
      */
     public function wpuf_payment_gateways( $gateways ) {
-        $crown_icon = WPUF_ROOT . '/assets/images/pro-badge.svg';
-        $crown      = '';
-
-        if ( file_exists( $crown_icon ) ) {
-            $crown = sprintf( '<span class="pro-icon-title"> %s</span>', '<img src="' . WPUF_ASSET_URI . '/images/pro-badge.svg" alt="PRO">' );
-        }
-
+        // Keep the admin label as plain text. The PRO badge is rendered by the
+        // gateway card UI based on the is_pro_preview flag, so embedding badge
+        // markup here would only show up as escaped text in the card grid.
         $gateways['stripe'] = [
-            'admin_label'    => sprintf(
-                // translators: %s is the crown symbol
-                __( 'Credit Card %s', 'wp-user-frontend' ),
-                $crown
-            ),
+            'admin_label'    => __( 'Credit Card', 'wp-user-frontend' ),
             'checkout_label' => __( 'Credit Card', 'wp-user-frontend' ),
             'label_class'    => 'pro-preview',
+            'is_pro_preview' => true,
         ];
 
         return $gateways;


### PR DESCRIPTION
## Summary

When WP User Frontend Pro is **deactivated**, the **Credit Card** option in **Settings → Payment → Payment Gateways** rendered broken: the gateway label printed raw escaped HTML (`Credit Card <span class="pro-icon-title"> <img ...pro-badge.svg ...>`) instead of a PRO badge, which also blew the card width out.

### Root cause
The card-grid gateway selector (#1830) prints the gateway `admin_label` via `esc_html()`. The free Stripe/Credit Card preview built its `admin_label` with embedded pro-badge markup, so that markup showed up as literal escaped text.

A second, related glitch: WordPress core's `input[type=checkbox]` styling has higher specificity than the plugin's `.wpuf-gateway-card__checkbox` hide, so core re-sized the hidden native checkbox and drew its own checkmark next to the custom green-circle toggle — a "double checkbox".

## Changes
- `Free_Loader::wpuf_payment_gateways()` — plain `Credit Card` `admin_label` + `is_pro_preview => true` instead of embedding badge markup in the label.
- Gateway card template — renders the PRO badge from `is_pro_preview` (escaped `esc_url`/`esc_attr_e`); label stays `esc_html`.
- `admin.less` / `admin.css` — hardened the native-checkbox hide (higher specificity + `clip`) so core can't re-size it / draw a second check; added PRO badge styles and safe name wrapping.

The original green-circle selection toggle is preserved. PayPal/Bank selection and saving are unchanged.

## Testing
On a local install, toggling Pro off/on:

| | Before | After |
|---|---|---|
| Pro OFF | Credit Card shows escaped HTML, oversized card | Credit Card shows as locked PRO preview (badge, greyed, disabled) |
| Pro ON | real Stripe gateway | unchanged |
| Selection indicator | native checkbox doubling the green toggle | single green-circle toggle, native checkbox fully hidden |

Verified each card renders exactly one visible toggle, PRO badge only on the Credit Card preview, no escaped HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added PRO badge indicators to gateway cards to highlight premium gateway options.

* **Style**
  * Enhanced gateway card styling with improved text wrapping and refined checkbox visibility handling for better visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->