### PR TITLE
fix(e2e): category/tag validation selector (td vs th primary column)

### DIFF
--- a/tests/e2e/pages/selectors.ts
+++ b/tests/e2e/pages/selectors.ts
@@ -232,14 +232,14 @@ export const Selectors = {
             clickCategoryMenu: '//a[normalize-space()="Categories"]',
             addNewCategory: '//input[@id="tag-name"]',
             submitCategory: '//input[@id="submit"]',
-            validateCategory: (categoryName: string) => `//tbody[@id="the-list"]//tr//td//strong//a[normalize-space()="${categoryName}"]`,
+            validateCategory: (categoryName: string) => `//tbody[@id="the-list"]//tr//strong//a[normalize-space()="${categoryName}"]`,
         },
 
         tags: {
             clickTagsMenu: '//a[normalize-space()="Tags"]',
             addNewTag: '//input[@id="tag-name"]',
             submitTag: '//input[@id="submit"]',
-            validateTag: (tagName: string) => `//tbody[@id="the-list"]//tr//td//strong//a[normalize-space()="${tagName}"]`,
+            validateTag: (tagName: string) => `//tbody[@id="the-list"]//tr//strong//a[normalize-space()="${tagName}"]`,
         },
 
         keys: {

--- a/tests/e2e/pages/settingsSetup.ts
+++ b/tests/e2e/pages/settingsSetup.ts
@@ -583,17 +583,36 @@ export class SettingsSetupPage extends Base {
     }
 
     async createPostCategories() {
-        //Go to Admin-Users
-        await this.navigateToURL(this.categoriesPage);
-        //Add New Category
-        //await this.validateAndClick(Selectors.settingsSetup.categories.clickCategoryMenu);
-        await this.page.waitForLoadState('domcontentloaded');
         const categoryNames: string[] = ['Science', 'Music'];
         for (let i = 0; i < categoryNames.length; i++) {
+            // Reload the categories screen for every term. WordPress's "Add New Category"
+            // form falls back to a full-page POST when its AJAX handler isn't bound, so filling
+            // the next term into a form left over from the previous submit races that reload and
+            // posts an empty name. A fresh page guarantees a stable form for each term.
+            await this.navigateToURL(this.categoriesPage);
+            await this.page.waitForLoadState('domcontentloaded');
+
+            const categoryRow = this.page
+                .locator(Selectors.settingsSetup.categories.validateCategory(categoryNames[i]))
+                .first();
+
+            // Idempotent: skip terms that already exist (e.g. a re-run against a used site).
+            if ( await categoryRow.count() > 0 ) {
+                continue;
+            }
+
             await this.validateAndFillStrings(Selectors.settingsSetup.categories.addNewCategory, categoryNames[i]);
             await this.validateAndClick(Selectors.settingsSetup.categories.submitCategory);
             await this.page.waitForTimeout(500);
-            await this.assertionValidate(Selectors.settingsSetup.categories.validateCategory(categoryNames[i]));
+
+            // The add completes either via AJAX (row injected in place) or a full-page POST (the
+            // submit navigates and the row is present after the redirect). Settle the page, then
+            // wait on the row; .first() tolerates any duplicate left on a re-used site.
+            await this.page.waitForLoadState('domcontentloaded').catch(() => {});
+            await this.page
+                .locator(Selectors.settingsSetup.categories.validateCategory(categoryNames[i]))
+                .first()
+                .waitFor({ timeout: 20000 });
         }
     }
     async createPostTags() {


### PR DESCRIPTION
## Problem
Setup phase LS0016/LS0017 (add post categories / tags) hung for 3 minutes and failed. Root cause: the validation selector was `//tbody[@id="the-list"]//tr//td//strong//a`, but WordPress renders the term name in the list's **primary column as a `<th scope="row">`, not a `<td>`**. So the locator never matched — the term was created server-side, but the assertion waited until the test timeout, and the loop never reached the second term.

This blocked the suite from ever getting past LS0016 locally.

## Fix
- Drop the `//td` segment so the row-title link matches in a `th` or `td` (`validateCategory`, `validateTag`).
- `createPostCategories`: reload the categories screen per term (the add form falls back to a full-page POST when its AJAX handler isn't bound, so reusing the prior form races the reload) and wait on the row with `.first()` + a bounded timeout, so a real failure surfaces in seconds instead of a 3-minute hang.

## Result
Setup now passes **LS0016–LS0028** (categories, tags, maps, recaptcha, turnstile, modules on/off, gateways, AI). Verified on a fresh wp-env.

No product code touched — e2e test-suite only.

https://claude.ai/code/session_019KGP9sp935QBeu32pGt5WY