### PR TITLE
fix(e2e): sync multi-step progressbar validators with redesigned 2-type markup

### DIFF
--- a/tests/e2e/pages/selectors.ts
+++ b/tests/e2e/pages/selectors.ts
@@ -1130,8 +1130,13 @@ export const Selectors = {
         postStatusColumn: (title: string, status: string, a: string, b: string) => `//td${a}[normalize-space(text())="${title}"]//..${b}//span[normalize-space(text())="${status}"]`,
         saveDraftButton: '//a[normalize-space(text())="Save Draft"]',
         draftSavedAlert: '//span[@class="wpuf-draft-saved"]',
-        multiStepProgressbar: '//div[normalize-space(text())="Step Start (100%)"]',
-        multiStepByStep: '//li[normalize-space(text())="Step Start"]',
+        // Progressbar ("progressive") type — the default. The frontend renders a header
+        // (.wpuf-progressbar-header) with "Step N of M" step text plus a percent, not the old
+        // "Step Start (100%)" label. Match the new step-text span.
+        multiStepProgressbar: '//div[contains(@class,"wpuf-multistep-progressbar")]//span[contains(@class,"wpuf-progressbar-step-text") and starts-with(normalize-space(.),"Step 1 of")]',
+        // Step-by-step type — renders a .wpuf-step-wizard of .wpuf-step-item circles, each with
+        // a .wpuf-step-label carrying the step legend ("Step Start"), not the old <li> markup.
+        multiStepByStep: '//div[contains(@class,"wpuf-step-wizard")]//div[contains(@class,"wpuf-step-label") and normalize-space(text())="Step Start"]',
         removeStepStart: '//div[@class="step-start-indicator"]/../../../..//span[4]',
         confirmDelete: '//button[normalize-space()="Yes, delete it"]',
         threeDotButton: '(//div[contains(@class,"wpuf-relative wpuf-inline-block")]//button)[1]',
@@ -1495,8 +1500,8 @@ export const Selectors = {
             multiStepTypeContainer: '//label[@for="multistep_progressbar_type-selectized"]//..//..//div[contains(@class,"selectize-control")]//div[contains(@class,"selectize-input")]',
             multiStepTypeDropdown: '//label[@for="multistep_progressbar_type-selectized"]//..//..//div[contains(@class,"selectize-dropdown-content")]',
             multiStepTypeOption: (value: string) => `//label[@for="multistep_progressbar_type-selectized"]//..//..//div[contains(@class,"selectize-dropdown-content")]//div[@data-value="${value}"]`,
-            multiStepProgressbar: '//div[normalize-space(text())="Step Start (100%)"]',
-            multiStepByStep: '//li[normalize-space(text())="Step Start"]',
+            multiStepProgressbar: '//div[contains(@class,"wpuf-multistep-progressbar")]//span[contains(@class,"wpuf-progressbar-step-text") and starts-with(normalize-space(.),"Step 1 of")]',
+            multiStepByStep: '//div[contains(@class,"wpuf-step-wizard")]//div[contains(@class,"wpuf-step-label") and normalize-space(text())="Step Start"]',
         },
 
         // Custom Fields Section


### PR DESCRIPTION
## Problem
The multi-step progressbar UI was **redesigned** and now has **two types** (Post_Form.php: `progressive` = "Progressbar", the default; `step_by_step` = "Step by Step"). PFS0030/PFS0031 still targeted the old markup and hung 3 minutes each:
- `multiStepProgressbar` expected `<div>Step Start (100%)</div>` — the new progressive type renders a `.wpuf-progressbar-header` with "Step N of M" step text + a percent span.
- `multiStepByStep` expected `<li>Step Start</li>` — the new step-by-step type renders a `.wpuf-step-wizard` of `.wpuf-step-item` circles, each with a `.wpuf-step-label`.

Confirmed against the live rendered DOM ("Step 1 of 1 100%") and the frontend JS (`frontend-form-step.js`).

## Fix
Point both validators at the current elements:
- Progressbar → `.wpuf-progressbar-step-text` starting "Step 1 of".
- Step by Step → `.wpuf-step-wizard .wpuf-step-label` = "Step Start".

## Verified
Fresh wp-env: **PFS0030 ✓ (2.6s), PFS0031 ✓ (4.8s)** — both previously timed out at 3m.

e2e test-suite only. No product code.

https://claude.ai/code/session_019KGP9sp935QBeu32pGt5WY