### PR TITLE
ci(e2e): refresh apt before playwright --with-deps (ondrej PPA label change)

### DIFF
--- a/.github/workflows/e2e-wpuf.yml
+++ b/.github/workflows/e2e-wpuf.yml
@@ -140,6 +140,13 @@ jobs:
             restore-keys: |
                 ${{ runner.os }}-playwright-
 
+      # setup-php adds the ondrej/php PPA; its InRelease Label later changed, so
+      # apt-get update fails (exit 100) and 'playwright install --with-deps' dies.
+      # Acknowledge the label change before installing browser OS dependencies.
+      - name: Refresh apt sources (ondrej PPA label changed)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: sudo apt-get update --allow-releaseinfo-change
+
       # Install browser binaries & OS dependencies if cache missed
       - name: Install Playwright browser binaries & OS dependencies
         id: pw-install


### PR DESCRIPTION
setup-php adds the ondrej/php PPA; its InRelease Label changed ("PPA for PHP" → redirect notice), so `apt-get update` fails with exit 100 and `playwright install --with-deps` dies ("Failed to install browsers"). This blocked the e2e run right after the wpuf-pro clone succeeded.

Fix: run `apt-get update --allow-releaseinfo-change` before the browser-deps install, only on Playwright cache miss (when --with-deps actually hits apt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the end-to-end test workflow to better handle cached Playwright browser downloads by refreshing package sources when needed. This helps installation steps run more reliably in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->