### PR TITLE
fix: guard against a null field object in the legacy render form

### DIFF
--- a/includes/class-frontend-render-form.php
+++ b/includes/class-frontend-render-form.php
@@ -751,7 +751,7 @@ class WPUF_Frontend_Render_Form {
             $wpuf_field = wpuf()->fields->get_field( $value['template'] );
             $posted_field_data = isset( $post_data[ $value['name'] ] ) ? $post_data[ $value['name'] ] : null;
 
-            if ( isset( $posted_field_data ) && method_exists( $wpuf_field, 'sanitize_field_data' ) ) {
+            if ( isset( $posted_field_data ) && $wpuf_field && method_exists( $wpuf_field, 'sanitize_field_data' ) ) {
                 $meta_key_value[ $value['name'] ] = $wpuf_field->sanitize_field_data( $posted_field_data, $value );
                 continue;
             } elseif ( isset( $post_data[ $value['name'] ] ) && is_array( $post_data[ $value['name'] ] ) ) {


### PR DESCRIPTION
## Problem

`WPUF_Frontend_Render_Form::prepare_meta_fields()` resolves the field object and then immediately reflects on it:

```php
$wpuf_field = wpuf()->fields->get_field( $value['template'] );
...
if ( isset( $posted_field_data ) && method_exists( $wpuf_field, 'sanitize_field_data' ) ) {
```

`Field_Manager::get_field()` (`includes/Admin/Forms/Field_Manager.php:72`) has no `else` — it falls off the end and returns `null` when the submitted field's `template` is not a registered field type. That happens with a field left over from a deactivated module, or a Pro field on a free-only install.

On PHP 8 `method_exists( null, ... )` is a `TypeError`, so the whole submission fatals instead of falling through to the plain `sanitize_text_field()` branch below.

## Fix

One token — the same guard that already shipped in 4.3.9 for the modern path:

```php
if ( isset( $posted_field_data ) && $wpuf_field && method_exists( $wpuf_field, 'sanitize_field_data' ) ) {
```

## Why this wasn't covered by the 4.3.9 fix

#1900 described **both** call sites but its diff only touched `FieldableTrait::prepare_meta_fields()`. That one is on `develop` at `FieldableTrait.php:843`; this legacy one was left unguarded. Found while closing #1900 as a duplicate.

## Behaviour

No behaviour change on the working path — when `$wpuf_field` is a real object the condition is identical. When it is `null`, execution now reaches the existing `elseif`/`else` sanitize branches instead of fatalling, which is what the modern path already does.

## Verification

- `php -l` clean
- Matches the already-merged line in `FieldableTrait.php` character for character
- PHPCS not run locally (no `vendor/bin/phpcs` in this checkout) — leaving it to the Inspections job

Refs #1832

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form submission handling by preventing invalid field sanitization checks when a field is unavailable.
  * Increased stability when processing posted form data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->