### PR TITLE
feat: support the .jfif image format in frontend uploads (#1675)

### DIFF
--- a/class/render-form.php
+++ b/class/render-form.php
@@ -1680,7 +1680,7 @@ class WPUF_Render_Form {
         <script type="text/javascript">
             ;(function($) {
                 $(document).ready( function(){
-                    var uploader = new WPUF_Uploader('wpuf-<?php echo esc_attr( $unique_id ); ?>-pickfiles', 'wpuf-<?php echo esc_attr( $unique_id ); ?>-upload-container', <?php echo esc_attr( $attr['count'] ); ?>, '<?php echo esc_attr( $attr['name'] ); ?>', 'jpg,jpeg,gif,png,bmp', <?php echo esc_attr( $attr['max_size'] ); ?>);
+                    var uploader = new WPUF_Uploader('wpuf-<?php echo esc_attr( $unique_id ); ?>-pickfiles', 'wpuf-<?php echo esc_attr( $unique_id ); ?>-upload-container', <?php echo esc_attr( $attr['count'] ); ?>, '<?php echo esc_attr( $attr['name'] ); ?>', 'jpg,jpeg,jfif,gif,png,bmp', <?php echo esc_attr( $attr['max_size'] ); ?>);
                     wpuf_plupload_items.push(uploader);
                 });
             })(jQuery);

--- a/includes/Ajax/Upload_Ajax.php
+++ b/includes/Ajax/Upload_Ajax.php
@@ -152,7 +152,15 @@ class Upload_Ajax {
      * @return array attachment result with success status and attach_id
      */
     public function handle_upload( $upload_data ) {
+        // Allow the .jfif image extension (a JPEG variant) for WPUF uploads only,
+        // then unhook so the site-wide allowed types are left unchanged.
+        add_filter( 'upload_mimes', [ $this, 'allow_jfif_mime_type' ] );
+        add_filter( 'wp_check_filetype_and_ext', [ $this, 'resolve_jfif_filetype' ], 10, 4 );
+
         $uploaded_file = wp_handle_upload( $upload_data, [ 'test_form' => false ] );
+
+        remove_filter( 'upload_mimes', [ $this, 'allow_jfif_mime_type' ] );
+        remove_filter( 'wp_check_filetype_and_ext', [ $this, 'resolve_jfif_filetype' ], 10 );
         // If the wp_handle_upload call returned a local path for the image
         if ( isset( $uploaded_file['file'] ) ) {
             $file_loc    = $uploaded_file['file'];
@@ -189,6 +197,46 @@ class Upload_Ajax {
             'success' => false,
             'error'   => $uploaded_file['error'],
         ];
+    }
+
+    /**
+     * Allow the .jfif image extension (a JPEG variant) during a WPUF upload.
+     *
+     * WordPress does not permit .jfif by default, so a valid JFIF/JPEG image
+     * uploaded through a frontend field would otherwise be rejected.
+     *
+     * @since 4.3.11
+     *
+     * @param array $mimes Allowed mime types keyed by extension pattern.
+     *
+     * @return array
+     */
+    public function allow_jfif_mime_type( $mimes ) {
+        $mimes['jfif'] = 'image/jpeg';
+
+        return $mimes;
+    }
+
+    /**
+     * Resolve a .jfif file to the image/jpeg type so WordPress' real-mime check
+     * accepts it instead of flagging an extension/mime mismatch.
+     *
+     * @since 4.3.11
+     *
+     * @param array  $data     File data array with keys ext, type, proper_filename.
+     * @param string $file     Full path to the file.
+     * @param string $filename The name of the file.
+     * @param array  $mimes    Allowed mime types.
+     *
+     * @return array
+     */
+    public function resolve_jfif_filetype( $data, $file, $filename, $mimes ) {
+        if ( empty( $data['ext'] ) && preg_match( '/\.jfif$/i', $filename ) ) {
+            $data['ext']  = 'jfif';
+            $data['type'] = 'image/jpeg';
+        }
+
+        return $data;
     }
 
     public static function attach_html( $attach_id, $type = NULL, $form_id = NULL ) {

--- a/includes/Fields/Form_Field_Featured_Image.php
+++ b/includes/Fields/Form_Field_Featured_Image.php
@@ -95,7 +95,7 @@ class Form_Field_Featured_Image extends Field_Contract {
         <script type="text/javascript">
             ;(function($) {
                 $(document).ready( function(){
-                    var uploader = new WPUF_Uploader('wpuf-<?php echo esc_attr( $unique_id ); ?>-pickfiles', 'wpuf-<?php echo esc_attr( $unique_id ); ?>-upload-container', <?php echo esc_attr($field_settings['count'] ); ?>, '<?php echo esc_attr( $field_settings['name'] ); ?>', 'jpg,jpeg,gif,png,bmp,webp', <?php echo esc_attr( $field_settings['max_size'] ); ?>);
+                    var uploader = new WPUF_Uploader('wpuf-<?php echo esc_attr( $unique_id ); ?>-pickfiles', 'wpuf-<?php echo esc_attr( $unique_id ); ?>-upload-container', <?php echo esc_attr($field_settings['count'] ); ?>, '<?php echo esc_attr( $field_settings['name'] ); ?>', 'jpg,jpeg,jfif,gif,png,bmp,webp', <?php echo esc_attr( $field_settings['max_size'] ); ?>);
                     wpuf_plupload_items.push(uploader);
                 });
             })(jQuery);

--- a/includes/Fields/Form_Field_Image.php
+++ b/includes/Fields/Form_Field_Image.php
@@ -78,7 +78,7 @@ class Form_Field_Image extends Field_Contract {
             <script type="text/javascript">
                 (function($) {
                     $(document).ready( function(){
-                        var uploader = new WPUF_Uploader('wpuf-<?php echo esc_attr( $unique_id ); ?>-pickfiles', 'wpuf-<?php echo esc_attr( $unique_id ); ?>-upload-container', <?php echo esc_attr( isset( $field_settings['count'] ) ? $field_settings['count'] : 1 ); ?>, '<?php echo esc_attr( $field_settings['name'] ); ?>', 'jpg,jpeg,gif,png,bmp,webp', <?php echo esc_attr( isset( $field_settings['max_size'] ) ? $field_settings['max_size'] : 1024 ); ?>);
+                        var uploader = new WPUF_Uploader('wpuf-<?php echo esc_attr( $unique_id ); ?>-pickfiles', 'wpuf-<?php echo esc_attr( $unique_id ); ?>-upload-container', <?php echo esc_attr( isset( $field_settings['count'] ) ? $field_settings['count'] : 1 ); ?>, '<?php echo esc_attr( $field_settings['name'] ); ?>', 'jpg,jpeg,jfif,gif,png,bmp,webp', <?php echo esc_attr( isset( $field_settings['max_size'] ) ? $field_settings['max_size'] : 1024 ); ?>);
                         wpuf_plupload_items.push(uploader);
                     });
                 })(jQuery);

--- a/includes/Render_Form.php
+++ b/includes/Render_Form.php
@@ -1565,7 +1565,7 @@ class Render_Form {
         <script type="text/javascript">
             ;(function($) {
                 $(document).ready( function(){
-                    var uploader = new WPUF_Uploader('wpuf-<?php echo esc_attr( $unique_id ); ?>-pickfiles', 'wpuf-<?php echo esc_attr( $unique_id ); ?>-upload-container', <?php echo esc_attr( $attr['count'] ); ?>, '<?php echo esc_attr( $attr['name'] ); ?>', 'jpg,jpeg,gif,png,bmp', <?php echo esc_attr( $attr['max_size'] ); ?>);
+                    var uploader = new WPUF_Uploader('wpuf-<?php echo esc_attr( $unique_id ); ?>-pickfiles', 'wpuf-<?php echo esc_attr( $unique_id ); ?>-upload-container', <?php echo esc_attr( $attr['count'] ); ?>, '<?php echo esc_attr( $attr['name'] ); ?>', 'jpg,jpeg,jfif,gif,png,bmp', <?php echo esc_attr( $attr['max_size'] ); ?>);
                     wpuf_plupload_items.push(uploader);
                 });
             })(jQuery);

--- a/wpuf-functions.php
+++ b/wpuf-functions.php
@@ -534,7 +534,7 @@ function wpuf_get_image_sizes() {
 function wpuf_allowed_extensions() {
     $extesions = [
         'images' => [
-            'ext' => 'jpg,jpeg,gif,png,bmp,webp',
+            'ext' => 'jpg,jpeg,jfif,gif,png,bmp,webp',
             'label' => __( 'Images', 'wp-user-frontend' ),
         ],
         'audio'  => [
@@ -6358,6 +6358,7 @@ if ( ! function_exists( 'wpuf_field_profile_photo_allowed_extensions' ) ) {
         $allowed_extensions = [
             'jpg'  => __( 'JPG', 'wpuf-pro' ),
             'jpeg' => __( 'JPEG', 'wpuf-pro' ),
+            'jfif' => __( 'JFIF', 'wpuf-pro' ),
             'png'  => __( 'PNG', 'wpuf-pro' ),
             'gif'  => __( 'GIF', 'wpuf-pro' ),
         ];


### PR DESCRIPTION
Closes weDevsOfficial/wpuf-pro#1675

## Why

`.jfif` is a JPEG variant. WordPress does **not** allow it by default, so a valid JFIF/JPEG image uploaded through a WPUF frontend field is rejected server-side — even though the file picker offered it. Verified on a real site:

```
WP core allows jfif by default: NO
wp_check_filetype_and_ext('x.jfif')  ->  ext=false  type=false   (rejected)
```

## Fix

- Add `jfif` to the image allowlists: `wpuf_allowed_extensions()`, the image + featured-image uploader ext strings (`Form_Field_Image`, `Form_Field_Featured_Image`, `Render_Form`, legacy `class/render-form.php`), and `wpuf_field_profile_photo_allowed_extensions()`.
- In `Upload_Ajax::handle_upload()`, register **scoped** `upload_mimes` + `wp_check_filetype_and_ext` filters (`jfif => image/jpeg`) around `wp_handle_upload()` and remove them right after — so the site-wide allowed types are left unchanged; only a WPUF upload permits jfif.

After the fix:
```
wp_check_filetype_and_ext('x.jfif')  ->  ext='jfif'  type='image/jpeg'   (accepted)
```

## Scope / audit
- Live free upload path for `image_upload` + `file_upload` fields → `wpuf_upload_file` AJAX → `Upload_Ajax::handle_upload` — covered.
- `wpuf_upload_attachment()` is dead code (no callers) — untouched.
- Pro user-directory photo uploads are a separate feature — out of scope here.

`php -l` clean on all six files; existing formats (jpg/jpeg/png/gif/bmp/webp) unchanged.