### PR TITLE
fix: enforce submission gate in AJAX submit_post (unauthenticated post via subscription-gated form)

### DIFF
--- a/includes/Ajax/Frontend_Form_Ajax.php
+++ b/includes/Ajax/Frontend_Form_Ajax.php
@@ -177,6 +177,24 @@ class Frontend_Form_Ajax {
             wpuf()->ajax->send_error( __( 'You must be logged in to submit posts.', 'wp-user-frontend' ) );
         }
 
+        // Enforce the form's submission gate (mandatory subscription, pack ownership,
+        // post-count limit) for new posts. The renderer checks this before showing the
+        // form, but the AJAX handler must re-check server-side — otherwise a scraped
+        // site-wide guest nonce can be replayed against a subscription-gated form to
+        // create a post with no order and no pending-payment status.
+        if ( ! isset( $_POST['post_id'] ) ) {
+            [ $user_can_post, $submission_info ] = $form->is_submission_open( $form, $this->form_settings );
+            $user_can_post                       = apply_filters( 'wpuf_can_post', $user_can_post, $form_id, $this->form_settings );
+
+            if ( 'yes' !== $user_can_post ) {
+                wpuf()->ajax->send_error(
+                    ! empty( $submission_info )
+                        ? $submission_info
+                        : __( 'You are not allowed to submit to this form.', 'wp-user-frontend' )
+                );
+            }
+        }
+
         [ $post_vars, $taxonomy_vars, $meta_vars ] = $this->get_input_fields( $this->form_fields );
 
         if ( ! isset( $_POST['post_id'] ) ) {

--- a/includes/Ajax/Frontend_Form_Ajax.php
+++ b/includes/Ajax/Frontend_Form_Ajax.php
@@ -182,9 +182,17 @@ class Frontend_Form_Ajax {
         // form, but the AJAX handler must re-check server-side — otherwise a scraped
         // site-wide guest nonce can be replayed against a subscription-gated form to
         // create a post with no order and no pending-payment status.
-        if ( ! isset( $_POST['post_id'] ) ) {
+        //
+        // A draft-backed submission still counts as new: it carries a post_id but sends
+        // wpuf_form_status "new" (same signal the update logic honours below), so key the
+        // gate on both so a replayed draft id cannot skip it.
+        $wpuf_form_status    = isset( $_POST['wpuf_form_status'] ) ? sanitize_text_field( wp_unslash( $_POST['wpuf_form_status'] ) ) : '';
+        $is_new_submission   = ! isset( $_POST['post_id'] ) || 'new' === $wpuf_form_status;
+
+        if ( $is_new_submission ) {
             [ $user_can_post, $submission_info ] = $form->is_submission_open( $form, $this->form_settings );
             $user_can_post                       = apply_filters( 'wpuf_can_post', $user_can_post, $form_id, $this->form_settings );
+            $submission_info                     = apply_filters( 'wpuf_addpost_notice', $submission_info, $form_id, $this->form_settings );
 
             if ( 'yes' !== $user_can_post ) {
                 wpuf()->ajax->send_error(


### PR DESCRIPTION
## Vulnerability
[WPScan] Unauthenticated post creation through a subscription-gated form (CVSS 5.3).

`Frontend_Form_Ajax::submit_post()` never called `Form::is_submission_open()`, so the mandatory-subscription / pack-ownership / post-count gate that the **renderer** enforces (`includes/Frontend/Frontend_Form.php`) was skipped on the write path. It verified only the `wpuf_form_add` nonce, which for logged-out visitors is a **site-wide constant** — an attacker could scrape it from any guest form and replay it against a subscription-gated form's ID:

- Post created (published where the gated form publishes), with **no order record and no pending-payment status**.
- Not just a payment bypass: where the open form moderates and the gated form publishes, this grants immediate **unreviewed publication**.

## Fix (minimal, mirrors the render path)
Re-check the gate server-side for **new** posts before building the post array, using the same call the renderer uses:

```php
[ $user_can_post, $submission_info ] = $form->is_submission_open( $form, $this->form_settings );
$user_can_post = apply_filters( 'wpuf_can_post', $user_can_post, $form_id, $this->form_settings );
if ( 'yes' !== $user_can_post ) { wpuf()->ajax->send_error( ... ); }
```

## Non-breaking
- Guest forms without charging, pay-per-post forms, and logged-in users with a valid pack all resolve to `yes` (unchanged).
- Only **new** submissions are gated (`post_id` unset); edits are untouched.
- The `wpuf_can_post` filter is preserved, so Pro/extension grants still apply.

## Verified — before / after (local WP, real guest HTTP requests, no cookies)

Gated form = `post_permission=guest_post` + `payment_options=on` + `choose_payment_option=force_pack_purchase` + `post_status=publish`. Guest `wpuf_form_add` nonce scraped/minted for user 0.

**Submit to the gated form:**

| | Result |
|---|---|
| **Before** (develop) | `{"success":true,…"message":"Post saved"}` — post **published**, no order |
| **After** (patch) | `{"success":false,…"error":"You need to purchase a subscription package to post in this form"}` — **no post created** |

**Legit non-gated guest form, on the patched code:**
`{"success":true,…"message":"Post saved"}` — post **created**. Legitimate guest posting is unaffected.

## Note on nonce binding
The report also suggests binding the nonce to the form ID. That changes the shared guest nonce contract (JS + guest-page caching) and risks breaking legitimate guest submissions, so it's intentionally out of scope here — the server-side gate closes the reported bypass on its own. Can follow up separately if desired.

Reported by external security researcher **Charles Vosburgh** — please credit in the changelog/advisory.

Closes weDevsOfficial/wpuf-pro#1653.
