### PR TITLE
fix: fail closed on registration nonce + safe redirect (CSRF session fixation)

### DIFF
--- a/includes/Frontend/Registration.php
+++ b/includes/Frontend/Registration.php
@@ -161,9 +161,10 @@ class Registration {
         if ( ! empty( $_POST['wpuf_registration'] ) && ! empty( $_POST['_wpnonce'] ) ) {
             $userdata = [];
             $user     = '';
-            if ( isset( $_POST['_wpnonce'] ) ) {
-                $nonce = sanitize_key( wp_unslash( $_POST['_wpnonce'] ) );
-                wp_verify_nonce( $nonce, 'wpuf_registration_action' );
+            $nonce = isset( $_POST['_wpnonce'] ) ? sanitize_key( wp_unslash( $_POST['_wpnonce'] ) ) : '';
+
+            if ( ! wp_verify_nonce( $nonce, 'wpuf_registration_action' ) ) {
+                return;
             }
             $validation_error = new WP_Error();
             $reg_fname  = isset( $_POST['reg_fname'] ) ? sanitize_text_field( wp_unslash( $_POST['reg_fname'] ) ) : '';
@@ -336,7 +337,7 @@ class Registration {
                 } else {
                     $redirect = $this->get_registration_url() . '?success=yes';
                 }
-                wp_redirect( apply_filters( 'wpuf_registration_redirect', $redirect, $user ) );
+                wp_safe_redirect( apply_filters( 'wpuf_registration_redirect', $redirect, $user ) );
                 exit;
             }
         }


### PR DESCRIPTION
## Vulnerability
[WPScan] Registration nonce check has no effect, leading to login session fixation via CSRF (CVSS 4.3).

`Registration::process_registration()` (hooked on `init`, so it fires on any URL) called `wp_verify_nonce()` in **void context** — nothing branched on the result, so any non-empty `_wpnonce` passed and registration proceeded. With `autologin_after_registration` on (default), the handler cleared the visitor's auth cookie and set a new one, binding their browser to an attacker-created account. The post-registration redirect also used `wp_redirect()` on `$_POST['redirect_to']` with no host allowlist, redirecting the victim off-site in the same request.

## Fix (minimal, no behavior change for legit flows)
1. **Fail closed on the nonce** — return early when `_wpnonce` is missing or invalid. The real form (`templates/registration-form.php`) already mints `wp_nonce_field( 'wpuf_registration_action' )`, so valid registrations are unaffected.
2. **`wp_redirect()` → `wp_safe_redirect()`** for the post-registration redirect, matching the already-safe redirect later in the same method. Internal redirects keep working; external hosts are blocked.

## Verified — before / after (local WP, real HTTP requests)

**Invalid nonce (the PoC form):**

| | Result |
|---|---|
| **Before** (develop) | `HTTP/2 302` → `location: https://attacker.example.com/`, `set-cookie: wordpress_logged_in_…=csrf_probe_user|…`, user **created** |
| **After** (patch) | `HTTP/2 200`, no redirect, no login cookie, user **not created** |

**Valid nonce (legit registration form), on the patched code:**
`HTTP/2 302` → `location: https://wps-site.test/registration/?success=yes`, user **created** — legit signup unaffected, and the redirect stays on-site.

Reported by external security researcher **Yaswanth Reddy Sunkara** — please credit in the changelog/advisory.

Closes weDevsOfficial/wpuf-pro#1654.
