### PR TITLE
User Directory: preview Pro directory features in the free wizard

### DIFF
--- a/src/js/user-directory/components/steps/StepAdvanced.js
+++ b/src/js/user-directory/components/steps/StepAdvanced.js
@@ -454,6 +454,7 @@ const StepAdvanced = ({ formData, setFormData, config }) => {
                     { key: 'az', label: __('A–Z alphabetical index bar', 'wp-user-frontend') },
                     { key: 'facets', label: __('Advanced faceted filter bar', 'wp-user-frontend') },
                     { key: 'copylink', label: __('Shareable / copy-link filtered view', 'wp-user-frontend') },
+                    { key: 'tags', label: __('Member tags — profile chips & tag filter', 'wp-user-frontend') },
                 ].map((feature) => (
                     <div key={feature.key} className="wpuf-flex wpuf-items-center wpuf-justify-between wpuf-py-2">
                         <div className="wpuf-flex wpuf-items-center wpuf-gap-3 wpuf-opacity-60">

--- a/src/js/user-directory/components/steps/StepAdvanced.js
+++ b/src/js/user-directory/components/steps/StepAdvanced.js
@@ -442,6 +442,30 @@ const StepAdvanced = ({ formData, setFormData, config }) => {
                     </div>
                 </div>
             </div>
+
+            {/* Pro-only directory features — locked preview */}
+            <div className="wpuf-mt-[25px] wpuf-border-t wpuf-border-gray-100 wpuf-pt-5">
+                <div className="wpuf-text-sm wpuf-font-semibold wpuf-text-gray-700 wpuf-mb-3">
+                    {__('More directory features', 'wp-user-frontend')}
+                </div>
+                {[
+                    { key: 'view_toggle', label: __('Visitor Grid / List view toggle', 'wp-user-frontend') },
+                    { key: 'timing', label: __('Show members on load or after search', 'wp-user-frontend') },
+                    { key: 'az', label: __('A–Z alphabetical index bar', 'wp-user-frontend') },
+                    { key: 'facets', label: __('Advanced faceted filter bar', 'wp-user-frontend') },
+                    { key: 'copylink', label: __('Shareable / copy-link filtered view', 'wp-user-frontend') },
+                ].map((feature) => (
+                    <div key={feature.key} className="wpuf-flex wpuf-items-center wpuf-justify-between wpuf-py-2">
+                        <div className="wpuf-flex wpuf-items-center wpuf-gap-3 wpuf-opacity-60">
+                            <span className="wpuf-inline-block wpuf-w-9 wpuf-h-5 wpuf-rounded-full wpuf-bg-gray-200 wpuf-relative wpuf-flex-shrink-0" aria-hidden="true">
+                                <span className="wpuf-absolute wpuf-top-0.5 wpuf-left-0.5 wpuf-w-4 wpuf-h-4 wpuf-rounded-full wpuf-bg-white"></span>
+                            </span>
+                            <span className="wpuf-text-sm wpuf-text-gray-500">{feature.label}</span>
+                        </div>
+                        <ProBadge config={config} utm="wpuf-user-directory-features" />
+                    </div>
+                ))}
+            </div>
         </div>
     );
 };


### PR DESCRIPTION
## What

Adds a locked **"More directory features"** section to the free Setup Wizard's Advanced Control step, previewing the Pro-only User Directory enhancements so free users see what Pro adds:

- Visitor Grid / List view toggle (#1575)
- Results-display timing — on load vs after search (#1577)
- A–Z alphabetical index bar (#1579)
- Advanced faceted filter bar (#1582)
- Shareable / copy-link filtered view (#1585)

Each renders as a disabled row with the existing `ProBadge` + upgrade link (reusing the wizard's established `isFree`/ProBadge convention). Free stays fully functional — nothing is gated; this only teases the Pro features.

## Pro side

The functional implementations live in the Pro repo (weDevsOfficial/wpuf-pro, branch `enhancement/user-directory-enhancements`, PR #1676).

## Notes

- Source-only change to `src/js/user-directory/components/steps/StepAdvanced.js`; the `wpuf-user-directory-free.js` bundle is a gitignored build artifact, compiled by the plugin's build.

https://claude.ai/code/session_019KGP9sp935QBeu32pGt5WY