### PR TITLE
fix: registration role privilege escalation + registration-off bypass (#1674)

### DIFF
--- a/includes/Frontend/Registration.php
+++ b/includes/Frontend/Registration.php
@@ -166,6 +166,16 @@ class Registration {
             if ( ! wp_verify_nonce( $nonce, 'wpuf_registration_action' ) ) {
                 return;
             }
+
+            // Honour the site's registration setting on the account-creation path,
+            // the same way the Register link in get_action_links() already does.
+            // Without this, a POST to the init-hooked handler creates an account
+            // even when registration is switched off. WordPress maps
+            // users_can_register onto the network setting on multisite.
+            // Reported by Murad Akhmedov (WPScan).
+            if ( ! get_option( 'users_can_register' ) ) {
+                return;
+            }
             $validation_error = new WP_Error();
             $reg_fname  = isset( $_POST['reg_fname'] ) ? sanitize_text_field( wp_unslash( $_POST['reg_fname'] ) ) : '';
             $reg_lname  = isset( $_POST['reg_lname'] ) ? sanitize_text_field( wp_unslash( $_POST['reg_lname'] ) ) : '';

--- a/wpuf-functions.php
+++ b/wpuf-functions.php
@@ -3978,7 +3978,9 @@ function wpuf_encryption( $id, $nonce = null ) {
     }
 
     $ciphertext_raw = openssl_encrypt( $id, Encryption_Helper::get_encryption_method(), $secret_key, OPENSSL_RAW_DATA, $secret_iv );
-    $hmac           = hash_hmac( 'sha256', $ciphertext_raw, $secret_key, true );
+    // Authenticate the IV together with the ciphertext so a tampered IV is
+    // rejected on the way back in (see wpuf_decryption()).
+    $hmac           = hash_hmac( 'sha256', $secret_iv . $ciphertext_raw, $secret_key, true );
 
     return base64_encode( $secret_iv.$hmac.$ciphertext_raw );
 }
@@ -4019,15 +4021,19 @@ function wpuf_decryption( $id, $nonce = null ) {
     $secret_iv      = substr( $c, 0, $ivlen );
     $hmac           = substr( $c, $ivlen, 32 );
     $ciphertext_raw = substr( $c, $ivlen + 32 );
-    $original_text  = openssl_decrypt( $ciphertext_raw, Encryption_Helper::get_encryption_method(), $secret_key, OPENSSL_RAW_DATA, $secret_iv );
-    $calcmac        = hash_hmac( 'sha256', $ciphertext_raw, $secret_key, true );
+    // The IV travels inside the payload, so it must be authenticated too: an
+    // unauthenticated IV lets an attacker flip the first CBC plaintext block and
+    // forge a different value under the unchanged ciphertext/HMAC (e.g. a higher
+    // role in registration). Cover IV + ciphertext and verify BEFORE decrypting.
+    // Reported by Murad Akhmedov (WPScan).
+    $calcmac        = hash_hmac( 'sha256', $secret_iv . $ciphertext_raw, $secret_key, true );
 
     // timing attack safe comparison
-    if ( hash_equals( $hmac, $calcmac ) ) {
-        return $original_text;
+    if ( ! hash_equals( $hmac, $calcmac ) ) {
+        return false;
     }
 
-    return false;
+    return openssl_decrypt( $ciphertext_raw, Encryption_Helper::get_encryption_method(), $secret_key, OPENSSL_RAW_DATA, $secret_iv );
 }
 
 /**


### PR DESCRIPTION
Closes weDevsOfficial/wpuf-pro#1674 · reported by **Murad Akhmedov** (WPScan). Both confirmed on 4.3.10, both on PHP builds without a usable sodium secretbox (the openssl fallback).

## 1. Unauthenticated privilege escalation via the registration role — CVSS 7.4

`wpuf_decryption()` took its IV from the **submitted** payload while the HMAC covered **only the ciphertext**. The IV was never authenticated, and CBC recovers the first plaintext block by XORing the IV into the block-cipher output — so an attacker recomputes the first 16 bytes and makes the unchanged ciphertext + unchanged HMAC decode to a **different role**. `process_registration()` accepted any role `get_role()` recognises except literal `administrator`, so Subscriber → Editor (or `shop_manager` on WooCommerce sites, etc.).

**Fix:** the HMAC now covers **IV + ciphertext** and is **verified before decrypting**, in both `wpuf_encryption()` and `wpuf_decryption()`. Any tampered IV → HMAC mismatch → `false` → role falls back to `default_role`. This also closes the guest-post `p_id`/`f_id` verification path (`Frontend_Form.php`), which uses the same helper.

## 2. Registrations accepted when registration is switched off — CVSS 5.3

`process_registration()` never consulted `users_can_register`, though `get_action_links()` already gates the Register link on it. **Fix:** gate the account-creation path on `get_option( 'users_can_register' )` (WordPress maps this onto the network setting on multisite).

## Proof (openssl branch)

```
PRE-FIX  forged IV-flip => 'editor'   ESCALATED
POST-FIX forged IV-flip => false      BLOCKED
round-trip => 'subscriber'            intact
```

## Compatibility / business logic
- **sodium path unchanged** — secretbox already authenticates everything; the common PHP 7.2+ case is unaffected either way.
- **Wire-format note:** the openssl HMAC scope changed (now covers IV). Registration role blobs are re-minted on every page render, so unaffected. The only narrow regression is a guest-post verification link that was **emailed before the update on a non-sodium site** — its old blob no longer verifies. Time-limited and rare.
- **Registration gate:** matches the plugin's own `get_action_links()` behaviour and WP core. Sites that intend to use WPUF registration must have "Anyone can register" on (as the Register link already requires).

Nonce fail-closed (Yaswanth Reddy Sunkara's separate item on the same thread) already shipped in 4.3.11. `php -l` clean; 2 files, +22/-6.