### PR TITLE
fix(security): block AI form-builder object injection & User Directory data disclosure

### DIFF
--- a/includes/AI/RestController.php
+++ b/includes/AI/RestController.php
@@ -1091,6 +1091,18 @@ class RestController extends WP_REST_Controller {
                     continue; // Skip invalid fields
                 }
 
+                // Reject a field whose input_type does not match its template
+                // (the AI form-builder object-injection primitive).
+                if ( ! $this->is_valid_field_definition( $field ) ) {
+                    wp_delete_post( $form_id, true );
+
+                    return new WP_Error(
+                        'invalid_field_definition',
+                        __( 'A submitted field has a template and input type that do not match.', 'wp-user-frontend' ),
+                        [ 'status' => 400 ]
+                    );
+                }
+
                 // Sanitize field data
                 $field['name'] = sanitize_key($field['name']);
                 $field['label'] = sanitize_text_field($field['label'] ?? '');
@@ -1641,7 +1653,74 @@ class RestController extends WP_REST_Controller {
      * @param int $form_id Form ID
      * @param array $fields Updated fields
      */
+    /**
+     * Build the allowed "template => input_type" map from the field registry.
+     *
+     * Derived from the canonical registry (free + pro via the `wpuf_form_fields`
+     * filter) so a submitted field cannot pair a template with a mismatched
+     * input_type — the primitive behind the AI form-builder object injection.
+     *
+     * @since WPUF_SINCE
+     *
+     * @return array<string, string> Template slug => canonical input type.
+     */
+    private function get_allowed_field_type_map() {
+        static $map = null;
+
+        if ( null !== $map ) {
+            return $map;
+        }
+
+        $map           = [];
+        $field_manager = new \WeDevs\Wpuf\Admin\Forms\Field_Manager();
+
+        foreach ( $field_manager->get_fields() as $template => $field_object ) {
+            if ( is_object( $field_object ) && method_exists( $field_object, 'get_field_props' ) ) {
+                $props = $field_object->get_field_props();
+
+                if ( isset( $props['input_type'] ) ) {
+                    $map[ $template ] = $props['input_type'];
+                }
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * Whether a submitted field's input_type is consistent with its template.
+     *
+     * Rejects mismatched definitions (e.g. input_type "text" on a "section_break"
+     * template) so an attacker cannot route a field through the wrong renderer.
+     * Unknown templates pass through — the render layer no longer instantiates
+     * objects, and unregistered templates are handled by their own renderers.
+     *
+     * @since WPUF_SINCE
+     *
+     * @param array $field Field definition.
+     *
+     * @return bool
+     */
+    private function is_valid_field_definition( $field ) {
+        if ( empty( $field['template'] ) || empty( $field['input_type'] ) ) {
+            return true;
+        }
+
+        $allowed  = $this->get_allowed_field_type_map();
+        $template = sanitize_key( $field['template'] );
+
+        if ( ! isset( $allowed[ $template ] ) ) {
+            return true;
+        }
+
+        return $allowed[ $template ] === $field['input_type'];
+    }
+
     private function update_form_field_posts($form_id, $fields) {
+        // Drop any field whose template/input_type pairing is invalid before saving,
+        // so a mismatched (object-injection) definition can never be persisted.
+        $fields = array_values( array_filter( $fields, [ $this, 'is_valid_field_definition' ] ) );
+
         // Get existing field posts ordered by menu_order
         $existing_posts = get_posts([
             'post_type' => 'wpuf_input',

--- a/includes/AI/RestController.php
+++ b/includes/AI/RestController.php
@@ -1094,7 +1094,7 @@ class RestController extends WP_REST_Controller {
                 // Reject a field whose input_type does not match its template
                 // (the AI form-builder object-injection primitive).
                 if ( ! $this->is_valid_field_definition( $field ) ) {
-                    wp_delete_post( $form_id, true );
+                    $this->delete_ai_form_and_field_posts( $form_id );
 
                     return new WP_Error(
                         'invalid_field_definition',
@@ -1119,7 +1119,7 @@ class RestController extends WP_REST_Controller {
 
                 if (is_wp_error($field_id)) {
                     // Clean up previously created fields and the form post
-                    wp_delete_post($form_id, true);
+                    $this->delete_ai_form_and_field_posts( $form_id );
                     return new WP_Error(
                         'field_creation_failed',
                         sprintf(__('Failed to create field at position %d: %s', 'wp-user-frontend'), $order, $field_id->get_error_message()),
@@ -1648,12 +1648,6 @@ class RestController extends WP_REST_Controller {
     }
 
     /**
-     * Update form field child posts
-     *
-     * @param int $form_id Form ID
-     * @param array $fields Updated fields
-     */
-    /**
      * Build the allowed "template => input_type" map from the field registry.
      *
      * Derived from the canonical registry (free + pro via the `wpuf_form_fields`
@@ -1716,6 +1710,43 @@ class RestController extends WP_REST_Controller {
         return $allowed[ $template ] === $field['input_type'];
     }
 
+    /**
+     * Delete an AI-created form along with any field child posts already inserted.
+     *
+     * wp_delete_post() does not cascade to children for non-hierarchical post
+     * types, so remove the wpuf_input children explicitly before the form itself
+     * to avoid orphaned field posts when an AI form build is rejected or fails.
+     *
+     * @since WPUF_SINCE
+     *
+     * @param int $form_id Form ID.
+     *
+     * @return void
+     */
+    private function delete_ai_form_and_field_posts( $form_id ) {
+        $field_ids = get_posts(
+            [
+                'post_type'      => 'wpuf_input',
+                'post_parent'    => $form_id,
+                'posts_per_page' => -1,
+                'post_status'    => 'any',
+                'fields'         => 'ids',
+            ]
+        );
+
+        foreach ( $field_ids as $field_id ) {
+            wp_delete_post( $field_id, true );
+        }
+
+        wp_delete_post( $form_id, true );
+    }
+
+    /**
+     * Update form field child posts
+     *
+     * @param int $form_id Form ID
+     * @param array $fields Updated fields
+     */
     private function update_form_field_posts($form_id, $fields) {
         // Drop any field whose template/input_type pairing is invalid before saving,
         // so a mismatched (object-injection) definition can never be persisted.

--- a/modules/user-directory/Api/Directory.php
+++ b/modules/user-directory/Api/Directory.php
@@ -513,22 +513,29 @@ class Directory extends WP_REST_Controller {
         $avatar_size  = ! empty( $request['avatar_size'] ) ? absint( $request['avatar_size'] ) : 128;
         $base_url     = ! empty( $request['base_url'] ) ? esc_url_raw( $request['base_url'] ) : '';
 
-        // Get directory settings
-        $settings = [];
-        if ( $directory_id ) {
-            $post = get_post( $directory_id );
-            if ( $post && User_Directory::POST_TYPE === $post->post_type && 'publish' === $post->post_status ) {
-                $settings = json_decode( $post->post_content, true ) ?: [];
-            } elseif ( $post && 'publish' !== $post->post_status ) {
-                return new WP_Error(
-                    'directory_not_published',
-                    __( 'Directory is not available.', 'wp-user-frontend' ),
-                    [ 'status' => 403 ]
-                );
-            }
+        // A published directory is required. Without it this public endpoint would
+        // enumerate every registered user (including admins), so refuse the request
+        // when no valid, published directory is supplied.
+        if ( ! $directory_id ) {
+            return new WP_Error(
+                'directory_required',
+                __( 'A valid directory is required.', 'wp-user-frontend' ),
+                [ 'status' => 400 ]
+            );
         }
 
-        // Merge with defaults
+        $post = get_post( $directory_id );
+
+        if ( ! $post || User_Directory::POST_TYPE !== $post->post_type || 'publish' !== $post->post_status ) {
+            return new WP_Error(
+                'directory_not_available',
+                __( 'Directory is not available.', 'wp-user-frontend' ),
+                [ 'status' => 404 ]
+            );
+        }
+
+        // Get directory settings, merged with defaults
+        $settings = json_decode( $post->post_content, true ) ?: [];
         $settings = wp_parse_args( $settings, User_Directory::get_default_settings() );
 
         // Build user query args - check users_per_page first (admin setting), then per_page

--- a/modules/user-directory/Helpers.php
+++ b/modules/user-directory/Helpers.php
@@ -13,6 +13,25 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+if ( ! function_exists( 'wpuf_ud_show_contact_info' ) ) {
+    /**
+     * Whether a viewer may see a user's contact details (email, phone).
+     *
+     * Hidden from anonymous visitors, matching WordPress core which never exposes
+     * user email to unauthenticated callers. Filterable so a site can deliberately
+     * opt in to public contact info. Shared by the free and pro directory output.
+     *
+     * @since WPUF_SINCE
+     *
+     * @param \WP_User|null $user The user whose contact info would be shown.
+     *
+     * @return bool
+     */
+    function wpuf_ud_show_contact_info( $user = null ) {
+        return (bool) apply_filters( 'wpuf_ud_show_contact_info', is_user_logged_in(), $user );
+    }
+}
+
 // Register cron handler for background Gravatar checks (Issue #20 performance fix)
 add_action( 'wpuf_ud_check_gravatar', 'wpuf_ud_do_gravatar_check', 10, 2 );
 
@@ -453,9 +472,10 @@ function wpuf_ud_get_profile_data( $user, $template_data = [], $layout = 'layout
         'bio'          => get_user_meta( $user->ID, 'description', true ),
     ];
 
-    // Build contact info - Using Pro-style icons with emerald circular background
+    // Build contact info - Using Pro-style icons with emerald circular background.
+    // Contact details are withheld from anonymous visitors (matching WP core).
     $contact_info = [];
-    if ( ! empty( $user->user_email ) ) {
+    if ( ! empty( $user->user_email ) && wpuf_ud_show_contact_info( $user ) ) {
         $contact_info['email'] = [
             'label'         => __( 'Email', 'wp-user-frontend' ),
             'value'         => $user->user_email,

--- a/modules/user-directory/views/directory/template-parts/row-3.php
+++ b/modules/user-directory/views/directory/template-parts/row-3.php
@@ -28,6 +28,12 @@ $last_name  = get_user_meta( $user->ID, 'last_name', true );
 // Get phone number
 $phone = get_user_meta( $user->ID, 'wpuf_profile_phone', true );
 
+// Contact details (email, phone) are hidden from anonymous visitors, matching
+// WordPress core which never exposes user email to unauthenticated callers.
+$show_contact_info = function_exists( 'wpuf_ud_show_contact_info' )
+    ? wpuf_ud_show_contact_info( $user )
+    : is_user_logged_in();
+
 // Get avatar size for card layout
 $card_avatar_size = ! empty( $avatar_size ) ? $avatar_size : 128;
 
@@ -64,7 +70,7 @@ $avatar = wpuf_ud_get_user_avatar_html( $user, $card_avatar_size, '!wpuf-rounded
         </h3>
 
         <!-- Email -->
-        <?php if ( $user_email ) : ?>
+        <?php if ( $user_email && $show_contact_info ) : ?>
             <p class="wpuf-text-[14px] wpuf-font-normal wpuf-text-gray-600 !wpuf-m-0">
                 <a href="<?php echo esc_url( 'mailto:' . $user_email ); ?>" target="_blank" rel="noopener" class="wpuf-text-gray-500 hover:wpuf-text-gray-900">
                     <?php echo esc_html( $user_email ); ?>
@@ -82,7 +88,7 @@ $avatar = wpuf_ud_get_user_avatar_html( $user, $card_avatar_size, '!wpuf-rounded
         <?php endif; ?>
 
         <!-- Phone Number -->
-        <?php if ( $phone ) : ?>
+        <?php if ( $phone && $show_contact_info ) : ?>
             <p class="wpuf-text-[14px] wpuf-font-normal wpuf-text-gray-600 !wpuf-m-0">
                 <a href="tel:<?php echo esc_attr( $phone ); ?>" class="wpuf-text-gray-500 hover:wpuf-text-gray-900">
                     <?php echo esc_html( $phone ); ?>

--- a/wpuf-functions.php
+++ b/wpuf-functions.php
@@ -950,6 +950,37 @@ function wpuf_get_gateways( $context = 'admin' ) {
 }
 
 /**
+ * Unserialize a value without ever instantiating PHP objects.
+ *
+ * Stored post meta may hold a serialized object payload (e.g. submitted through a
+ * form field). Passing it to maybe_unserialize() would instantiate arbitrary
+ * classes, enabling PHP object injection. This restricts deserialization to plain
+ * data and strips any object, so a serialized-object payload can never be revived.
+ *
+ * @since WPUF_SINCE
+ *
+ * @param mixed $value Possibly-serialized value.
+ *
+ * @return mixed Unserialized data with objects removed, or the original value.
+ */
+function wpuf_safe_unserialize( $value ) {
+    if ( ! is_string( $value ) || ! is_serialized( $value ) ) {
+        return $value;
+    }
+
+    if ( PHP_VERSION_ID >= 70000 ) {
+        return @unserialize( $value, [ 'allowed_classes' => false ] );
+    }
+
+    // PHP 5.6 fallback: refuse anything carrying an object marker (O:/C:).
+    if ( preg_match( '/(?:^|;|\{)[OC]:[0-9]+:/', $value ) ) {
+        return $value;
+    }
+
+    return maybe_unserialize( $value );
+}
+
+/**
  * Show custom fields in post content area
  *
  * @since 3.3.0 Introducing `render_field_data` to render field value
@@ -1107,7 +1138,7 @@ function wpuf_show_custom_fields( $content ) {
 
                     if ( $field_value ) {
                         if ( is_serialized( $field_value[0] ) ) {
-                            $field_value = maybe_unserialize( $field_value[0] );
+                            $field_value = wpuf_safe_unserialize( $field_value[0] );
                         }
 
                         if ( is_array( $field_value[0] ) ) {
@@ -1265,7 +1296,7 @@ function wpuf_show_custom_fields( $content ) {
 
                     // Unserialize if needed
                     if ( is_serialized( $repeat_data ) ) {
-                        $repeat_data = maybe_unserialize( $repeat_data );
+                        $repeat_data = wpuf_safe_unserialize( $repeat_data );
                     }
 
                     if ( ! is_array( $repeat_data ) ) {
@@ -1406,8 +1437,8 @@ function wpuf_show_custom_fields( $content ) {
                     if ( ! empty( $filter_html ) ) {
                         $html .= $filter_html;
                     } elseif ( is_serialized( $value[0] ) ) {
-                        $new            = maybe_unserialize( $value[0] );
-                        $modified_value = implode( $separator, $new );
+                        $new            = wpuf_safe_unserialize( $value[0] );
+                        $modified_value = is_array( $new ) ? implode( $separator, $new ) : '';
 
                         if ( $modified_value ) {
                             $html .= '<li>';


### PR DESCRIPTION
Coordinated disclosure via WPScan (report 11406598). Two reported issues, both reproducible on 4.3.9, fixed here.

## 1. PHP Object Injection via AI form builder (CVE-2026-14558)
- **`includes/AI/RestController.php`** — validate each submitted field's `input_type` against its `template` using the canonical field registry (free + pro via the `wpuf_form_fields` filter). Mismatched definitions are rejected on create and dropped on update, so a field can't be routed through the wrong renderer.
- **`wpuf-functions.php`** — new `wpuf_safe_unserialize()` (`allowed_classes => false`, with a PHP 5.6 fallback) replaces every render-time `maybe_unserialize()` of post meta in `wpuf_show_custom_fields()`. Stored meta can no longer instantiate an arbitrary object.

## 2. Unauthenticated User Directory email/phone disclosure
- **`modules/user-directory/Api/Directory.php`** — the public search route now requires a valid, **published** directory; `directory_id=0` (which enumerated every registered user, admins included) is refused.
- **`modules/user-directory/Helpers.php` + `views/.../row-3.php` + profile view** — new shared `wpuf_ud_show_contact_info()` gate hides email/phone from anonymous visitors (filterable via `wpuf_ud_show_contact_info`), matching WP core. Applied to the row template and the profile contact-info builder.

## Validation
- Object-injection PoC: serialized-object payload through the patched render path no longer fires `__wakeup` (renders empty); serialized arrays still render.
- AI validation: runtime registry check — 64 templates mapped (pro included); the `text` + `section_break` pairing is rejected.
- Directory endpoint (live, unauthenticated): no `directory_id` → `400 directory_required`; published directory → `200` with email/phone absent; draft directory → `404 directory_not_available`.
- `php -l` clean on all changed files.

> Note: Pro ships a parallel user-directory implementation (`User_Listing` / `ProfileDataHelper`); the same hardening is being applied there in a separate wpuf-pro PR.

Closes weDevsOfficial/wpuf-pro#1637

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved form validation to prevent invalid field configurations from being saved.
  * Added safer handling of serialized custom-field data.

* **Bug Fixes**
  * Directory searches now require a valid, published directory.
  * Contact details in directory listings are shown only when permitted, with support for configurable visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
