### PR TITLE
docs(e2e): document the th-not-td category/tag validator selectors

### DIFF
--- a/tests/e2e/pages/selectors.ts
+++ b/tests/e2e/pages/selectors.ts
@@ -232,6 +232,9 @@ export const Selectors = {
             clickCategoryMenu: '//a[normalize-space()="Categories"]',
             addNewCategory: '//input[@id="tag-name"]',
             submitCategory: '//input[@id="submit"]',
+            // No //td segment on purpose: WordPress renders the term name in the list's primary
+            // column as a <th scope="row">, not a <td>. //td//strong//a never matched, so the
+            // add succeeded but validation hung until the test timeout. Do not re-add //td.
             validateCategory: (categoryName: string) => `//tbody[@id="the-list"]//tr//strong//a[normalize-space()="${categoryName}"]`,
         },
 
@@ -239,6 +242,9 @@ export const Selectors = {
             clickTagsMenu: '//a[normalize-space()="Tags"]',
             addNewTag: '//input[@id="tag-name"]',
             submitTag: '//input[@id="submit"]',
+            // No //td segment on purpose: WordPress renders the term name in the list's primary
+            // column as a <th scope="row">, not a <td>. //td//strong//a never matched, so the
+            // add succeeded but validation hung until the test timeout. Do not re-add //td.
             validateTag: (tagName: string) => `//tbody[@id="the-list"]//tr//strong//a[normalize-space()="${tagName}"]`,
         },
 


### PR DESCRIPTION
Follow-up to #1954. Adds a regression-guarding comment at `validateCategory`/`validateTag` explaining why there is no `//td` segment: WordPress renders the term name in the list's primary column as a `<th scope="row">`, so `//td//strong//a` never matches and the LS0016/LS0017 assertions hang for 3 minutes. Prevents anyone re-adding `//td`.

Comment-only, e2e test-suite only — no product or behaviour change.

Closes weDevsOfficial/wpuf-pro#1686

https://claude.ai/code/session_019KGP9sp935QBeu32pGt5WY