### PR TITLE
User Directory: live result count on the free directory

### DIFF
--- a/assets/js/ud-search-shortcode.js
+++ b/assets/js/ud-search-shortcode.js
@@ -174,6 +174,17 @@
                     hideLoading();
 
                     try {
+                        const udI18n = ( window.wpufUserDirectorySearch && window.wpufUserDirectorySearch.i18n ) || {};
+
+                        // Update the visible "Showing X of Y" result count (sits above the list, survives list re-renders)
+                        const countNode = listingDiv.querySelector('.wpuf-ud-result-count');
+                        if (countNode && data.count_label) {
+                            countNode.textContent = data.count_label;
+                            if (typeof data.total !== 'undefined') {
+                                countNode.setAttribute('data-total', data.total);
+                            }
+                        }
+
                         // If we have results, restore the user list container first
                         if (data.rows_html && data.rows_html.trim() !== '') {
                             // Remove "no results" message if it exists
@@ -214,11 +225,11 @@
 
                                     const heading = document.createElement('h3');
                                     heading.style.cssText = 'font-size: 1rem; font-weight: 600; color: #111827; margin-bottom: 0.5rem;';
-                                    heading.textContent = 'No users found matching your search criteria.';
+                                    heading.textContent = udI18n.noUsersFound || 'No users found matching your search criteria.';
 
                                     const description = document.createElement('p');
                                     description.style.cssText = 'font-size: 0.875rem; color: #6b7280;';
-                                    description.textContent = 'Try adjusting your search or filter to find what you\'re looking for.';
+                                    description.textContent = udI18n.tryAdjusting || 'Try adjusting your search or filter to find what you\'re looking for.';
 
                                     noResultsContent.appendChild(iconContainer);
                                     noResultsContent.appendChild(heading);

--- a/modules/user-directory/Api/Directory.php
+++ b/modules/user-directory/Api/Directory.php
@@ -649,6 +649,12 @@ class Directory extends WP_REST_Controller {
                 _n( '%d user found', '%d users found', $total, 'wp-user-frontend' ),
                 $total
             ),
+            'count_label'     => sprintf(
+                /* translators: 1: number of members shown on this page, 2: total members matched */
+                _n( 'Showing %1$s of %2$s member', 'Showing %1$s of %2$s members', $total, 'wp-user-frontend' ),
+                number_format_i18n( count( $users ) ),
+                number_format_i18n( $total )
+            ),
         ] );
     }
 

--- a/modules/user-directory/views/directory/layout-3.php
+++ b/modules/user-directory/views/directory/layout-3.php
@@ -30,6 +30,18 @@ if ( ! defined( 'ABSPATH' ) ) {
             
         </div>
     <?php endif; ?>
+    <div class="wpuf-ud-result-count !wpuf-text-sm !wpuf-text-gray-500 !wpuf-mb-4" data-total="<?php echo esc_attr( $total ); ?>">
+        <?php
+        echo esc_html(
+            sprintf(
+                /* translators: 1: number of members shown on this page, 2: total members matched */
+                _n( 'Showing %1$s of %2$s member', 'Showing %1$s of %2$s members', (int) $total, 'wp-user-frontend' ),
+                number_format_i18n( count( $users ) ),
+                number_format_i18n( $total )
+            )
+        );
+        ?>
+    </div>
     <div class="wpuf-ud-list wpuf-ud-list-layout-3 wpuf-flow-root">
         <?php if ( ! empty( $users ) ) { ?>
             <div>


### PR DESCRIPTION
## Summary

Free portion of the User Directory **result count** feature — a live **"Showing X of Y members"** count above the free directory list. Display-only; no query or submission changes.

- `Api/Directory.php`: `/search` response now returns a localized `count_label` (`_n` + `number_format_i18n`).
- `views/directory/layout-3.php`: renders the count node above the list.
- `assets/js/ud-search-shortcode.js`: updates the count live from the search response and wires the empty state to localized strings.

## Testing
Real-browser tested on the free directory shortcode: count renders on load and updates on search/filter; plural/singular correct.

Free portion of weDevsOfficial/wpuf-pro#1581 (the Pro PR weDevsOfficial/wpuf-pro#1676 covers the block + shortcode Pro side).

https://claude.ai/code/session_019KGP9sp935QBeu32pGt5WY
