### PR TITLE
fix: repair the admin review notice and keep notices out of the premium topbar

### DIFF
--- a/assets/css/admin/premium.css
+++ b/assets/css/admin/premium.css
@@ -154,6 +154,19 @@ body .wpuf-premium-page h4 {
     padding: 0 20px;
 }
 
+/* Admin notices park after the topbar, at the wp-header-end marker in the
+   view. #wpcontent's left padding is zeroed above so the bands can run
+   edge-to-edge; without this the notices would sit flush against the menu
+   instead of following the page's own rhythm. */
+.wpuf-premium-page > .notice,
+.wpuf-premium-page > .updated,
+.wpuf-premium-page > .error,
+.wpuf-premium-page > #wpuf-review-notice {
+    max-width: 1256px;
+    margin-right: auto;
+    margin-left: auto;
+}
+
 /* Shared building blocks ------------------------------------------------- */
 .wpuf-pp-section {
     padding: 72px 0;

--- a/includes/Admin/Promotion.php
+++ b/includes/Admin/Promotion.php
@@ -121,7 +121,20 @@ class Promotion {
                 </div>
             </div>
             <style type="text/css">
+                /*
+                 * These links only borrow .notice-dismiss to hook the dismiss
+                 * handler below; they are inline labels, not core's X button.
+                 * Core styles that class as a 24x24 absolutely positioned flex
+                 * box, so every one of those properties has to be undone or the
+                 * labels get clamped to 24px and wrap one word per line.
+                 */
                 #wpuf-review-notice .notice-dismiss{
+                    position: relative;
+                    top: auto;
+                    right: auto;
+                    display: inline-block;
+                    width: auto;
+                    height: auto;
                     padding: 0 0 0 26px;
                 }
 

--- a/includes/Admin/views/premium.php
+++ b/includes/Admin/views/premium.php
@@ -231,6 +231,16 @@ $wpuf_plans = [
         </div>
     </div>
 
+    <?php
+    /*
+     * Parks admin notices here. Without this marker core's common.js relocates
+     * every .notice to just after the first h1/h2 inside .wrap — which on this
+     * page is the topbar title, nested in a flex row. Notices then become flex
+     * items and collapse into unreadable narrow columns.
+     */
+    ?>
+    <hr class="wp-header-end">
+
     <div class="wpuf-premium-page__inner">
 
         <?php // 1. Hero. ?>


### PR DESCRIPTION
Two separate admin-notice defects, found while investigating one screenshot.

### 1. Review notice links collapsed to a 24px column

The three links in `#wpuf-review-notice` borrow core's `.notice-dismiss` class to hook the dismiss handler in the inline script. Core styles that class as its **X button** — absolutely positioned, `width: 24px; height: 24px; display: flex`.

The plugin's inline CSS overrode `display`, `position` and `padding`, but never `width`. Both dismiss links were therefore clamped to 24px and wrapped one word per line, while "Sure! I'd love to!" rendered fine — it carries no `.notice-dismiss` class. That asymmetry is what pinned the rule.

Not a regression in this plugin: core gained `width`/`height`/`display:flex` on `.notice-dismiss` in a later release, and the plugin's overrides no longer covered the whole rule. It affects every WPUF admin page on a current WordPress.

Fix undoes the sizing and offsets explicitly.

### 2. Promotional banner landed inside the premium topbar

`includes/Admin/views/premium.php` opens `<div class="wrap wpuf-premium-page">` with no `<hr class="wp-header-end">`, so core's `common.js` relocates every `.notice` to just after the first `h1`/`h2` in `.wrap`. Here that is the topbar title, nested in `.wpuf-pp-topbar__left` (`display: flex`) — so `#wpuf-bfcm-notice` became a flex item and collapsed.

Adds the marker between topbar and hero, and centres relocated notices on the page width: `#wpcontent`'s left padding is zeroed on this page so the bands can run edge to edge, which would otherwise leave notices flush against the admin menu.

Only the promo banner is relocated — the review notice has no `.notice` class, so core never moves it. The two defects are independent.

### Testing

- [x] `php -l` clean on both PHP files
- [ ] `composer phpcs` — **not run**, `vendor/bin/phpcs` absent in this checkout (`composer phpcs` exits 127)
- [ ] **Visual confirmation pending** — committed at the author's request before the rendered result was verified in a browser

Reproducing the review notice locally needs `wpuf_review_notice_dismiss` set to `no` and an install older than 15 days.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the Premium page layout so administrative notices align consistently with the page content.
  - Fixed notice dismissal controls to remain properly positioned and sized without wrapping or being clipped.
  - Prevented notices from appearing in unintended locations within the Premium page.

- **Style**
  - Added a clearer visual separation between the page header and its content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->