### PR TITLE
fix(security): 4.3.11 follow-up — draft gate bypass, registration session fixation, role hardening

### DIFF
--- a/includes/Ajax/Frontend_Form_Ajax.php
+++ b/includes/Ajax/Frontend_Form_Ajax.php
@@ -183,18 +183,25 @@ class Frontend_Form_Ajax {
         // site-wide guest nonce can be replayed against a subscription-gated form to
         // create a post with no order and no pending-payment status.
         //
-        // A draft-backed submission still counts as new: it carries a post_id but sends
-        // wpuf_form_status "new" (same signal the update logic honours below), so key the
-        // gate on both so a replayed draft id cannot skip it.
-        $wpuf_form_status    = isset( $_POST['wpuf_form_status'] ) ? sanitize_text_field( wp_unslash( $_POST['wpuf_form_status'] ) ) : '';
-        $is_new_submission   = ! isset( $_POST['post_id'] ) || 'new' === $wpuf_form_status;
+        // Whether this is a new submission is decided from server state, never from a
+        // client-supplied field. Keying it on the request shape let a caller carry a
+        // post_id and omit wpuf_form_status to have the request treated as an edit, which
+        // skipped the gate entirely while the update branch still published the post.
+        //
+        // A draft that has not been submitted yet still counts as new: draft_post() flags
+        // it with _wpuf_draft_pending and that flag is cleared once the submission goes
+        // through, so finishing a draft is gated exactly once. Posts without the flag are
+        // genuine edits (including everything created before this flag existed) and are
+        // not re-gated, matching [wpuf_edit], which the renderer never gates.
+        $posted_post_id    = isset( $_POST['post_id'] ) ? absint( wp_unslash( $_POST['post_id'] ) ) : 0;
+        $is_new_submission = ! $posted_post_id || (bool) get_post_meta( $posted_post_id, '_wpuf_draft_pending', true );
 
         if ( $is_new_submission ) {
             [ $user_can_post, $submission_info ] = $form->is_submission_open( $form, $this->form_settings );
             $user_can_post                       = apply_filters( 'wpuf_can_post', $user_can_post, $form_id, $this->form_settings );
             $submission_info                     = apply_filters( 'wpuf_addpost_notice', $submission_info, $form_id, $this->form_settings );
 
-            if ( 'yes' !== $user_can_post ) {
+            if ( ! wpuf_is_option_on( $user_can_post ) ) {
                 wpuf()->ajax->send_error(
                     ! empty( $submission_info )
                         ? $submission_info
@@ -407,6 +414,13 @@ class Frontend_Form_Ajax {
             $this->update_post_meta( $meta_vars, $post_id );
             // set the post form_id for later usage
             update_post_meta( $post_id, self::$config_id, $form_id );
+
+            // The submission went through, so the post is no longer an unsubmitted draft.
+            // Clearing the flag means later edits are treated as edits and are not gated
+            // again, which keeps someone whose pack has since expired able to edit their
+            // own content.
+            delete_post_meta( $post_id, '_wpuf_draft_pending' );
+
             // if user has a subscription pack
             $this->wpuf_user_subscription_pack( $this->form_settings, $post_id );
             // set the post form_id for later usage

--- a/includes/Frontend/Frontend_Form.php
+++ b/includes/Frontend/Frontend_Form.php
@@ -203,6 +203,31 @@ class Frontend_Form extends Frontend_Render_Form {
             wp_send_json_error( [ 'message' => __( 'You must be logged in to save drafts.', 'wp-user-frontend' ) ] );
         }
 
+        // Saving a new draft is part of the add-post flow, so it has to pass the same
+        // submission gate the renderer applies before it will show the form at all
+        // (Frontend_Form::add_post_shortcode()). Without this, a subscription-gated form
+        // could be driven through the draft endpoint to create a post that never passed
+        // the gate, which submit_post() would then finish.
+        //
+        // Editing an existing draft is deliberately not re-gated: [wpuf_edit] is not
+        // gated either, so re-checking here would stop someone whose pack has since
+        // expired from editing content they already own.
+        if ( ! isset( $_POST['post_id'] ) ) {
+            [ $user_can_post, $submission_info ] = $form->is_submission_open( $form, $this->form_settings );
+            $user_can_post                       = apply_filters( 'wpuf_can_post', $user_can_post, $form_id, $this->form_settings );
+            $submission_info                     = apply_filters( 'wpuf_addpost_notice', $submission_info, $form_id, $this->form_settings );
+
+            if ( ! wpuf_is_option_on( $user_can_post ) ) {
+                wp_send_json_error(
+                    [
+                        'message' => ! empty( $submission_info )
+                            ? $submission_info
+                            : __( 'You are not allowed to submit to this form.', 'wp-user-frontend' ),
+                    ]
+                );
+            }
+        }
+
         [ $post_vars, $taxonomy_vars, $meta_vars ] = $this->get_input_fields( $this->form_fields );
 
         $entry_fields = $form->prepare_entries();
@@ -288,6 +313,13 @@ class Frontend_Form extends Frontend_Render_Form {
 
             // set the post form_id for later usage
             update_post_meta( $post_id, self::$config_id, $form_id );
+
+            // Mark the draft as still awaiting submission. submit_post() reads this to tell
+            // a draft being finished (which must pass the submission gate) apart from an
+            // edit of a post that was already submitted (which must not be re-gated), so
+            // that it never has to trust a client-supplied "is this new" field. Posts that
+            // predate this meta simply have no flag and are treated as edits, as before.
+            update_post_meta( $post_id, '_wpuf_draft_pending', 1 );
 
             // save post formats if have any
             if ( isset( $this->form_settings['post_format'] ) && $this->form_settings['post_format'] !== '0' ) {

--- a/includes/Frontend/Registration.php
+++ b/includes/Frontend/Registration.php
@@ -153,6 +153,50 @@ class Registration {
     }
 
     /**
+     * Whether a role may be assigned by frontend registration
+     *
+     * The role a form offers is configurable — sites legitimately register
+     * contributors, authors, editors and marketplace roles such as Dokan's or
+     * WooCommerce's shop_manager — so this is deliberately not an allow-list of
+     * role names, which would break those installs. It only refuses roles that
+     * could take the site over, whatever they are named.
+     *
+     * @since WPUF_SINCE
+     *
+     * @param string $role Role slug decoded from the submitted registration form.
+     *
+     * @return bool
+     */
+    protected function is_role_allowed_for_registration( $role ) {
+        if ( 'administrator' === $role ) {
+            return false;
+        }
+
+        $role_object = get_role( $role );
+
+        if ( ! $role_object ) {
+            return false;
+        }
+
+        // Capabilities that amount to control of the site. A role holding any of them is
+        // never handed out by a public registration form, even if it is what the form was
+        // configured with. shop_manager, vendor/seller and the standard author roles hold
+        // none of these, so marketplace and editorial setups are unaffected.
+        $site_control_caps = apply_filters(
+            'wpuf_registration_forbidden_capabilities',
+            [ 'manage_options', 'install_plugins', 'edit_plugins', 'edit_themes', 'edit_files' ]
+        );
+
+        foreach ( $site_control_caps as $capability ) {
+            if ( ! empty( $role_object->capabilities[ $capability ] ) ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Process registration form
      *
      * @return void
@@ -164,6 +208,23 @@ class Registration {
             $nonce = isset( $_POST['_wpnonce'] ) ? sanitize_key( wp_unslash( $_POST['_wpnonce'] ) ) : '';
 
             if ( ! wp_verify_nonce( $nonce, 'wpuf_registration_action' ) ) {
+                return;
+            }
+
+            // The registration form only ever renders for logged-out visitors, so a
+            // request arriving with an authenticated session did not come from it.
+            //
+            // This guard is what actually stops the reported session fixation: the nonce
+            // cannot, because wp_nonce_field() on a logged-out-only template mints it at
+            // user id 0 with an empty session token, so every anonymous visitor is served
+            // the same value and it stays valid for around a day. Anyone can fetch the
+            // page once and embed that value in a cross-site form. Without this check the
+            // handler runs on init for a logged-in victim, and the autologin below then
+            // clears their session and hands their browser a cookie for the account it
+            // just created.
+            //
+            // Reported by Yaswanth Reddy Sunkara (WPScan).
+            if ( is_user_logged_in() ) {
                 return;
             }
 
@@ -279,9 +340,9 @@ class Registration {
             $userdata['user_email'] = $reg_email;
             $userdata['user_pass']  = $pwd1;
             if ( get_role( $dec_role ) ) {
-                $userdata['role'] = empty( $dec_role ) || 'administrator' === $dec_role ? get_option(
-                    'default_role'
-                ) : $dec_role;
+                $userdata['role'] = empty( $dec_role ) || ! $this->is_role_allowed_for_registration( $dec_role )
+                    ? get_option( 'default_role' )
+                    : $dec_role;
             }
             $user = wp_insert_user( $userdata );
             if ( is_wp_error( $user ) ) {

--- a/includes/Frontend/Registration.php
+++ b/includes/Frontend/Registration.php
@@ -178,14 +178,39 @@ class Registration {
             return false;
         }
 
-        // Capabilities that amount to control of the site. A role holding any of them is
-        // never handed out by a public registration form, even if it is what the form was
-        // configured with. shop_manager, vendor/seller and the standard author roles hold
-        // none of these, so marketplace and editorial setups are unaffected.
+        // Capabilities that amount to control of the site: running code on it (plugin,
+        // theme and core install/update/edit), changing its settings, or promoting
+        // yourself. A role holding any of them is never handed out by a public
+        // registration form, whatever the form was configured with.
+        //
+        // Deliberately *not* listed: unfiltered_html, which the stock editor role holds,
+        // and edit_users, which some marketplace plugins grant to store-manager roles.
+        // Including either would refuse roles sites legitimately register into. Verified
+        // against a WooCommerce + Dokan install: no non-administrator role holds any
+        // capability in this list.
+        $default_site_control_caps = [
+            'manage_options',
+            'activate_plugins',
+            'install_plugins',
+            'update_plugins',
+            'edit_plugins',
+            'edit_themes',
+            'update_core',
+            'edit_files',
+            'promote_users',
+            'manage_network',
+        ];
+
         $site_control_caps = apply_filters(
             'wpuf_registration_forbidden_capabilities',
-            [ 'manage_options', 'install_plugins', 'edit_plugins', 'edit_themes', 'edit_files' ]
+            $default_site_control_caps
         );
+
+        // A third-party filter returning a non-array must not fatal here, and returning
+        // empty must not silently turn the check off.
+        $site_control_caps = ! empty( $site_control_caps ) && is_array( $site_control_caps )
+            ? $site_control_caps
+            : $default_site_control_caps;
 
         foreach ( $site_control_caps as $capability ) {
             if ( ! empty( $role_object->capabilities[ $capability ] ) ) {


### PR DESCRIPTION
Closes weDevsOfficial/wpuf-pro#1688

Follow-up to the researchers re-testing our 4.3.11 build. I verified every one of their claims against the code first — all four are accurate. This PR fixes the three that are still open in code; the fourth (CVE-2026-75823/75824) was already fixed in `dc3ac019` but **missed the 4.3.11 tag by 40 minutes**, so it just needs to ship.

## 1. CVE-2026-17563 — subscription gate bypassed through the draft path
*Reported by Charles Vosburgh*

The 4.3.11 gate keyed on the **shape of the request**:

```php
$is_new_submission = ! isset( $_POST['post_id'] ) || 'new' === $wpuf_form_status;
```

so carrying a `post_id` and omitting `wpuf_form_status` made the handler treat a brand-new submission as an edit and skip the gate — while the update branch still published the post from the form's `edit_post_status`. `draft_post()` had no gate at all, which is where the usable `post_id` came from.

**Fix**
- `draft_post()` runs the same `is_submission_open()` / `wpuf_can_post` gate the renderer applies in `add_post_shortcode()` — **for new drafts only**.
- `submit_post()` decides new-vs-edit from **server state**: `draft_post()` flags a draft `_wpuf_draft_pending`, `submit_post()` clears it once the submission completes.

## 2. CVE-2026-17564 — registration session fixation
*Reported by Yaswanth Reddy Sunkara*

Their diagnosis is the important part, and it is right: **the nonce cannot authenticate this request.** `wp_nonce_field()` on a template that only renders for logged-out visitors mints the nonce at user id 0 with an empty session token, so every anonymous visitor is served the same value and it stays valid for roughly a day. Fetch the page once with no cookies and it can be replayed cross-site. Branching on `wp_verify_nonce()` in 4.3.11 was the right change but does not close this.

**Fix:** `process_registration()` returns early when `is_user_logged_in()`. The registration form only ever renders logged-out, so an authenticated request did not come from it — and this is what actually stops the attack, because the autologin below can no longer clear a victim session and re-issue it for the account it just created.

Their other finding here is confirmed fixed: `wp_safe_redirect()` holds against protocol-relative hosts, embedded authorities and backslash-mangled schemes.

## 3. CVE-2026-75823 — role tampering hardening
*Reported by Murad Akhmedov*

`dc3ac019` (already on develop) authenticates the encrypted role blob, which stops tampering. This adds the defence-in-depth they asked for: assignment now refuses any role holding **site-control capabilities**, instead of only the literal `administrator` slug.

Deliberately a **capability check, not a role allow-list** — an allow-list would break every marketplace install.

## Preserving existing behaviour

This is the part I was most careful about; all three guards are additive and none changes a setting's meaning.

**Role matrix** — verified against every role registered on a Dokan + WooCommerce install:

| role | assignable |
|---|---|
| `administrator` | **no** |
| `editor`, `author`, `contributor`, `subscriber` | yes |
| `shop_manager`, `shop_vendor`, `shop_worker`, `shop_accountant`, `customer` | yes |
| `vendor`, `seller`, `pending_vendor` (Dokan) | yes |
| unknown / non-existent role | no (falls back to `default_role`) |

Filterable via `wpuf_registration_forbidden_capabilities`.

**Draft matrix** — the gate must never catch a genuine edit:

| case | gated |
|---|---|
| brand-new submission (no `post_id`) | yes |
| unsubmitted draft (`_wpuf_draft_pending`) | yes |
| post that already completed a submission | **no** |
| legacy post/draft created before this flag existed | **no** |
| the same draft, after its submission completes | **no** |

So a user whose pack has expired can still edit content they already own, and existing sites see no change on upgrade — posts without the flag are treated as edits exactly as before. Editing an existing draft is not re-gated either, matching `[wpuf_edit]`, which the renderer never gates.

**Helper choice:** `wpuf_is_option_on()` for the submission verdict rather than the literal `'yes' !==` comparison. Both producers — `Form::is_submission_open()` and the only `wpuf_can_post` filter (`Subscription::force_pack_permission`) — return strictly `yes`/`no`. `wpuf_is_checkbox_or_toggle_on()` would also accept `'1'` and `'true'`, which nothing emits for this value and which a security gate should not widen to accept; that helper stays correct for real toggle settings.

## Verification

- `php -l` clean on **7.4 and 8.5** for all three files. PHPCS: 0 errors on the changed lines.
- Role matrix and draft matrix above both executed against a live install (results as tabled).
- No hook, filter, template path or public method signature changed. New meta `_wpuf_draft_pending` is internal and self-clearing.

**End-to-end, in a real browser (Playwright against a fresh wp-env, free + pro on this branch):**

| step | result |
|---|---|
| Logged-out visitor registers through the form | account created, "Registration successful" — **legit path unaffected** |
| Anonymous nonce lifted with a cookie-less `fetch('/registration/')` | returned a valid nonce — confirms the researcher's point that the nonce authenticates nothing |
| Same registration POST replayed from a **logged-in** victim session | **no account created — guard holds** (the account-creation half, and therefore the session swap, never happens) |
| Re-register an already-registered email (logged out) | no duplicate, user count unchanged |
| WPUF login | works; login page renders the logged-in state |

**Confirmed not in scope of the guard:** profile editing runs through `Frontend_Account::update_profile()`, a different handler that `process_registration()` never touches, so a logged-in user editing their profile is unaffected.

Test accounts created during verification were removed afterwards.

## Security self-review of this diff

Checked that the fixes do not introduce anything new:

| check | result |
|---|---|
| Can a user set/clear `_wpuf_draft_pending` to skip the gate? | **No.** Meta keys come from the form's field definitions (`prepare_meta_fields()` keys off `$value['name']`), which the admin controls — a submitter cannot choose the key. |
| Is the new meta exposed? | Underscore-prefixed, so protected — not REST-exposed, not shown in custom fields UI. Self-clearing once the submission completes. |
| Input handling | `absint( wp_unslash( $_POST['post_id'] ) )`. |
| Guard ordering in `draft_post()` | `check_ajax_referer()` → logged-in check → **then** the gate, so it cannot be used as an unauthenticated probe. |
| Filter safety | `wpuf_registration_forbidden_capabilities` is cast and empty-checked, so a third-party filter returning a non-array cannot fatal, and returning empty cannot silently disable the check. |
| Fail-closed | Unknown/non-existent role → `default_role`; empty or `no` verdict → blocked. |
| Output / SQL | No new output and no SQL; the gate message goes back through the same `send_error()` path the existing gate already used. |
| Contracts | No hook, filter, template path or public method signature changed. |

**One residual, unchanged from before this PR and worth stating plainly:** a user re-submitting a post they already own to a *different* form is still treated as an edit and is not gated. That requires owning the post, creates no content they could not already create, and behaves exactly as 4.3.11 did — but if we want to close it too, the fix is to refuse a `post_id` whose recorded `wpuf_form_id` is not the form being submitted to. Happy to add that here if you would rather not leave it.

## Still to do (tracked in wpuf-pro#1688)

- Ship `dc3ac019` in the next release, with the `users_can_register` behaviour change called out in the changelog — sites that deliberately disable WP registration so WPUF is the only signup path will be affected, and it is worth deciding whether they get a supported filter.
- Manual regression pass before release: pack holder posts + saves drafts, expired-pack user edits an existing post, guest posting, Dokan/WC Vendors registration, custom-role registration, autologin on and off, multisite.
- Offer the researchers a pre-release build — they asked for one.
