### PR TITLE
fix(e2e): handle redesigned custom-widget multiselect on the frontend (PF0003)

### DIFF
--- a/tests/e2e/pages/base.ts
+++ b/tests/e2e/pages/base.ts
@@ -329,6 +329,40 @@ export class Base {
         }
     }
 
+    // Select a value in an enhanced multiselect. WPUF's redesigned multi-select field
+    // (Form_Field_MultiDropdown enqueues wpuf-custom-multiselect) wraps the native
+    // <select multiple> in a custom widget and hides the real element, so page.selectOption()
+    // hangs waiting for a visible option. Set the option on the (attached but hidden) native
+    // select and dispatch change/input so the widget syncs — robust to the widget's markup.
+    async selectMultiSelectByValue(locator: string, value: string) {
+        try {
+            await this.waitForLoading();
+            const element = this.page.locator(locator).first();
+            await element.waitFor({ state: 'attached' });
+            const matched = await element.evaluate((select: HTMLSelectElement, val: string) => {
+                const opt = Array.from(select.options).find(
+                    o => o.value === val || o.text.trim() === val
+                );
+                if (!opt) {
+                    return false;
+                }
+                opt.selected = true;
+                select.dispatchEvent(new Event('change', { bubbles: true }));
+                select.dispatchEvent(new Event('input', { bubbles: true }));
+                return true;
+            }, value);
+            expect(
+                matched,
+                `Multiselect ${locator} has no option matching "${value}"`
+            ).toBe(true);
+            await this.waitForLoading();
+            console.log('\x1b[33m%s\x1b[0m', `✅ Multiselected ${locator} with ${value}`);
+        } catch (error) {
+            console.log('\x1b[31m%s\x1b[0m', `❌ Failed to multiselect ${locator} with value ${value}: ${error}`);
+            throw error;
+        }
+    }
+
     // Wait for networkidle
     async waitForLoading() {
         await this.page.waitForLoadState('domcontentloaded');

--- a/tests/e2e/pages/postForm.ts
+++ b/tests/e2e/pages/postForm.ts
@@ -224,8 +224,8 @@ export class PostFormPage extends Base {
         console.log(PostForm.textarea);
         //Enter Dropdown
         await this.selectOptionWithValue(Selectors.postForms.postFormsFrontendCreate.postDropdownFormsFE, PostForm.dropdown);
-        //Enter Multi Select
-        await this.selectOptionWithValue(Selectors.postForms.postFormsFrontendCreate.postMultiSelectFormsFE, PostForm.multiSelect);
+        //Enter Multi Select (redesigned into a custom widget over a hidden native select)
+        await this.selectMultiSelectByValue(Selectors.postForms.postFormsFrontendCreate.postMultiSelectFormsFE, PostForm.multiSelect);
         //Enter Radio
         await this.validateAndClick(Selectors.postForms.postFormsFrontendCreate.postRadioFormsFE);
         //Enter Checkbox


### PR DESCRIPTION
## Problem
PF0003 (User is Creating Post from Frontend) hung for 3 minutes and the browser was torn down ("Target page, context or browser has been closed") — the post shard's only failure (96 passed, 1 failed).

Root cause: the **multi-select field was redesigned**. `Form_Field_MultiDropdown` now enqueues `wpuf-custom-multiselect`, which wraps the native `<select multiple>` in a custom widget and hides the real element. `page.selectOption('//select[@name="multi_select[]"]', …)` then waits forever for a visible option. (Confirmed: the field's config still holds `{"Option":"Option"}`, and the native select is present but hidden behind the widget.)

## Fix
Add `Base.selectMultiSelectByValue()`: set the chosen option on the attached-but-hidden native `<select>` and dispatch `change`/`input` so the custom widget syncs — robust to the widget's markup. Use it in `createPostFE`.

## Verified (fresh wp-env)
- **PF0003 passes in 6.2s** (was a 3-minute timeout), **PF0004** validates the created post.
- Also confirmed on clean state that the **subscription buy-now** shard test (SB0015) passes with the redesigned Tailwind pack template — its CI failure is state/cascade, not a selector/design bug.

e2e test-suite only. No product code.

https://claude.ai/code/session_019KGP9sp935QBeu32pGt5WY