### PR TITLE
fix(e2e): wpCli uses @wordpress/env + the container backing QA_BASE_URL

### DIFF
--- a/tests/e2e/utils/wpEnvCli.ts
+++ b/tests/e2e/utils/wpEnvCli.ts
@@ -1,7 +1,19 @@
 import { execSync } from 'child_process';
 
 /**
- * Run a wp-cli command inside the wp-env "tests-cli" container and return stdout.
+ * The wp-env CLI container that backs the site under test. wp-env serves the dev
+ * site (:8888) from `cli` and the tests site (:8889, the default target) from
+ * `tests-cli`. DB assertions must run against whichever one QA_BASE_URL points at,
+ * otherwise they read a different database than the browser navigates and fail
+ * (e.g. "Command failed" when a page created for the run isn't in that DB).
+ */
+function wpEnvCliContainer(): string {
+    return ( process.env.QA_BASE_URL || '' ).includes( ':8888' ) ? 'cli' : 'tests-cli';
+}
+
+/**
+ * Run a wp-cli command inside the wp-env container backing QA_BASE_URL and return
+ * stdout.
  *
  * Works both locally and in CI because both bring the environment up with
  * `wp-env` (see .github/workflows/e2e-wpuf.yml). `--skip-plugins --skip-themes`
@@ -10,7 +22,10 @@ import { execSync } from 'child_process';
  * surface (e.g. MailPoet subscribers, whose admin UI is gated by onboarding).
  */
 export function wpCli(command: string): string {
-    const full = `npx wp-env run tests-cli wp --skip-plugins --skip-themes ${command}`;
+    // Use the current package name: `wp-env` is a deprecated shim that only prints
+    // "Please run npx @wordpress/env instead" and exits 0 without running wp-cli, which
+    // made every wpCli() call return that message and throw when parsing its result.
+    const full = `npx @wordpress/env run ${wpEnvCliContainer()} wp --skip-plugins --skip-themes ${command}`;
     return execSync(full, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
 }
 


### PR DESCRIPTION
## Problem
`wpCli()` (utils/wpEnvCli.ts) shelled out to `npx wp-env run …`. `wp-env` is a **deprecated shim** that only prints `Please run npx @wordpress/env instead` and exits **without running wp-cli**. So every DB-seed/assert helper got that message back and threw `Command failed` — breaking the frontend-login spec (FL0001, which seeds a `[wpuf-login]` page in `beforeAll`), MailPoet subscriber checks, and option get/set helpers.

## Fix
- Use `@wordpress/env` (verified: it actually runs wp-cli where `wp-env` returns the redirect message).
- Target the container backing `QA_BASE_URL`: dev (:8888) → `cli`, tests (:8889, default) → `tests-cli`, so DB assertions hit the same database the browser navigates.

e2e test-suite only. Backward-compatible for CI (tests env → `tests-cli`, unchanged).

https://claude.ai/code/session_019KGP9sp935QBeu32pGt5WY