### PR TITLE
fix: build tailwind css before the vite entries so a fresh checkout builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "scripts": {
     "release": "grunt release",
-    "build": "npm run build:forms-list && npm run build:subscriptions && npm run build:frontend-subscriptions && npm run build:ai-form-builder && npm run build:account && npm run build:user-directory && npm run build:blocks && npm run build:legacy && npm run build:css",
+    "build": "npm run build:css && npm run build:forms-list && npm run build:subscriptions && npm run build:frontend-subscriptions && npm run build:ai-form-builder && npm run build:account && npm run build:user-directory && npm run build:blocks && npm run build:legacy && npm run build:css",
     "build:blocks": "wp-scripts build --config webpack.config.js",
     "watch:blocks": "wp-scripts start --config webpack.config.js",
     "build:legacy": "grunt less && grunt concat && grunt uglify",


### PR DESCRIPTION
Closes weDevsOfficial/wpuf-pro#1657

### Problem

On a fresh clone (no generated assets), `npm run build` dies at `build:ai-form-builder`:

```
error during build:
Could not resolve "../css/ai-form-builder.css" from "assets/js/ai-form-builder.js"
```

`assets/js/ai-form-builder.js` imports `../css/ai-form-builder.css`, which is a gitignored tailwind output produced by `build:css` — and `build:css` runs *last* in the chain. The failure aborts everything after it: `build:account`, `build:user-directory`, `build:blocks`, `build:legacy`, `build:css`. Result: `assets/css/admin/form-builder.css` missing (form builder unstyled), user-directory bundle missing, post-form block bundle missing.

### Fix

Run `build:css` first so the generated stylesheets exist before the vite entries import them. It still runs last, so classes emitted by the later steps are picked up.

### Testing

On a checkout with the generated assets removed:

- before: `npm run build` → exit 1 at `build:ai-form-builder`
- after: `npm run build` → exit 0, and all outputs present — `assets/css/admin/form-builder.css`, `assets/css/ai-form-builder.css`, `assets/css/frontend/account.css`, `assets/js/ai-form-builder.min.js`, `assets/js/wpuf-user-directory-free.js`, `assets/js/blocks/post-form.js`
