### PR TITLE
fix(e2e): green MailPoet chain (EM0001-EM0005) + wpCli instance override

### DIFF
--- a/tests/e2e/pages/mailPoet.ts
+++ b/tests/e2e/pages/mailPoet.ts
@@ -142,7 +142,17 @@ export class MailPoetPage extends Base {
      * email is a subscriber inside the named MailPoet list.
      */
     async validateUserSubscribedToList(email: string, listName: string) {
-        const subscribed = isMailPoetSubscriberInList(email, listName);
+        // WPUF hands the subscriber to MailPoet during registration, but MailPoet commits the
+        // segment link asynchronously, so an immediate DB read right after EM0004 can miss it.
+        // Poll a few times before asserting rather than failing on the first (too-early) read.
+        let subscribed = false;
+        for (let attempt = 0; attempt < 10; attempt++) {
+            subscribed = isMailPoetSubscriberInList(email, listName);
+            if (subscribed) {
+                break;
+            }
+            await this.page.waitForTimeout(1000);
+        }
         expect(
             subscribed,
             `Expected ${email} to be a MailPoet subscriber in list "${listName}"`

--- a/tests/e2e/utils/wpEnvCli.ts
+++ b/tests/e2e/utils/wpEnvCli.ts
@@ -26,7 +26,13 @@ export function wpCli(command: string): string {
     // "Please run npx @wordpress/env instead" and exits 0 without running wp-cli, which
     // made every wpCli() call return that message and throw when parsing its result.
     const full = `npx @wordpress/env run ${wpEnvCliContainer()} wp --skip-plugins --skip-themes ${command}`;
-    return execSync(full, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+    // `@wordpress/env` resolves the instance from its working directory. In CI the suite and
+    // the wp-env instance share this directory, so the default cwd is correct. For a local
+    // setup where the wp-env project lives elsewhere (its .wp-env.json is not under tests/e2e),
+    // point WPUF_E2E_WP_ENV_DIR at that project dir so DB assertions hit the running instance
+    // instead of an unstarted one in the test cwd.
+    const cwd = process.env.WPUF_E2E_WP_ENV_DIR || process.cwd();
+    return execSync(full, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], cwd } );
 }
 
 /**


### PR DESCRIPTION
## MailPoet (EM0001-EM0005) — now fully green
With MailPoet active, the whole subscribe-on-registration chain passes. Two fixes:

1. **EM0005 async timing** — WPUF hands the subscriber to MailPoet during registration, but MailPoet commits the segment link asynchronously. An immediate DB read right after EM0004 could miss it. `validateUserSubscribedToList` now polls (10×1s) before asserting.

2. **wpCli instance (`WPUF_E2E_WP_ENV_DIR`)** — `@wordpress/env` resolves the instance from its working directory. In CI the suite and the wp-env instance share the dir (default cwd correct). A local split setup (wp-env project's `.wp-env.json` outside `tests/e2e`) can now set `WPUF_E2E_WP_ENV_DIR` so DB assertions hit the **running** instance instead of an unstarted one in the test cwd. CI behavior unchanged.

## Verified (local wp-env + MailPoet)
- **EM0001–EM0005 all pass**; registered visitor confirmed in "Newsletter mailing list".
- Side effect: the **frontend-login spec** (FL0001–FL0006), which also uses `wpCli`, passes too (FL0005 self-skips = mailer env, by design).
- The MailPoet **product works** — WPUF correctly subscribes the user (subscriber row + segment link verified).

e2e test-suite only. No product code.

https://claude.ai/code/session_019KGP9sp935QBeu32pGt5WY