### PR TITLE
fix: Oxygen Builder compatibility — load assets on builder layouts and keep password reset reachable

### DIFF
--- a/includes/Free/Simple_Login.php
+++ b/includes/Free/Simple_Login.php
@@ -299,7 +299,37 @@ class Simple_Login {
             return $url;
         }
 
+        // the lost password step is rendered by [wpuf-login]; if the configured
+        // login page does not have it, keep WordPress' own url so the user can
+        // still reset the password
+        if ( ! $this->login_page_renders_wpuf_form() ) {
+            return $url;
+        }
+
         return $this->get_action_url( 'lostpassword', $redirect );
+    }
+
+    /**
+     * Whether the configured login page renders the WPUF login form
+     *
+     * The `action` routing for lostpassword, rp and resetpass only runs inside
+     * the [wpuf-login] shortcode, so a login page built with another login form
+     * cannot serve those steps.
+     *
+     * @since WPUF_SINCE
+     *
+     * @return bool
+     */
+    protected function login_page_renders_wpuf_form() {
+        $page_id = wpuf_get_option( 'login_page', 'wpuf_profile', false );
+
+        if ( ! $page_id ) {
+            return false;
+        }
+
+        $has_form = wpuf_has_shortcode( 'wpuf-login', $page_id );
+
+        return apply_filters( 'wpuf_login_page_renders_form', $has_form, $page_id );
     }
 
     /**

--- a/includes/Free/Simple_Login.php
+++ b/includes/Free/Simple_Login.php
@@ -1215,6 +1215,19 @@ class Simple_Login {
      * @return void
      */
     public function default_wp_login_override() {
+        // only take over the login screen itself. `login_form_login` also runs
+        // for the submitted credentials, and redirecting those would stop them
+        // ever reaching wp_signon(), so any login form that posts to
+        // wp-login.php - a page builder login element, a theme form - could
+        // never log anybody in
+        $request_method = isset( $_SERVER['REQUEST_METHOD'] )
+            ? strtoupper( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_METHOD'] ) ) )
+            : 'GET';
+
+        if ( 'GET' !== $request_method ) {
+            return;
+        }
+
         $override       = wpuf_get_option( 'register_link_override', 'wpuf_profile', false );
         $login_redirect = wpuf_get_option( 'wp_default_login_redirect', 'wpuf_profile', false );
         $login_page     = wpuf_get_option( 'login_page', 'wpuf_profile', null );

--- a/wpuf-functions.php
+++ b/wpuf-functions.php
@@ -1706,7 +1706,71 @@ function wpuf_has_shortcode( $shortcode = '', $post_id = false ) {
         $found = true;
     }
 
+    // page builders that keep the layout outside post_content, e.g. Oxygen
+    if ( ! $found && wpuf_builder_layout_has_shortcode( $shortcode, $post_to_check->ID ) ) {
+        $found = true;
+    }
+
     return $found;
+}
+
+/**
+ * Check whether a page builder layout contains a shortcode
+ *
+ * Builders like Oxygen keep the layout in their own post meta and leave
+ * post_content empty, so wpuf_has_shortcode() cannot see a shortcode placed in
+ * a builder element. Without this the frontend assets never get enqueued on
+ * such pages and every script driven WPUF form stops working.
+ *
+ * @since WPUF_SINCE
+ *
+ * @param string $shortcode shortcode tag, without brackets
+ * @param int    $post_id   post to inspect
+ *
+ * @return bool
+ */
+function wpuf_builder_layout_has_shortcode( $shortcode, $post_id ) {
+    if ( empty( $shortcode ) || empty( $post_id ) ) {
+        return false;
+    }
+
+    $needle = '[' . $shortcode;
+
+    $meta_keys = apply_filters(
+        'wpuf_builder_layout_meta_keys', [
+            '_ct_builder_shortcodes', // Oxygen
+            '_ct_builder_json',       // Oxygen
+            '_elementor_data',        // Elementor
+        ]
+    );
+
+    foreach ( $meta_keys as $meta_key ) {
+        $layout = get_post_meta( $post_id, $meta_key, true );
+
+        if ( is_string( $layout ) && stripos( $layout, $needle ) !== false ) {
+            return true;
+        }
+    }
+
+    // Oxygen can also serve the shortcode from the template applied to this request
+    if (
+        defined( 'CT_VERSION' )
+        && absint( $post_id ) === absint( get_the_ID() )
+        && function_exists( 'ct_template_output' )
+    ) {
+        static $oxygen_template = null;
+
+        if ( null === $oxygen_template ) {
+            $template        = ct_template_output( true );
+            $oxygen_template = is_string( $template ) ? $template : '';
+        }
+
+        if ( '' !== $oxygen_template && stripos( $oxygen_template, $needle ) !== false ) {
+            return true;
+        }
+    }
+
+    return false;
 }
 
 /**


### PR DESCRIPTION
Closes weDevsOfficial/wpuf-pro#1666
Closes weDevsOfficial/wpuf-pro#1667
Closes weDevsOfficial/wpuf-pro#1669

Client report: weDevsOfficial/wpuf-pro#1662 (Oxygen Builder site — registration redirect and lost password both broken).

## Problem

**1. No WPUF asset ever loads on a page builder layout that lives outside `post_content`.**

`wpuf_has_shortcode()` only looked at `$post->post_content`, and `Frontend::enqueue_scripts()` gates every frontend style/script on it. Oxygen keeps the layout in `_ct_builder_shortcodes` / `_ct_builder_json` post meta and leaves `post_content` empty, so the gate never fired and `frontend-form.min.js` was missing. Since that file binds the submit handler, a `[wpuf_profile type="registration"]` or `[wpuf_form]` on an Oxygen page **could not submit at all** — pressing Register did nothing and no user was created. Uploads, conditional logic, multistep and subscription packs were dead on those pages too.

The gate already had an Elementor bypass (`class_exists( '\Elementor\Plugin' )`), so Elementor sites masked the problem; Oxygen had no equivalent.

**2. The lost password url was rewritten to a page that cannot serve it.**

`filter_lostpassword_url()` always pointed `wp_lostpassword_url()` at `{login_page}/?action=lostpassword`. That `action` routing only exists inside the `[wpuf-login]` shortcode (`Simple_Login::login_form()`). When the configured Login Page renders a different login form — Oxygen's own login element in this client's case — the link landed on a plain login form and the user could never reach the reset step.

**3. Submitted login credentials were redirected away from `wp-login.php`.**

`default_wp_login_override()` is hooked to `login_form_login`, which `wp-login.php` fires inside `case 'login':` for the GET that renders the screen **and** for the POST that carries the credentials. The POST was redirected to the WPUF login page before `wp_signon()` ran, so with **Register Link Override** + **WP Default Login Redirect** enabled no login form posting to `wp-login.php` could authenticate — Oxygen's login element, a theme form, or `wp-login.php` itself. The user was bounced back to the login screen with no error. On this client's site that meant nobody could log in at all.

## Fix

- `wpuf_has_shortcode()` now also consults `wpuf_builder_layout_has_shortcode()`, which scans the builder layout meta (`_ct_builder_shortcodes`, `_ct_builder_json`, `_elementor_data`) and, on Oxygen only, the template applied to the current request via `ct_template_output( true )` (result statically cached, so the template is resolved at most once per request).
- The meta key list is filterable through `wpuf_builder_layout_meta_keys` so another builder can be added without touching core.
- `filter_lostpassword_url()` returns WordPress' own url unless the configured login page really renders the WPUF form, overridable via `wpuf_login_page_renders_form`.
- `default_wp_login_override()` returns early unless the request is a `GET`, so it still replaces the login *screen* but never intercepts submitted credentials. `[wpuf-login]` is unaffected — it posts to itself and is handled in `process_login()` on `init`.

No new settings, no admin UI, no migration. Users do not have to change anything: sites that already work keep the exact same behaviour, Oxygen sites simply start loading the assets they always needed.

## Compatibility / regression notes

- Every caller of `wpuf_has_shortcode()` is in `includes/Frontend.php` (lines 44-53, 71, 172, 192) and only decides asset enqueueing and which subscription script handle to use — no form processing, redirect or capability logic reads it, so widening it cannot change submission behaviour.
- Both registration redirect paths are untouched and stay independent: free `[wpuf-registration]` → `$_POST['redirect_to']` → `wpuf_registration_redirect`; Pro `[wpuf_profile type="registration"]` → the form's `reg_redirect_to` / `reg_page_id`.
- The newly loaded `frontend-form.min.js` does not hijack the simple registration form: that form is `form.wpuf-registration-form` with a plain `input[name="wp-submit"]`, while the JS binds `form.wpuf-form-add` / `.wpuf-submit-button`. Re-tested after the change — it still posts normally and still lands on `?success=yes`.
- `_elementor_data` is included so Elementor pages that place `[wpuf-login]` in a Shortcode widget are still detected by the new login page check (they have empty `post_content` as well).
- Cost on non-builder sites: three `get_post_meta()` reads (object-cached) and no queries at all when the metas are absent.

## Security

Read-only predicate — no superglobals, no output, no SQL, no state change, so no nonce/capability surface is added. Meta values are used only through `is_string()` + `stripos()`, never unserialized by us and never echoed, and those meta keys are writable only by users who can already edit the page. The lost password change hands back core's own reset url, which keeps WordPress' standard nonce and validation flow.

## Testing

Local clone of the client's stack — WP 7.0.4, free 4.3.10 + this patch, Pro 4.2.15, Oxygen 4.9.7, `twentytwentyfive` — using the client's real Oxygen page trees.

| case | before | after |
|---|---|---|
| `frontend-form.min.js` on an Oxygen page | absent | present |
| Pro registration form on Oxygen page, submit | nothing happens, no user created | user created |
| …its **Redirect To → page** setting | never applied | redirects to the configured page |
| Free `[wpuf-registration]` on Oxygen page | `?success=yes` | `?success=yes` (unchanged) |
| Lost Password link, login page with Oxygen's login element | `/login/?action=lostpassword` → plain login form | core reset url → working reset form |
| Lost Password link, login page with `[wpuf-login]` | WPUF lost password form | WPUF lost password form (unchanged) |
| Login via Oxygen login element, with both override settings on | bounced back to login, never authenticated | logged in, redirected to the configured page |
| `wp-login.php` GET, both override settings on | redirects to WPUF login page | redirects to WPUF login page (unchanged) |
| Login via `[wpuf-login]` | works | works (unchanged) |

Also re-verified after packaging the change onto the shipped 4.3.10 build and installing it on the clone: Oxygen-hosted `[wpuf_dashboard]`, `[wpuf_account]` and `[wpuf_sub_pack]` pages all render with assets loaded, and the WPUF core lost-password flow completes (`?checkemail=confirm`).

`php -l` clean on both files; LF endings preserved.
