### PR TITLE
chore: gitignore the .playwright-mcp scratch dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ phpcs-report.txt
 # Ignore the following directories and files for automation tests
 test-results
 playwright-report
+.playwright-mcp/
 tests/e2e/node_modules/
 tests/e2e/test-results/
 tests/e2e/setup


### PR DESCRIPTION
Playwright MCP writes snapshots/console logs to `.playwright-mcp/` at the plugin root during local test/debug. Disposable — ignore it like the other automation artifacts (`test-results`, `playwright-report`).