### PR TITLE
fix: PayPal webhook never fires so transactions are never recorded

### DIFF
--- a/Lib/Gateway/Paypal.php
+++ b/Lib/Gateway/Paypal.php
@@ -472,7 +472,7 @@ class Paypal {
         // Add rewrite rule for webhook endpoint
         add_rewrite_rule(
             '^webhook_triggered/?$',
-            'index.php?action=webhook_triggered=1',
+            'index.php?wpuf_paypal_action=webhook_triggered',
             'top'
         );
 
@@ -495,7 +495,18 @@ class Paypal {
      * Handle webhook request
      */
     public function handle_webhook_request() {
-        if ( 'action' === get_query_var( 'action' ) &&
+        // The saved webhook URL uses a plain `?action=webhook_triggered` query string, which
+        // WordPress never exposes as a query var, so read the superglobal as well as the
+        // rewritten `wpuf_paypal_action` var. The payload is authenticated below by
+        // verify_webhook_signature_from_input(), so no nonce applies to this endpoint.
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        $action = isset( $_GET['action'] ) ? sanitize_text_field( wp_unslash( $_GET['action'] ) ) : '';
+
+        if ( 'webhook_triggered' !== $action ) {
+            $action = get_query_var( 'wpuf_paypal_action' );
+        }
+
+        if ( 'webhook_triggered' === $action &&
             isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' === $_SERVER['REQUEST_METHOD'] &&
             isset( $_SERVER['HTTP_PAYPAL_TRANSMISSION_ID'] ) ) {
             $raw_input = file_get_contents( 'php://input' );
@@ -528,7 +539,11 @@ class Paypal {
 
                 $acknowledged = true;
             } catch ( \Exception $e ) {
-               throw new \Exception( 'Webhook processing failed: ' . esc_html( $e->getMessage() ) );
+                // Never re-throw here: an uncaught exception would return a 500 HTML page to
+                // PayPal instead of the acknowledgement below, and PayPal would keep retrying.
+                if ( defined( 'WPUF_DEBUG' ) && WPUF_DEBUG ) {
+                    error_log( 'WPUF Debug: PayPal webhook processing failed: ' . $e->getMessage() );
+                }
             }
 
             // Always acknowledge to PayPal
@@ -2504,33 +2519,6 @@ class Paypal {
     }
 }
 
-// Register webhook endpoint
-add_action(
-    'init', function () {
-		add_rewrite_rule(
-            '^webhook_triggered/?$',
-            'index.php?action=webhook_triggered=1',
-            'top'
-		);
-	}
-);
-
-// Add query var
-add_filter(
-    'query_vars', function ( $vars ) {
-		$vars[] = 'wpuf_paypal_action';
-		return $vars;
-	}
-);
-
-// Handle webhook request
-add_action(
-    'template_redirect', function () {
-		if ( get_query_var( 'action' ) === 'webhook_triggered' ) {
-			$paypal = new \WeDevs\Wpuf\Lib\Gateway\Paypal();
-			$raw_input = file_get_contents( 'php://input' );
-			$paypal->process_webhook( $raw_input );
-			exit;
-		}
-	}
-);
+// Webhook endpoint registration and handling live in Paypal::register_webhook_endpoint() and
+// Paypal::handle_webhook_request(), both hooked in the constructor. The duplicate registration
+// that used to sit here bypassed the signature check performed by handle_webhook_request().


### PR DESCRIPTION
Closes weDevsOfficial/wpuf-pro#1660

## Problem

PayPal payments complete, the buyer lands on the success page, but **no row is written to `wp_wpuf_transaction`**. Every PayPal payment is invisible in Payments → Transactions.

`Payment::insert_payment()` is only reached from the webhook path, and that path never runs. `handle_webhook_request()` was gated on:

```php
if ( 'action' === get_query_var( 'action' ) &&
```

This compares the query var’s **value** against the literal string `'action'`, so it is never true. On top of that, `action` is not a registered query var — the `query_vars` filter registers `wpuf_paypal_action`, which nothing reads — so `get_query_var( 'action' )` returns `''` regardless. That also disabled the duplicate handler at the bottom of the file.

The buyer still sees success because `handle_paypal_return()` captures the order and redirects without inserting.

Regression from #1576 (PayPal library upgrade, 2025-05-29), shipped since v4.1.5 and still present in v4.3.9.

## Changes

- `handle_webhook_request()` reads the sanitized `action` superglobal (`sanitize_text_field( wp_unslash( … ) )`), falling back to the rewritten `wpuf_paypal_action` query var.
- Rewrite target fixed: `index.php?wpuf_paypal_action=webhook_triggered` (was `index.php?action=webhook_triggered=1`, a double `=`).
- The `catch` no longer re-throws. Once the gate works, re-throwing would return a 500 HTML page to PayPal instead of the acknowledgement, and PayPal would retry indefinitely. Failures are now logged behind `WPUF_DEBUG` and still acknowledged.
- Removed the duplicate module-level `template_redirect` handler. It called `process_webhook()` directly and would double-process every event once the gate started matching.

`verify_webhook_signature_from_input()` is untouched, so unsigned POSTs are still rejected. No new capability or nonce surface — this endpoint is authenticated by PayPal’s webhook signature, which is why the superglobal read carries a `phpcs:ignore` for `NonceVerification`.

## Verification (live sandbox install, WPUF 4.3.9 + Pro 4.2.14)

Same request, before and after:

| | before | after |
|---|---|---|
| `POST /?action=webhook_triggered` | `200`, 78310 bytes, `text/html` (homepage) | `200`, 18 bytes, `{"status":"error"}` |

The `error` on an unsigned probe is correct — signature verification rejects it.

Runtime proof of the dead gate before the fix:

```
get_query_var(action) = []
condition ( 'action' === get_query_var('action') ) : FALSE
```

nginx access log showed PayPal delivering all along, 628 POSTs answered with the homepage:

```
POST /?action=webhook_triggered HTTP/1.1" 200 13240 "-" "PayPal/AUHD-1.0-1"
```

After the fix, a real sandbox PayPal purchase of a $500 pack recorded:

```
id 3 | user_id 4 | status completed | cost 500 | pack_id 58
payment_type paypal | transaction_id 34J63953ER739481J | 2026-08-03 12:11:38
```

First PayPal transaction that install has ever recorded. Rewrite rules were flushed after the change (the `wpuf_paypal_webhook_flushed` option suppresses re-flushing, so it must be deleted when the rule changes — worth noting for anyone testing this).

## Note

`composer phpcs` could not be run — phpcs is not installed in my checkout (`vendor/bin/phpcs` missing, `composer phpcs` exits 127). The diff follows the standard by hand: strict comparisons, `wp_unslash()` + `sanitize_text_field()`, spacing inside parens. Please let CI confirm.