### PR TITLE
docs: refresh wp.org readme copy and clean up changelog formatting

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,6 @@
-=== User Frontend: AI Powered Frontend Post Submission, User Directory, User Profile, Membership & User Registration ===
+=== User Frontend – Membership, User Registration, User Profile, User Directory & Content Restriction with Frontend Post Submission ===
+
+
 Contributors: wedevs, tareq1988, nizamuddinbabu
 Donate link: https://tareq.co/donate/
 Tags: frontend post, user directory, membership, user profile, user registration
@@ -8,44 +10,65 @@ Stable tag: 4.3.10
 Requires PHP: 7.4
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
-Create a frontend post submission form, user registration form, user profile page, membership site, user directory, and content restriction.
+
+
+Create an AI-powered frontend post form, user registration form, user profile page, membership site, user directory, and content restriction.
+
+
 == Description ==
-<strong>#1 Plugin to Build Complete Frontend Experiences for WordPress</strong>
-User Frontend is an all-in-one frontend post submission, user registration, profile builder, membership, and user directory plugin for WordPress.
+
+
+**#1 Plugin to Build Complete Frontend Experiences for WordPress**
+
+
+[User Frontend](https://wedevs.com/wp-user-frontend-pro/) is an all-in-one frontend post submission, user registration, profile builder, membership, and user directory plugin for WordPress.
+
 
 Instead of sending users to the WordPress dashboard, User Frontend lets them register, submit posts, edit content, manage their user profile, purchase subscriptions, and interact with your website directly from the frontend.
 
+
 Whether you're building a guest posting website, directory website, membership platform, WooCommerce marketplace, community website, or event submission portal, User Frontend gives you everything you need in one plugin.
+
 
 From drag-and-drop form building and AI-powered form generation to frontend editing, payment collection, subscriptions, and content restriction, User Frontend helps you create professional user experiences without writing code.
 
-== Why Choose User Frontend ==
+
+= Why Choose User Frontend =
+
 
 Most WordPress form plugins focus on collecting data. User Frontend goes much further.
 
-It transforms WordPress into a <strong>complete frontend content management system</strong> where users can perform nearly every action without ever accessing the WordPress admin dashboard.
+
+It transforms WordPress into a **complete frontend content management system** where users can perform nearly every action without ever accessing the WordPress admin dashboard.
+
 
 With User Frontend, you can:
+
 
 * Create unlimited frontend post submission forms
 * Build custom user registration forms
 * Design beautiful frontend user profile pages
 * Allow users to edit their own posts
 * Accept guest post submissions
-* Create searchable user directories
-* Sell memberships and subscriptions
+* Create a searchable user directory
+* Sell membership plans and subscriptions
 * Restrict premium content
 * Charge users for post submissions
 * Build WooCommerce product submission forms
 * Connect with Elementor, ACF, n8n, Mailchimp, Stripe, PayPal and more
 
+
 Everything works together inside a single plugin designed specifically for frontend content management.
 
-== Perfect for Building ==
+
+= Perfect for Building =
+
 
 User Frontend is ideal for creating almost any website where users need to interact with content from the frontend.
 
+
 Popular use cases include:
+
 
 * Guest Blogging Websites
 * User Generated Content Platforms
@@ -65,198 +88,220 @@ Popular use cases include:
 * Startup Directories
 * Employee Portals, and more.
 
+
 Instead of building these features with multiple plugins, User Frontend combines them into one flexible solution.
 
-<strong>FREE FEATURES</strong>
+
+**FREE FEATURES**
 
 
-<strong>AI Post Form Builder</strong>
+**AI Post Form Builder**
 
 
 Describe the type of form you want, and the AI generates a complete post submission form with smart fields, labels, and structure, saving you time and setup effort.
 
 
-<strong>n8n Integration to Automate Post Form Data</strong>
+**n8n Integration to Automate Post Form Data**
 
 
 Send every post submission straight to n8n in real time. Use the captured data instantly to trigger actions, run workflows, and sync information across your tools without any manual steps.
 
 
-<strong>One Time Payments</strong>
+**One Time Payments**
 
 
 Offer simple one-off payment options so users can pay once for posting or upgrades, remove recurring fees, and complete purchases with more confidence.
 
 
-<strong> Frontend Post Form Templates</strong>
+**Frontend Post Form Templates**
 
 
 Pick from ready-made form templates for jobs, products, events, listings and more, letting you launch fully designed post forms in minutes.
 
 
-<strong>Unlimited Post-Type Form Creation</strong>
+**Unlimited Post-Type Form Creation**
 
 
 The forms let users create new posts and edit their profile from the site frontend, with no need to access admin panel or backend.
 
 
-<strong>Update Profile from the Frontend</strong>
+**Update Profile from the Frontend**
 
 
 This WordPress Profile Builder Plugin allows registered users to edit their profile using default fields from frontend. (Unlimited fields can be added using PRO)
 
 
-<strong>Flexibility for Admins</strong>
+**Flexibility for Admins**
 
 
 Admins can manage users both from frontend and backend to control who can access the dashboard.
 
 
-<strong>Featured Image & Image Upload</strong>
+**Featured Image & Image Upload**
 
 
 Users can upload images and featured image for a post using the Image Upload option on the post content area.
 
 
-<strong>Drag-and-drop Form Builder</strong>
+**Drag-and-drop Form Builder**
 
 
 Quickly build your form with necessary fields using drag-and-drops and real-time preview that updates as you make changes.
 
 
-<strong>Publish Your WPUF Forms Using Gutenberg</strong>
+**Publish Your WPUF Forms Using Gutenberg**
 
 
 Easily add your published forms in the Gutenberg editor with the WPUF block. Simply select it from the drop-down included in the dedicated WPUF block for Gutenberg. The entire form automatically renders within the editor as well as on the page.
 
 
-<strong>Use Forms Anywhere Easily with Shortcodes</strong>
+**Use Forms Anywhere Easily with Shortcodes**
 
 
 All of the forms get a unique shortcode which you can paste on any page and the form will generate without breaking the style of your theme.
 
 
-<strong>WordPress Guest Post Submission</strong>
+**WordPress Guest Post Submission**
 
 
 Enable guests to post from your site frontend without registering with User Frontend, the WordPress User Registration plugin. Choose to require a name and email address to register automatically and allow them to comment on the posts. Allow email verification for guests.
 
 
-<strong>Role Based Access Control</strong>
+**Role Based Access Control**
 
 
 Enable certain user roles to make posts, while restricting others. Create the unauthorized message you want to show to restricted users.
 
 
-<strong>Submit and Update Anything from Frontend</strong>
+**Submit and Update Anything from Frontend**
 
 
 Users can upload images, fill out forms, even enter data with multiple-choice menus. Allow users to update their posts from the front end.
 
 
-<strong>Build Customized Forms with Custom Post Types</strong>
+**Build Customized Forms with Custom Post Types**
 
 
 Taking advantage of custom post types will allow you to work on any platform. User Frontend is WooCommerce-supported, so you can also create products for your WooCommerce site using our forms.
 
 
-<strong>Set Post Status, Post Message, Update Post Button text</strong>
+**Set Post Status, Post Message, Update Post Button text**
 
 
 Assign separate default statuses for new posts or edited posts. Set the message you want to show users after form submission and change the text of the submit buttons as you like.
 
 
-<strong>Custom Redirection After Login and Submission</strong>
+**Custom Redirection After Login and Submission**
 
 
 Redirect users to another page after logging in, form submission, or editing form submission.
 
 
-<strong>Earn with Subscription Based Posting</strong>
+**Earn with Subscription Based Posting**
 
 
 Create subscription packs to earn through “Pay Per Post” payments. Submissions posted via these subscriptions have duration and posting limits.
 
 
-<strong>Schedule Forms & Restrict Entries</strong>
+**Schedule Forms & Restrict Entries**
 
 
 Choose to keep your form active for certain dates. Set a message when the form expires. And limit entries to as many as required. The PRO version also allows setting up post-expiration.
 
 
-<strong>Get Reminded with Emails</strong>
+**Get Reminded with Emails**
 
 
 Trigger emails on multiple events like new form submissions, guest posts, publish notifications, and new subscriptions. More email notifications can be set up with the PRO version.
 
 
-<strong>Integrate with Advanced Custom Fields (ACF)</strong>
+**Integrate with Advanced Custom Fields (ACF)**
 
 
 Connect form fields with ACF fields to view user submissions in ACF format from your dashboard. Allow users to edit fields from the front end.
 
 
-<strong>Create Subscription Packs, Pay-per-posts, & Receive Payments from Users</strong>
+**Create Subscription Packs, Pay-per-posts, & Receive Payments from Users**
 
 
 Create and subscribe users to membership packs, allow pay per post, force subscription package purchase, and set fallback pay per post charges with this WordPress Membership Plugin.
-<strong>Membership Features</strong>
+
+
+**Membership Features**
+
+
 Turn your site into a membership platform without leaving WordPress. Create membership tiers, control access by subscription level, and manage the entire member lifecycle from the frontend.
+
+
 * **Membership Tiers** – Build multiple membership levels with different pricing, posting limits, and access rules for each plan.
 * **Paid Memberships Pro Integration** – Connect User Frontend with PMPro to sync membership levels and unlock advanced membership site workflows. (PRO)
 * **Content Restriction by Membership Level** – Restrict pages, posts, or custom content so only members on the right plan can view it.
 * **Membership Management Dashboard** – Approve, pause, or cancel membership requests and view transaction history from a single screen.
 
 
-<strong>Manage Transactions and Membership</strong>
+**Manage Transactions and Membership**
+
+
 Approve or keep membership requests pending – you’re in complete control. View all details from a single screen.
-<strong>Restrict Frontend Posting by Membership</strong>
+
+
+**Restrict Frontend Posting by Membership**
+
+
 Control who can submit content based on their membership plan. Create exclusive posting experiences for premium members with ease.
-<strong>Build Frontend Post Submission Forms</strong>
+
+
+**Build Frontend Post Submission Forms**
+
+
 Create and manage frontend post submission forms with ease. Let users submit, edit, and update content without accessing the WordPress dashboard.
-<strong>Create a User Directory</strong>
+
+
+**Create a User Directory**
+
+
 Build a basic searchable user directory for free. Help visitors find members quickly with built-in search. Showcase your WordPress member directory with modern layouts.
 
 
-<strong>Manage and Import/Export Forms Easily</strong>
+**Manage and Import/Export Forms Easily**
 
 
 Install required WPUF pages in a click; delete post forms, user registration forms, or subscriptions in one go. Import forms from other places and export forms as JSON.
 
 
-<strong>Custom Login & User Registration Form</strong>
+**Custom Login & User Registration Form**
 
 
 This WordPress Registration Form Plugin also allows you to build user registration forms using default templates. More fields can be added with PRO.
 
 
-<strong>Display Custom Fields Data in Post</strong>
+**Display Custom Fields Data in Post**
 
 
 Custom field data is viewable to visitors on the frontend on single post pages. Admins can also disable this if they don’t want to display custom fields to everyone.
 
 
-<strong>Elementor Compatibility</strong>
+**Elementor Compatibility**
 
 
-User Frontend is now fully compatible with <strong>Elementor</strong>, the popular WordPress page builder. You can build and design <strong>frontend forms, user dashboards, and subscription pages</strong> in Elementor without using shortcodes.
+User Frontend is now fully compatible with **Elementor**, the popular WordPress page builder. You can build and design **frontend forms, user dashboards, and subscription pages** in Elementor without using shortcodes.
 
 
-This integration combines the power of <strong>User Frontend (frontend content management)</strong> with <strong>Elementor (visual page builder)</strong> for a faster and smoother workflow.
+This integration combines the power of **User Frontend (frontend content management)** with **Elementor (visual page builder)** for a faster and smoother workflow.
 
 
-<strong>Available Elementor Widgets</strong>
+**Available Elementor Widgets**
 
 
-* <strong>Account Widget</strong> – Customize the user account dashboard layout and appearance
-* <strong>Subscription Widget</strong> – Display and organize user subscription plans clearly
-* <strong>Post Form Widget</strong> – Design frontend submission forms visually using Elementor
+* **Account Widget** – Customize the user account dashboard layout and appearance
+* **Subscription Widget** – Display and organize user subscription plans clearly
+* **Post Form Widget** – Design frontend submission forms visually using Elementor
 
 
-These widgets help you turn your site into a <strong>frontend content management system</strong> without backend access.
+These widgets help you turn your site into a **frontend content management system** without backend access.
 
 
-<strong>How Elementor Integration Works</strong>
+**How Elementor Integration Works**
 
 
 * Drag and drop User Frontend widgets into Elementor
@@ -264,7 +309,7 @@ These widgets help you turn your site into a <strong>frontend content management
 * Publish pages and display them on the frontend
 
 
-User Frontend handles <strong>form logic, user roles, and permissions</strong>, while Elementor controls <strong>design and layout</strong>.
+User Frontend handles **form logic, user roles, and permissions**, while Elementor controls **design and layout**.
 
 
 = How to download and install WPUF FREE =
@@ -293,8 +338,12 @@ Try an <a href="https://wedevs.com/in/wpuf/demo/?utm_medium=referral&utm_source=
 * Turkish translation by mugurcagdas
 
 
-<strong>User Frontend PRO – Premium Features</strong>
-The Pro features make it a complete frontend content management plugin for WordPress. Let users register, submit posts, edit content, manage profiles, and access membership features without entering the WordPress dashboard.
+**User Frontend PRO – Premium Features**
+
+
+[WP User Frontend Pro](https://wedevs.com/wp-user-frontend-pro/pricing/) gives you everything you need to manage content from the frontend of your WordPress site. Let users register, submit and edit posts, manage their profiles, and access membership features without ever entering the WordPress dashboard.
+
+
 * **20+ Modules** – BuddyPress, Paid Memberships Pro, Social Login, User Directory, Stripe, Mailchimp, Private Messaging, Reports, Analytics, and more.
 * **AI Registration Form Builder** – Generate complete user registration forms from a prompt.
 * **20+ Form Templates** – Ready-made templates for vendors, memberships, events, directories, and more.
@@ -304,7 +353,7 @@ The Pro features make it a complete frontend content management plugin for WordP
 * **Subscription View & Post Control** – Restrict posting and viewing by subscription.
 * **Repeat Fields** – Add repeatable groups for links, skills, galleries, and more.
 * **User Directory** – Create searchable, filterable, and customizable user directories.
-* **Gutenberg Blocks** – Display user directories and profiles with blocks.
+* **Gutenberg Blocks for User Directory** – Display user directories and profiles with blocks.
 * **SEO Module** – Add SEO metadata to user-submitted content.
 * **Content Restriction** – Restrict pages, posts, or content by role or subscription.
 * **Menu Restriction** – Show or hide menus based on roles or subscriptions.
@@ -331,6 +380,7 @@ The Pro features make it a complete frontend content management plugin for WordP
 * **Frontend Customizer** – Customize frontend labels and colors.
 * **Advanced Email Notifications** – Send custom notifications for key events.
 * **Tax Support** – Apply country and state-based taxes to payments.
+
 
 = Premium Modules =
 
@@ -363,10 +413,6 @@ Check out the <a href="https://wedevs.com/wp-user-frontend-pro/pricing/?utm_medi
 You can always explore every update, fix and improvement in the **full changelog** here: [https://headwayapp.co/user-frontend-changelog](https://headwayapp.co/user-frontend-changelog)
 
 
-
-
-
-
 = Checkout Our Other Products =
 
 
@@ -385,27 +431,37 @@ You can always explore every update, fix and improvement in the **full changelog
 User Frontend uses the following third-party services to enhance frontend content management features. All data shared with these services is necessary for the plugin functionality and handled securely.
 
 
-1. **OpenAI API** – Used to generate AI-assisted project plans, task lists, and suggestions. Task titles, descriptions, and deadlines may be sent for AI processing.
+1. **OpenAI API** – Used to power AI-assisted form creation and content generation in WP User Frontend. Form prompts, field descriptions, and user instructions may be sent to OpenAI to generate forms and related content.
    – **[Terms of Service](https://openai.com/terms) and [Privacy Policy](https://openai.com/privacy)**
 
 
-2. **Google Generative Language API** – Assists content generation for tasks and projects. Task titles, descriptions, and comments may be sent for AI suggestions.
+2. **Google Generative Language API** – Enables AI-powered form generation and content suggestions. Form prompts, field descriptions, and related inputs may be sent to Google's AI models for processing.
    – **[Terms of Service](https://cloud.google.com/terms) and [Privacy Policy](https://policies.google.com/privacy)**
 
 
-3. **Anthropic API** – Provides AI-assisted responses and task suggestions. Task details like titles, descriptions, and deadlines may be sent for AI processing.
-   – **[Terms of Service](https://cloud.anthropic.com/terms) and [Privacy Policy](https://anthropic.com/privacy)**
+3. **Anthropic API** – Provides AI-assisted form generation and content suggestions. Form prompts, field descriptions, and related inputs may be sent to Anthropic's AI models to generate forms and improve content.
+   – **[Terms of Service](https://www.anthropic.com/legal/consumer-terms) and [Privacy Policy](https://anthropic.com/privacy)**
 
 
 = Terms and Conditions =
-– [weDevs Terms of Service](https://wedevs.com/terms-and-conditions/)
-– [weDevs Privacy Policy](https://wedevs.com/privacy-policy/)
+
+
+* [weDevs Terms of Service](https://wedevs.com/terms-and-conditions/)
+* [weDevs Privacy Policy](https://wedevs.com/privacy-policy/)
 
 
 = Privacy Policy =
+
+
 User Frontend uses the [Appsero](https://appsero.com) SDK to collect **optional telemetry data only with your consent**. No data is collected by default. Telemetry starts only after you opt in through the admin notice, helping us improve the plugin and troubleshoot issues faster.
+
+
 == Installation ==
+
+
 After having installed the plugin:
+
+
 1. Click "Install WPUF Pages" after installation for automatic settings installation.
 1. Create a form from the form builder. Get the shortcode for a form. Copy and paste that shortcode to a page.
 1. Create a new Page “Edit” for editing posts and insert shortcode `[wpuf_edit]`
@@ -413,21 +469,25 @@ After having installed the plugin:
 1. To add Login feature, use the shortcode: `[wpuf-login]`
 1. To enable a registration form in the frontend, use the shortcode: `[wpuf-registration]`
 1. Create a new Page “Dashboard” and insert shortcode `[wpuf_dashboard]`
-    To list custom post type **event**, use `[wpuf_dashboard post_type="event"]`
+   To list custom post type **event**, use `[wpuf_dashboard post_type="event"]`
 1. Set the *Edit Page* option from *Others* tab on settings page.
-1. To show the subscription info, insert the shortcdoe `[wpuf_sub_info]`
+1. To show the subscription info, insert the shortcode `[wpuf_sub_info]`
 1. To show the subscription packs, insert the shortcode `[wpuf_sub_pack]`
 1. For subscription payment page, set the *Payment Page* from *Payments* tab on settings page.
 
 
 = Video =
+
+
 [youtube https://www.youtube.com/watch?v=rzxdIN8ZMYc]
 
 
 == Frequently Asked Questions ==
 
 
-= Can I create a user directory for free? = 
+= Can I create a user directory for free? =
+
+
 Yes. The free version includes a basic searchable User Directory so visitors can browse and search registered members right out of the box. Upgrade to Professional for advanced layouts, filters, unlimited directories, and SEO controls for profile pages.
 
 
@@ -535,11 +595,6 @@ redirected to the edit page with that post id. Then you'll see the edit post for
 Please report security bugs found in the source code of the User Frontend plugin through the [Patchstack Vulnerability Disclosure  Program](https://patchstack.com/database/vdp/8e79568c-ae3d-4e3e-9633-e478e8b0610e). The Patchstack team will assist you with verification, CVE assignment, and notify the developers of this plugin.
 
 
-=  =
-
-
-
-
 == Screenshots ==
 
 
@@ -563,22 +618,27 @@ Please report security bugs found in the source code of the User Frontend plugin
 == Changelog ==
 
 
-= v4.3.10 (06 August, 2026) =
-* Enhance – Redesigned all five post form templates with a modern, consistent UI/UX.
-* Enhance – Post form multistep now matches the new registration design, with progress-bar colors driven by form settings.
-* Enhance – Improved readability of the form title, description, help text and field labels on dark templates.
-* Enhance – Modernized the file and image upload progress UI.
+= 4.3.10 (06 August, 2026) =
+
+
+* Enhance – Redesigned all five frontend post form templates with a modern, consistent UI/UX.
+* Enhance – Improved the user registration multistep experience with progress bar colors that automatically match your form settings.
+* Enhance – Improved readability of form titles, descriptions, help text, and field labels across dark templates.
+* Enhance – Modernized the file and image upload progress UI for frontend post submissions.
+* Enhance – Improved styling consistency across frontend post forms, user registration forms, user profile forms, membership forms, and user directory templates.
 * Fix – Dropdown/multiselect chevrons and the Field Size setting now render consistently across all templates.
 * Fix – Multistep next/previous button spacing no longer overlaps the field focus border.
 * Fix – Improved form label color contrast on Template 4 for better accessibility.
 * Fix – "Use Theme CSS" now correctly disables the plugin's Template 1 styling so your theme's CSS takes over.
 * Fix – Multistep step labels and the progress header are now readable on dark templates (Template 2 and 5).
 * Fix – Checkboxes are now visually distinct from radio buttons on Template 1.
-* Fix – PayPal webhook now fires reliably so subscription and pack transactions are recorded.
+* Fix – PayPal webhooks now fire reliably so membership subscription and content pack transactions are recorded.
 * Dev – The default form skin moved from the generic `.wpuf-style` class to the template-scoped `.wpuf-form-layout1`; update any custom CSS that targeted `.wpuf-style`.
 
 
-= v4.3.9 (20 July, 2026) =
+= 4.3.9 (20 July, 2026) =
+
+
 * New – Post Form Gutenberg block to place a frontend post submission form in the block editor with full style controls.
 * New – Change Password tab in the user profile account page so members can update their password from the frontend.
 * New – Redesigned Upgrade to Pro page with a plan comparison and pricing toggle.
@@ -593,43 +653,59 @@ Please report security bugs found in the source code of the User Frontend plugin
 * Fix – Corrected the Custom HTML field tooltip; WordPress shortcodes require the Shortcode field.
 
 
-= v4.3.8 (19 June, 2026) =
+= 4.3.8 (19 June, 2026) =
+
+
 * Fix – Security: hardened file upload handling to prevent unauthorized deletion of media attachments and modification of a frontend post via crafted form submissions.
 * Fix – Credit Card payment gateway now displays correctly on the Payment settings page when the Pro add-on is inactive.
 
 
-= v4.3.7 (4 June, 2026) =
+= 4.3.7 (4 June, 2026) =
+
+
 * Fix – Tag suggestions not loading in frontend post form builder
 * Fix – Checkbox styling in frontend post form builder
 
 
-= v4.3.6 (22 May, 2026) =
+= 4.3.6 (22 May, 2026) =
+
+
 * Fix – Restore edit button for custom post type published posts after 4.2.9
 
 
-= v4.3.5 (11 May, 2026) =
+= 4.3.5 (11 May, 2026) =
+
+
 * Chore – Exclude .DS_Store files from builds and SVN deploy
 
 
-= v4.3.4 (11 May, 2026) =
-Chore – Clean up internal Claude build files from the release package.
+= 4.3.4 (11 May, 2026) =
 
 
-= v4.3.3 (30 April, 2026) =
-Enhance – Bind cancel nonce to user and enforce ownership
-Fix – Resolve post expiration not working
+* Chore – Clean up internal Claude build files from the release package.
 
 
-= v4.3.2 (24 April, 2026) =
-New – Add guest and paid guest post templates and assets
-New – Add user directory page creation to installer and tools
-Enhance – Add 'General' category for registration forms
-Fix – Sanitize file IDs with absint and remove debug logs
-Fix – Resolve unauthorized subscription pack assignment
-Fix – Enable fallback pay-per-post when force_pack is set
+= 4.3.3 (30 April, 2026) =
 
 
-= v4.3.1 (8 April, 2026) =
+* Enhance – Bind cancel nonce to user and enforce ownership
+* Fix – Resolve post expiration not working
+
+
+= 4.3.2 (24 April, 2026) =
+
+
+* New – Add guest and paid guest post templates and assets
+* New – Add user directory page creation to installer and tools
+* Enhance – Add 'General' category for registration forms
+* Fix – Sanitize file IDs with absint and remove debug logs
+* Fix – Resolve unauthorized subscription pack assignment
+* Fix – Enable fallback pay-per-post when force_pack is set
+
+
+= 4.3.1 (8 April, 2026) =
+
+
 * New – Add Elementor Account page widget
 * New – Add Elementor Subscription widget
 * New – Add Elementor Post Form Builder widget
@@ -640,11 +716,15 @@ Fix – Enable fallback pay-per-post when force_pack is set
 * Fix – Resolve CSS/JS warning in setup wizard
 
 
-= v4.3.0 (11 March, 2026) =
+= 4.3.0 (11 March, 2026) =
+
+
 * New – Add User Directory Module
 
 
-= v4.2.10 (26 February, 2026) =
+= 4.2.10 (26 February, 2026) =
+
+
 * New – Add Logout link to navigation menu for Classic and FSE themes
 * New – Support custom image icons in Form Builder
 * New – Add Kazakhstani Tenge (KZT) and expand currency list to ISO 4217 standard
@@ -652,7 +732,9 @@ Fix – Enable fallback pay-per-post when force_pack is set
 * Enhance – Improve Login form stability and validation fixes
 
 
-= v4.2.9 (24 February, 2026) =
+= 4.2.9 (24 February, 2026) =
+
+
 * New – Integration-specific AI form builder support
 * New – Add Shortcodes Reference page under Tools menu
 * Enhance – Improve Bank payment system
@@ -661,7 +743,15 @@ Fix – Enable fallback pay-per-post when force_pack is set
 * Fix – Correct AI form builder button text
 
 
-= v4.2.8 (28 January, 2026) =
+= 4.2.8 (28 January, 2026) =
+
+
+* Re-release of 4.2.7 with no functional changes.
+
+
+= 4.2.7 (27 January, 2026) =
+
+
 * New – Account page Re-Design
 * New – AI settings improvements with temperature control, API key masking, and connection testing
 * Enhance – Remove currency symbol from AI form builder pricing fields
@@ -670,16 +760,9 @@ Fix – Enable fallback pay-per-post when force_pack is set
 * Enhance – Improve string translation and escaping in modal templates
 
 
-= v4.2.7 (27 January, 2026) =
-* New – Account page Re-Design
-* New – AI settings improvements with temperature control, API key masking, and connection testing
-* Enhance – Remove currency symbol from AI form builder pricing fields
-* Enhance – Form builder UI and usability tweaks
-* Enhance – Conditional options for field icon settings
-* Enhance – Improve string translation and escaping in modal templates
+= 4.2.6 (14 January, 2026) =
 
 
-= v4.2.6 (14 January, 2026) =
 * New – Add AI-powered field options generator for dropdown, radio, and checkbox fields
 * Fix – Correctly detect ACF taxonomies
 * Fix – Subscription page title is broken
@@ -689,7 +772,9 @@ Fix – Enable fallback pay-per-post when force_pack is set
 * Fix – Event Venue & Organizer Handling Issues in Frontend Event Submission
 
 
-= v4.2.5 (01 January, 2026) =
+= 4.2.5 (01 January, 2026) =
+
+
 * Enhancement – Warning message for empty field options
 * Enhancement – Login and Registration help text
 * Fix – Add authorization checks for attachment deletion in form submission
@@ -698,32 +783,44 @@ Fix – Enable fallback pay-per-post when force_pack is set
 * Fix – Add italic, underline, and bold styling to Settings link in field validators
 
 
-= v4.2.4 (10 December, 2025) =
+= 4.2.4 (10 December, 2025) =
+
+
 * New – n8n integration for post form
 * Fix – Duplicate event on update for event calendar integration
 
 
-= v4.2.3 (20 November, 2025) =
+= 4.2.3 (20 November, 2025) =
+
+
 * Enhancement – Add dynamic AI model fetching and improved error handling
 * Enhancement – System prompt update for better output for AI form builder
 * Enhancement – Change pricing field logo
 * Enhancement – Styling, CSS > replaced all old pro icon with new icon
 
 
-= v4.2.2 (04 November, 2025) =
+= 4.2.2 (04 November, 2025) =
+
+
 * Fix – Show/Hide field based on subscription plan
 * Fix – Frontend subscription page CSS fixes
 
 
-= v4.2.1 (30 October, 2025) =
+= 4.2.1 (30 October, 2025) =
+
+
 * New – AI Powered Post Form Creation
 
 
-= v4.1.15 (22 October, 2025) =
+= 4.1.15 (22 October, 2025) =
+
+
 * Fix – Unwanted text appearing in 'View' and 'Preview' links
 
 
-= v4.1.14 (21 October, 2025) =
+= 4.1.14 (21 October, 2025) =
+
+
 * New – Dynamic Field Icons for improved visual customization
 * New – Taxonomy View Restriction settings to control visibility by taxonomy
 * Enhancement – Added Upgrade and Discount links on the plugin page for easier access
@@ -731,29 +828,41 @@ Fix – Enable fallback pay-per-post when force_pack is set
 * Enhancement – Renamed "Published" tab to "Saved" on Form List pages for better clarity
 
 
-= v4.1.13 (07 October, 2025) =
+= 4.1.13 (07 October, 2025) =
+
+
 * Enhancement – Security and Capabilities check
 
 
-= v4.1.12 (24 September, 2025) =
+= 4.1.12 (24 September, 2025) =
+
+
 * New – Video Content Submission post form template
 
 
-= v4.1.11 (10 September, 2025) =
+= 4.1.11 (10 September, 2025) =
+
+
 * Fix – CSS scope conflict
 
 
-= v4.1.10 (01 September, 2025) =
+= 4.1.10 (01 September, 2025) =
+
+
 * New – Allow webp image format in file upload fields
 * Enhancement – Cleanup post form settings by removing form template option
 * Fix – Prevent same name file conflicts upload
 
 
-= v4.1.9 (12 August, 2025) =
+= 4.1.9 (12 August, 2025) =
+
+
 * Fix – The Events Calendar integration
 
 
-= v4.1.8 (04 August, 2025) =
+= 4.1.8 (04 August, 2025) =
+
+
 * New – Template filtering search in post form
 * Fix – Invoice and email not sent for payment gateways
 * Fix – Product tag suggestion for WooCommerce
@@ -762,11 +871,13 @@ Fix – Enable fallback pay-per-post when force_pack is set
 * Fix – Ensure Google Map fields display on frontend posts
 * Fix – Required field validation for 'Pay as you post' to prevent empty submission
 * Fix – Conditionally show 'Require email verification' only when 'Require Name and Email address' is checked
-* Fix – A typo From Expired Message <span aria-hidden="true" class="wp-exclude-emoji"><span aria-hidden="true" class="wp-exclude-emoji"><span aria-hidden="true" class="wp-exclude-emoji">→</span></span></span> Form Expired Message
+* Fix – A typo From Expired Message → Form Expired Message
 * Fix – Post forms list table CSS
 
 
-= v4.1.7 (15 July, 2025) =
+= 4.1.7 (15 July, 2025) =
+
+
 * New – Add Sort Order for subscription
 * Enhancement – Update country list and improve state handling
 * Fix – Conflict with email log plugin
@@ -774,7 +885,9 @@ Fix – Enable fallback pay-per-post when force_pack is set
 * Fix – CSS on long form lists
 
 
-= v4.1.6 (30 June, 2025) =
+= 4.1.6 (30 June, 2025) =
+
+
 * Enhancement – form title, description toggle added for post form
 * Enhancement – separate translation context for date range "To"
 * Fix – PayPal redirection issues
@@ -783,7 +896,9 @@ Fix – Enable fallback pay-per-post when force_pack is set
 * Fix – Dynamic url for {login} and {register} in un-authorized message
 
 
-= v4.1.5 (2 June, 2025) =
+= 4.1.5 (2 June, 2025) =
+
+
 * Enhancement – Added support for unlimited subscriptions.
 * Enhancement – Added trial period & next billing dates in subscription.
 * Enhancement – Added “Show More” button for subscriptions with many post types.
@@ -797,14 +912,18 @@ Fix – Enable fallback pay-per-post when force_pack is set
 * Fix – Fixed tag auto-suggestions not appearing in post forms.
 
 
-= v4.1.4 (12 May, 2025) =
+= 4.1.4 (12 May, 2025) =
+
+
 * Enhance – Post form list page UI and UX
 * Fix – Coupon functionality
 * Fix – Post submission when name email not required
 * Fix – Styling on multiple pages
 
 
-= v4.1.3 (23 April, 2025) =
+= 4.1.3 (23 April, 2025) =
+
+
 * Fix – Draft button does not appear
 * Fix – Post submission when name email not required
 * Fix – Subscription number not showing
@@ -814,17 +933,23 @@ Fix – Enable fallback pay-per-post when force_pack is set
 * Fix – Minor css and styling
 
 
-= v4.1.2 (16 April, 2025) =
+= 4.1.2 (16 April, 2025) =
+
+
 * Fix – Help page of profile editing has duplicated text
 * Fix – Warning message not showing when guest post submitted with duplicate email, username
 
 
-= v4.1.1 (27 March, 2025) =
+= 4.1.1 (27 March, 2025) =
+
+
 * Fix – Resolved validation issue with error (!) after form submission.
 * Fix – Improve template selection UX to uncheck a selected post form template.
 
 
-= v4.1.0 (20 March, 2025) =
+= 4.1.0 (20 March, 2025) =
+
+
 * Enhance – Redesigned Post Form Builder UI/UX
 * Enhance – Reorganized Forms Settings for better structure
 * Enhance – Added a search bar for quick field filtering
@@ -832,18 +957,24 @@ Fix – Enable fallback pay-per-post when force_pack is set
 * Enhance – Improved field grouping & customization
 
 
-= v4.0.15 (19 March, 2025) =
+= 4.0.15 (19 March, 2025) =
+
+
 * Fix – Security vulnerabilities: escaped variables & sanitized inputs
 * Fix – Reverted SweetAlert2 to v11.4.8 for compliance
 * Fix – Removed unnecessary files
 
 
-= v4.0.14 (23 Nov, 2024) =
+= 4.0.14 (23 Nov, 2024) =
+
+
 * Fix – Error in login page
 * Fix – Support situations in which (WPUF) translations are loaded too early
 
 
-= v4.0.13 (14 Nov, 2024) =
+= 4.0.13 (14 Nov, 2024) =
+
+
 * Enhance – Cloudflare Turnstile field on form builder
 * Enhance – Cloudflare Turnstile on login form
 * Fix – Events calendar post form integration
@@ -851,7 +982,9 @@ Fix – Enable fallback pay-per-post when force_pack is set
 * Fix – Post description image broken for block theme
 
 
-= v4.0.12 (14 Oct, 2024) =
+= 4.0.12 (14 Oct, 2024) =
+
+
 * Enhance – Decimal value for subscription pack
 * Fix – Required asterisk on password label
 * Fix – Field overlapping in address field
@@ -859,7 +992,9 @@ Fix – Enable fallback pay-per-post when force_pack is set
 * Fix – Integrations not loading properly for Dokan, ACF, WC Vendors
 
 
-= v4.0.11 (12 Sep, 2024) =
+= 4.0.11 (12 Sep, 2024) =
+
+
 * Enhance – Subscription design revamp
 * Enhance – Consistent format in email templates
 * Enhance – Move newsletter subscription to weMail
@@ -868,22 +1003,30 @@ Fix – Enable fallback pay-per-post when force_pack is set
 * Fix – State field is not changing
 
 
-= v4.0.10 (08 Aug, 2024) =
+= 4.0.10 (08 Aug, 2024) =
+
+
 * Fix – Error on WC post template
 * Fix – Move login validation to pro
 
 
-= v4.0.9 (17 Jul, 2024) =
+= 4.0.9 (17 Jul, 2024) =
+
+
 * Fix – Remove PHP AllowDynamicProperties warning on plugin pages
 * Fix – Remove print_emoji_styles is deprecated message from setup page
 
 
-= v4.0.8 (03 Jul, 2024) =
+= 4.0.8 (03 Jul, 2024) =
+
+
 * Fix – Optimized the script loading process by removing a Promise polyfill
 * Fix – Added validation on the transaction page
 
 
-= v4.0.7 (11 Jun, 2024) =
+= 4.0.7 (11 Jun, 2024) =
+
+
 * Enhance – Remove what's new page
 * Fix – Pending user can log in
 * Fix – Error when multiple password fields in form
@@ -894,7 +1037,9 @@ Fix – Enable fallback pay-per-post when force_pack is set
 * Fix – Form import is not working
 
 
-= v4.0.6 (13 Feb, 2024) =
+= 4.0.6 (13 Feb, 2024) =
+
+
 * Enhance – Update deprecated uses for PHP versions and latest WordPress
 * Enhance – Eye icon inside password field
 * Fix – Error after PayPal payment
@@ -902,11 +1047,15 @@ Fix – Enable fallback pay-per-post when force_pack is set
 * Fix – Subscription posting restriction not working
 
 
-= v4.0.5 (31 Jan, 2024) =
+= 4.0.5 (31 Jan, 2024) =
+
+
 * Enhance – Integrate headway and canny
 
 
-= v4.0.4 (25 Jan, 2024) =
+= 4.0.4 (25 Jan, 2024) =
+
+
 * Enhance – Add visibility to the Columns field
 * Fix – Login with reCAPTCHA gives error
 * Fix – AJAX image upload
@@ -917,28 +1066,27 @@ Fix – Enable fallback pay-per-post when force_pack is set
 * Fix – Error in setup wizard
 
 
-= v4.0.3 (05 Jan, 2024) =
-* Enhance – Restructure plugin codes
-* Fix – Error when editing the featured post
-* Fix – add/edit post forms if the site language is set to Simplified Chinese
-* Fix – Errors with Post Form Conditional Logic
+= 4.0.3 (05 Jan, 2024) =
 
 
-= v4.0.2 (03 Jan, 2024) =
-* Enhance – Restructure plugin codes
-* Fix – Error when editing the featured post
-* Fix – add/edit post forms if the site language is set to Simplified Chinese
-* Fix – Errors with Post Form Conditional Logic
+* Re-release of 4.0.0 with no functional changes.
 
 
-= v4.0.1 (03 Jan, 2024) =
-* Enhance – Restructure plugin codes
-* Fix – Error when editing the featured post
-* Fix – add/edit post forms if the site language is set to Simplified Chinese
-* Fix – Errors with Post Form Conditional Logic
+= 4.0.2 (03 Jan, 2024) =
 
 
-= v4.0.0 (02 Jan, 2024) =
+* Re-release of 4.0.0 with no functional changes.
+
+
+= 4.0.1 (03 Jan, 2024) =
+
+
+* Re-release of 4.0.0 with no functional changes.
+
+
+= 4.0.0 (02 Jan, 2024) =
+
+
 * Enhance – Restructure plugin codes
 * Fix – Error when editing the featured post
 * Fix – add/edit post forms if the site language is set to Simplified Chinese
@@ -949,4 +1097,6 @@ Fix – Enable fallback pay-per-post when force_pack is set
 
 
 = v2.3 =
-* It's a **massive update and change** from the previous version 1.3.2. Please do test in your site and main compatibility.
+
+
+* It's a **massive update and change** from the previous version 1.3.2. Please do test in your site and maintain compatibility.


### PR DESCRIPTION
Refreshes the wp.org listing copy (plugin title, short description, Description body) and fixes formatting the wp.org readme parser mishandles.

### Changes
- **Section levels** — `Why Choose User Frontend` and `Perfect for Building` demoted from `==` to `=`. As `==` they were parsed as separate top-level readme sections rather than Description subheadings.
- **Inline bold** — normalised `<strong>` to Markdown `**`, matching the style already used in the Pro feature list.
- **Stray heading** — removed the empty `=  =` heading before Screenshots.
- **Changelog headings** — dropped the `v` prefix (`= v4.3.10 =` → `= 4.3.10 =`) so headings match the released version numbers.
- **Changelog accuracy** — 4.0.1/4.0.2/4.0.3 and 4.2.8 duplicated the entries of the release before them; collapsed into re-release notes. Fixed the escaped-emoji markup in the 4.1.8 typo entry.
- **Copy** — external-services descriptions now describe WPUF's AI form generation instead of the project/task wording carried over from another plugin; corrected the Anthropic ToS link; fixed `shortcdoe` and `main compatibility` typos.
- Added the missing trailing newline.

Short description is 141 chars (under the 150 limit). No `##` Markdown headers, no CRLF.

### Notes
- No functional changes — `readme.txt` only.
- The same content is being pushed directly to wp.org SVN (`trunk` + `tags/4.3.10`) so the live listing updates without waiting for a release; the wp.org page serves `tags/<Stable tag>/readme.txt`.