### PR TITLE
fix: block PHP object injection when the edit form reads submitted meta (WPScan, CVSS 8.8)

### DIFF
--- a/class/render-form.php
+++ b/class/render-form.php
@@ -1108,7 +1108,7 @@ class WPUF_Render_Form {
 
             if ( $multiselect ) {
                 if ( is_serialized( $selected ) ) {
-                    $selected = maybe_unserialize( $selected );
+                    $selected = wpuf_safe_unserialize( $selected );
                 } elseif ( is_array( $selected ) ) {
                     $selected = $selected;
                 } else {
@@ -1192,7 +1192,7 @@ class WPUF_Render_Form {
         if ( $post_id ) {
             if ( $value = $this->get_meta( $post_id, $attr['name'], $type, true ) ) {
                 if ( is_serialized( $value ) ) {
-                    $selected = maybe_unserialize( $value );
+                    $selected = wpuf_safe_unserialize( $value );
                 } elseif ( is_array( $value ) ) {
                     $selected = $value;
                 } else {
@@ -1616,7 +1616,7 @@ class WPUF_Render_Form {
 
                 if ( $images ) {
                     if ( is_serialized( $images[0] ) ) {
-                        $images = maybe_unserialize( $images[0] );
+                        $images = wpuf_safe_unserialize( $images[0] );
                     }
 
                     if ( is_array( $images[0] ) ) {

--- a/includes/Admin/Forms/Post/Templates/Post_Form_Template_WooCommerce.php
+++ b/includes/Admin/Forms/Post/Templates/Post_Form_Template_WooCommerce.php
@@ -341,7 +341,7 @@ Edit URL: {editlink}'
                 $images = $images[0];
             }
             if ( is_serialized( $images[0] ) ) {
-                $images = maybe_unserialize( $images[0] );
+                $images = wpuf_safe_unserialize( $images[0] );
             }
             update_post_meta( $post_id, '_product_image_gallery', implode( ',', $images ) );
         }

--- a/includes/Fields/Form_Field_Checkbox.php
+++ b/includes/Fields/Form_Field_Checkbox.php
@@ -162,7 +162,7 @@ class Form_Field_Checkbox extends Field_Contract {
         $formatted_value = [];
 
         if ( is_serialized( $value ) ) {
-            $formatted_value = maybe_unserialize( $value );
+            $formatted_value = wpuf_safe_unserialize( $value );
         } elseif ( is_array( $value ) ) {
             $formatted_value = $value;
         } else {

--- a/includes/Fields/Form_Field_Image.php
+++ b/includes/Fields/Form_Field_Image.php
@@ -35,7 +35,7 @@ class Form_Field_Image extends Field_Contract {
 
             if ( $this->is_meta( $field_settings ) && ! empty( $images[0] ) ) {
                 if ( is_serialized( $images[0] ) ) {
-                    $images = maybe_unserialize( $images[0] );
+                    $images = wpuf_safe_unserialize( $images[0] );
                 }
 
                 if ( is_array( $images[0] ) ) {

--- a/includes/Fields/Form_Field_MultiDropdown.php
+++ b/includes/Fields/Form_Field_MultiDropdown.php
@@ -31,7 +31,7 @@ class Form_Field_MultiDropdown extends Form_Field_Dropdown {
             $selected = $this->get_meta( $post_id, $field_settings['name'], $type );
 
             if ( is_serialized( $selected ) ) {
-                $selected = maybe_unserialize( $selected );
+                $selected = wpuf_safe_unserialize( $selected );
             } elseif ( is_array( $selected ) ) {
                 $selected = $selected;
             } else {

--- a/includes/Render_Form.php
+++ b/includes/Render_Form.php
@@ -964,7 +964,7 @@ class Render_Form {
 
             if ( $multiselect ) {
                 if ( is_serialized( $selected ) ) {
-                    $selected = maybe_unserialize( $selected );
+                    $selected = wpuf_safe_unserialize( $selected );
                 } elseif ( is_array( $selected ) ) {
                     $selected = $selected;
                 } else {
@@ -1048,7 +1048,7 @@ class Render_Form {
         if ( $post_id ) {
             if ( $value = $this->get_meta( $post_id, $attr['name'], $type, true ) ) {
                 if ( is_serialized( $value ) ) {
-                    $selected = maybe_unserialize( $value );
+                    $selected = wpuf_safe_unserialize( $value );
                 } elseif ( is_array( $value ) ) {
                     $selected = $value;
                 } else {
@@ -1501,7 +1501,7 @@ class Render_Form {
 
                 if ( $images ) {
                     if ( is_serialized( $images[0] ) ) {
-                        $images = maybe_unserialize( $images[0] );
+                        $images = wpuf_safe_unserialize( $images[0] );
                     }
 
                     if ( is_array( $images[0] ) ) {

--- a/modules/user-directory/views/profile/template-parts/file-2.php
+++ b/modules/user-directory/views/profile/template-parts/file-2.php
@@ -18,7 +18,7 @@ if ( $table_exists ) {
     ) );
     
     foreach ( $messages as $message ) {
-        $message_data = maybe_unserialize( $message->message );
+        $message_data = wpuf_safe_unserialize( $message->message );
         if ( is_array( $message_data ) && ! empty( $message_data['files'] ) && is_array( $message_data['files'] ) ) {
             $private_message_attachment_ids = array_merge( $private_message_attachment_ids, $message_data['files'] );
         }


### PR DESCRIPTION
Closes weDevsOfficial/wpuf-pro#1661

## Problem

4.3.10 added `wpuf_safe_unserialize()` (`allowed_classes => false`) but applied it at three call sites only, all in the **post display renderer**. Every path that rebuilds a **form** from stored post meta still called bare `maybe_unserialize()`.

A Subscriber can store a serialized object through a stock Checkbox or Multi Select field — submitted values are not matched against the configured options, so an arbitrary string is accepted — then open their own post in the edit form and have the object instantiated in their session. No mismatched field definition is involved, so the 4.3.10 validator never applies. Secondary paths: an Administrator or Editor opening the submission in wp-admin, and a Guest Post-enabled form making the write unauthenticated.

## Fix

Route every **submission-originating** meta read through `wpuf_safe_unserialize()`:

| File | Context |
|---|---|
| `includes/Fields/Form_Field_Checkbox.php` | `get_formatted_value()` — reported |
| `includes/Fields/Form_Field_MultiDropdown.php` | `render()` — reported |
| `includes/Fields/Form_Field_Image.php` | `render()` — reported as same shape |
| `includes/Render_Form.php` ×3 | multiselect / checkbox / image branches |
| `class/render-form.php` ×3 | same three branches in the legacy renderer |
| `includes/Admin/Forms/Post/Templates/Post_Form_Template_WooCommerce.php` | `_product_image` gallery meta, written by submissions |
| `modules/user-directory/views/profile/template-parts/file-2.php` | `wpuf_message` rows (user-submitted) |

11 lines, one-for-one function swap. No signatures, hooks, templates, markup, CSS or JS touched.

`class/render-form.php` is not loaded by `wpuf.php` and nothing references `WPUF_Render_Form` — but it ships in the package, so it is patched for parity rather than left as a second report.

## Not changed, deliberately

The report also suggests constraining `prepare_meta_fields()` writes to the administrator-configured options. That would reject values that are legitimately dynamic — options injected by filters, ACF-backed fields, conditional fields — so it is a behaviour change that risks breaking live forms. Left out of this security fix; worth a separate discussion.

Admin-authored data (form `post_content`, subscription pack meta, gateway transaction meta, upgrade routines) still uses `maybe_unserialize()` — not attacker-controlled, and untouched to keep this diff to the vulnerability.

## Testing

Verified on a real site (`wp eval-file`, WP + PHP 8):

**Exploit blocked**
```
maybe_unserialize()     -> WPUF_Probe_Evil        | __wakeup fired: YES (VULNERABLE)
wpuf_safe_unserialize() -> __PHP_Incomplete_Class | __wakeup fired: no (BLOCKED)
```

**Through the patched field class**, including a real `update_post_meta()` / `get_post_meta()` round-trip:
```
legit serialized array -> ["red","green","blue"]   matches expected: YES
pipe-separated string  -> ["red","green"]
plain array            -> ["a","b"]
legit meta read back   -> ["red","green"]
payload meta read back -> __PHP_Incomplete_Class   | __wakeup fired: no (BLOCKED)
```

**No rendering change** — 14 legitimate value shapes (serialized arrays of strings/ints, nested arrays, pipe strings, empty, null, UTF-8, quoted, bool, already-array) compared `maybe_unserialize()` vs `wpuf_safe_unserialize()` with `===`: **0 differences**. `php -l` clean on all 7 files.

Reported by **WPScan** — please credit WPScan in the changelog/advisory.