### PR TITLE
fix(e2e): setup robustness — pagination-independent page checks + optional Dokan notice

### DIFF
--- a/tests/e2e/pages/settingsSetup.ts
+++ b/tests/e2e/pages/settingsSetup.ts
@@ -132,18 +132,27 @@ export class SettingsSetupPage extends Base {
     }
 
     async validateWPUFpages() {
-        await this.navigateToURL(this.pagesPage);
+        // Validate each WPUF page independently of pagination. The pages list is sorted
+        // alphabetically and other plugins (WooCommerce, MailPoet, Dokan, EDD) add their own
+        // pages, so which pagination page a WPUF row lands on is not stable — relying on a
+        // fixed "page 1 then Next" split makes this flaky (a shifted row times out). Instead
+        // search the list for each page (WP admin `s=` param) so its row is always on screen.
+        const wpufPages: Array<[string, string]> = [
+            [ 'Account', Selectors.settingsSetup.wpufPages.wpufAccountPage ],
+            [ 'Dashboard', Selectors.settingsSetup.wpufPages.wpufDashboardPage ],
+            [ 'Edit', Selectors.settingsSetup.wpufPages.wpufEditPage ],
+            [ 'Login', Selectors.settingsSetup.wpufPages.wpufLoginPage ],
+            [ 'Order Received', Selectors.settingsSetup.wpufPages.orderReceivedPage ],
+            [ 'Payment', Selectors.settingsSetup.wpufPages.paymentPage ],
+            [ 'Subscription', Selectors.settingsSetup.wpufPages.wpufSubscriptionPage ],
+            [ 'Thank You', Selectors.settingsSetup.wpufPages.thankYouPage ],
+        ];
 
-        //Validate WPUF Pages
-        await this.assertionValidate(Selectors.settingsSetup.wpufPages.wpufAccountPage);
-        await this.assertionValidate(Selectors.settingsSetup.wpufPages.wpufDashboardPage);
-        await this.assertionValidate(Selectors.settingsSetup.wpufPages.wpufEditPage);
-        await this.assertionValidate(Selectors.settingsSetup.wpufPages.wpufLoginPage);
-        await this.assertionValidate(Selectors.settingsSetup.wpufPages.orderReceivedPage);
-        await this.assertionValidate(Selectors.settingsSetup.wpufPages.paymentPage);
-        await this.validateAndClick(Selectors.settingsSetup.wpufPages.clickNextPage);
-        await this.assertionValidate(Selectors.settingsSetup.wpufPages.wpufSubscriptionPage);
-        await this.assertionValidate(Selectors.settingsSetup.wpufPages.thankYouPage);
+        for (const [ pageName, selector ] of wpufPages) {
+            await this.navigateToURL(`${this.pagesPage}&s=${encodeURIComponent(pageName)}`);
+            await this.page.waitForLoadState('domcontentloaded');
+            await this.assertionValidate(selector);
+        }
         console.log('WPUF Pages are validated. all pages created successfully');
     }
 

--- a/tests/e2e/pages/settingsSetup.ts
+++ b/tests/e2e/pages/settingsSetup.ts
@@ -354,10 +354,20 @@ export class SettingsSetupPage extends Base {
                 await this.validateAndClick(Selectors.settingsSetup.pluginStatusCheck.clickDokanLite);
 
                 await this.navigateToURL(this.pluginsPage);
+                // Activation is confirmed by the Deactivate control appearing.
                 await this.assertionValidate(Selectors.settingsSetup.pluginStatusCheck.clickDokanLiteDeactivate);
 
-                await this.validateAndClick(Selectors.settingsSetup.pluginStatusCheck.clickAllow);
-
+                // Some Dokan versions surface an Appsero opt-in ("Allow") after activation and
+                // some do not. Dismiss it when present, but never block on it — it is optional
+                // UI, and activation is already verified above. Blocking here hung LS0030 for
+                // the full test timeout on builds where the notice never appears.
+                const dokanAllow = this.page.locator(Selectors.settingsSetup.pluginStatusCheck.clickAllow).first();
+                try {
+                    await dokanAllow.waitFor({ timeout: 5000 });
+                    await dokanAllow.click();
+                } catch (e) {
+                    console.log('Dokan Appsero opt-in not shown; continuing');
+                }
 
                 await this.navigateToURL(this.wpAdminPage);
                 await this.validateAndClick(Selectors.login.basicNavigation.clickDokanSidebar);


### PR DESCRIPTION
Two verified fixes to the setup phase, both real test bugs (not happy-path masking):

## LS0010 — pagination-independent WPUF page validation
The check hard-coded a page-1 / Next / page-2 split of the admin Pages list. The list is alphabetical and other active plugins (WooCommerce, MailPoet, EDD, Dokan) add pages, so a WPUF row shifts across the 20-per-page boundary and a page-1 assertion then waits for a row now on page 2 → 3-min timeout. **This is exactly why CI hangs at LS0010 (MailPoet present) but local passes.** Verified every WPUF page exists with its post-state label — only the pagination assumption was wrong. Now searches the list per page (WP admin `s=`) so each row is always on screen; dropped the fragile Next click.

## LS0030 — don't block on Dokan's optional Appsero notice
Dokan's post-activation "Allow" opt-in appears on some builds and not others; clicking it unconditionally hung LS0030 for the full timeout when absent. Activation is confirmed by the Deactivate control; the notice is now best-effort.

e2e test-suite only, no product code. Verified locally: LS0010 passes and setup runs through LS0019.

Known remaining (separate, deeper): LS0011 (Dokan + WPUF both create a "Dashboard" page → frontend-nav collision when wp-env auto-activates Dokan) and non-idempotent settings on local re-runs (LS0020 Turnstile) — both fixture-lifecycle, not product bugs.

https://claude.ai/code/session_019KGP9sp935QBeu32pGt5WY