### PR TITLE
fix(security): Patchstack 4.3.11 — file-deletion IDOR, guest pay bypass, PayPal lifecycle abuse

### DIFF
--- a/Lib/Gateway/Paypal.php
+++ b/Lib/Gateway/Paypal.php
@@ -225,6 +225,18 @@ class Paypal {
                     }
                     break;
 
+                // A subscription that PayPal expires or suspends is no longer
+                // paying. Previously only an explicit CANCELLED event revoked the
+                // local pack, so these states left the entitlement active. Revoke
+                // it here too; a later ACTIVATED / PAYMENT.SALE.COMPLETED re-grants
+                // it if the buyer reactivates.
+                case 'BILLING.SUBSCRIPTION.EXPIRED':
+                case 'BILLING.SUBSCRIPTION.SUSPENDED':
+                    if ( isset( $event['resource'] ) ) {
+                        $this->handle_subscription_revoked( $event['resource'], $event['event_type'] );
+                    }
+                    break;
+
                 case 'BILLING.SUBSCRIPTION.CREATED':
                     if ( isset( $event['resource'] ) ) {
                         $this->handle_subscription_created( $event['resource'] );
@@ -672,6 +684,19 @@ class Paypal {
                 throw new \Exception( 'Invalid custom data in subscription' );
             }
 
+            // BILLING.SUBSCRIPTION.CREATED only means the merchant created the
+            // subscription. Until the buyer approves it, PayPal keeps it in
+            // APPROVAL_PENDING with no payment, so an attacker can start checkout,
+            // abandon the approval page and still receive this signed event.
+            // Granting the pack here handed out the entitlement for free. Only act
+            // once PayPal reports the subscription genuinely ACTIVE; every other
+            // state waits for ACTIVATED / PAYMENT.SALE.COMPLETED to grant it.
+            $paypal_status = isset( $subscription['status'] ) ? strtoupper( $subscription['status'] ) : '';
+
+            if ( 'ACTIVE' !== $paypal_status ) {
+                return;
+            }
+
             $user_id = $custom_data['user_id'];
             $subscription_id = $subscription['id']; // This is the PayPal subscription ID
             $trial_period_days = isset( $custom_data['trial_period_days'] ) ? $custom_data['trial_period_days'] : 0;
@@ -700,10 +725,21 @@ class Paypal {
             $period = isset( $pack_meta['_cycle_period'] ) ? $pack_meta['_cycle_period'] : 'month';
             $interval = isset( $pack_meta['_billing_cycle_number'] ) ? intval( $pack_meta['_billing_cycle_number'] ) : 1;
 
+            // WPUF stores per-post-type quotas under _post_type_name (+ any
+            // additional_cpt_options), not _post_types. Reading the wrong key left
+            // this empty and fell through to the unlimited (-1) default below, so a
+            // limited pack silently became unlimited. Read the real keys, matching
+            // User_Subscription::add_pack().
+            $pack_post_types = isset( $pack_meta['_post_type_name'] ) && is_array( $pack_meta['_post_type_name'] )
+                ? $pack_meta['_post_type_name'] : [];
+            $pack_additional_cpt = isset( $pack_meta['additional_cpt_options'] ) && is_array( $pack_meta['additional_cpt_options'] )
+                ? $pack_meta['additional_cpt_options'] : [];
+            $pack_quota = array_merge( $pack_post_types, $pack_additional_cpt );
+
             // Create subscription data structure with all necessary meta
             $subscription_data = [
                 'pack_id' => $custom_data['item_number'],
-                'posts' => isset( $pack_meta['_post_types'] ) ? $pack_meta['_post_types'] : [],
+                'posts' => $pack_quota,
                 'total_feature_item' => isset( $pack_meta['_total_feature_item'] ) ? $pack_meta['_total_feature_item'] : '-1',
                 'remove_feature_item' => isset( $pack_meta['_remove_feature_item'] ) ? $pack_meta['_remove_feature_item'] : '-1',
                 'status' => 'completed',
@@ -1807,6 +1843,59 @@ class Paypal {
     }
 
     /**
+     * Whether a cached PayPal plan still matches the pack's current terms
+     *
+     * Compares the plan's REGULAR billing cycle price, currency and
+     * period/interval against the pack settings the current checkout is using.
+     *
+     * @since WPUF_SINCE
+     *
+     * @param array      $plan     Plan representation returned by PayPal.
+     * @param int|float  $amount   Current pack amount.
+     * @param string     $period   Current billing period (day|week|month|year).
+     * @param int        $interval Current billing interval count.
+     *
+     * @return bool
+     */
+    private function plan_matches_pack( $plan, $amount, $period, $interval ) {
+        if ( empty( $plan['billing_cycles'] ) || ! is_array( $plan['billing_cycles'] ) ) {
+            return false;
+        }
+
+        $regular = null;
+
+        foreach ( $plan['billing_cycles'] as $cycle ) {
+            if ( isset( $cycle['tenure_type'] ) && 'REGULAR' === $cycle['tenure_type'] ) {
+                $regular = $cycle;
+                break;
+            }
+        }
+
+        if ( null === $regular ) {
+            return false;
+        }
+
+        $expected_currency = wpuf_get_option( 'currency', 'wpuf_payment', 'USD' );
+        $expected_value    = number_format( (float) $amount, 2, '.', '' );
+        $expected_unit     = strtoupper( (string) $period );
+        $expected_count    = max( 1, intval( $interval ) );
+
+        $plan_value    = isset( $regular['pricing_scheme']['fixed_price']['value'] )
+            ? number_format( (float) $regular['pricing_scheme']['fixed_price']['value'], 2, '.', '' ) : '';
+        $plan_currency = isset( $regular['pricing_scheme']['fixed_price']['currency_code'] )
+            ? $regular['pricing_scheme']['fixed_price']['currency_code'] : '';
+        $plan_unit     = isset( $regular['frequency']['interval_unit'] )
+            ? strtoupper( $regular['frequency']['interval_unit'] ) : '';
+        $plan_count    = isset( $regular['frequency']['interval_count'] )
+            ? intval( $regular['frequency']['interval_count'] ) : 0;
+
+        return $plan_value === $expected_value
+            && $plan_currency === $expected_currency
+            && $plan_unit === $expected_unit
+            && $plan_count === $expected_count;
+    }
+
+    /**
      * Get or create a PayPal subscription plan
      */
     private function get_or_create_plan( $pack, $amount, $period, $interval, $trial_period_days = 0 ) {
@@ -1837,7 +1926,16 @@ class Paypal {
 
                 if ( ! is_wp_error( $response ) ) {
                     $body = json_decode( wp_remote_retrieve_body( $response ), true );
-                    if ( isset( $body['status'] ) && 'ACTIVE' === $body['status'] ) {
+
+                    // Reuse the cached plan only when it still matches the pack's
+                    // current price, currency and billing period/interval. The id
+                    // is cached pack-wide and never invalidated on a pack edit,
+                    // currency change or a first buyer's coupon, so a later buyer
+                    // could otherwise be billed an old/discounted amount on a stale
+                    // ACTIVE plan. On any mismatch fall through and mint a fresh
+                    // plan bound to the current settings.
+                    if ( isset( $body['status'] ) && 'ACTIVE' === $body['status']
+                        && $this->plan_matches_pack( $body, $amount, $period, $interval ) ) {
                         return $plan_id;
                     }
                 }
@@ -2268,6 +2366,78 @@ class Paypal {
 
             // Trigger action for other plugins
             do_action( 'wpuf_paypal_subscription_cancelled', $user_id, $subscription_id );
+        } catch ( \Exception $e ) {
+            throw $e;
+        }
+    }
+
+    /**
+     * Revoke a subscription that PayPal expired or suspended
+     *
+     * Mirrors the CANCELLED path: the local pack is reduced to a terminal record
+     * with no pack_id, so the subscription-based posting gate treats the user as
+     * having no active pack. A later reactivation re-grants it through the
+     * ACTIVATED / PAYMENT.SALE.COMPLETED handlers.
+     *
+     * @since WPUF_SINCE
+     *
+     * @param array  $subscription PayPal subscription resource.
+     * @param string $event_type   Originating webhook event type.
+     *
+     * @return void
+     */
+    private function handle_subscription_revoked( $subscription, $event_type ) {
+        try {
+            $custom_data = [];
+
+            if ( isset( $subscription['custom_id'] ) ) {
+                $custom_data = json_decode( $subscription['custom_id'], true );
+            }
+
+            if ( ! $custom_data || ! isset( $custom_data['user_id'] ) ) {
+                throw new \Exception( 'Invalid custom data in subscription' );
+            }
+
+            $user_id         = $custom_data['user_id'];
+            $subscription_id = isset( $subscription['id'] ) ? $subscription['id'] : '';
+            $status          = 'BILLING.SUBSCRIPTION.EXPIRED' === $event_type ? 'expired' : 'suspended';
+
+            update_user_meta(
+                $user_id,
+                '_wpuf_subscription_pack',
+                [
+                    'profile_id' => $subscription_id,
+                    'status'     => $status,
+                    'updated'    => gmdate( 'Y-m-d H:i:s' ),
+                ]
+            );
+
+            global $wpdb;
+            $wpdb->update(
+                $wpdb->prefix . 'wpuf_subscribers',
+                [
+                    'subscribtion_status' => $status,
+                    'expire'              => gmdate( 'd-m-Y' ),
+                ],
+                [
+                    'user_id'        => $user_id,
+                    'transaction_id' => $subscription_id,
+                    'gateway'        => 'PayPal',
+                ],
+                [ '%s', '%s' ],
+                [ '%d', '%s', '%s' ]
+            );
+
+            /**
+             * Fires after a PayPal subscription is revoked on expiry or suspension.
+             *
+             * @since WPUF_SINCE
+             *
+             * @param int    $user_id
+             * @param string $subscription_id
+             * @param string $event_type
+             */
+            do_action( 'wpuf_paypal_subscription_revoked', $user_id, $subscription_id, $event_type );
         } catch ( \Exception $e ) {
             throw $e;
         }

--- a/Lib/Gateway/Paypal.php
+++ b/Lib/Gateway/Paypal.php
@@ -354,26 +354,23 @@ class Paypal {
                     if ( isset( $custom_data['subtotal'] ) && isset( $custom_data['tax'] ) ) {
                         $subtotal = floatval( $custom_data['subtotal'] );
                         $tax = floatval( $custom_data['tax'] );
-                    } else {
-                        // Recalculate: assume tax is correct, adjust subtotal
-                        // Or if subtotal seems wrong (equals total), calculate from total - tax
-                        if ( abs( $subtotal - $total_amount ) < 0.01 && $tax > 0 ) {
-                            // Subtotal equals total, which is wrong - recalculate
-                            $subtotal = $total_amount - $tax;
-                        } elseif ( $tax > 0 && $subtotal > 0 ) {
-                            // Both exist but don't add up - trust the total and recalculate
-                            $subtotal = $total_amount - $tax;
-                        }
+                        // Recalculate: assume tax is correct, adjust subtotal.
+                        // Or if subtotal seems wrong (equals total), calculate from total - tax.
+                    } elseif ( abs( $subtotal - $total_amount ) < 0.01 && $tax > 0 ) {
+                        // Subtotal equals total, which is wrong - recalculate
+                        $subtotal = $total_amount - $tax;
+                    } elseif ( $tax > 0 && $subtotal > 0 ) {
+                        // Both exist but don't add up - trust the total and recalculate
+                        $subtotal = $total_amount - $tax;
                     }
                 }
             } elseif ( isset( $custom_data['subtotal'] ) && isset( $custom_data['tax'] ) ) {
                 // Fallback: Use custom_id data if breakdown not available
                 $subtotal = floatval( $custom_data['subtotal'] );
                 $tax = floatval( $custom_data['tax'] );
-            } else {
-                // If no breakdown and no custom_data, try to recalculate from subscription pack
-                // This ensures accurate tax calculation based on current settings
-                if ( 'pack' === $custom_data['type'] && ! empty( $custom_data['item_number'] ) ) {
+                // If no breakdown and no custom_data, try to recalculate from subscription pack.
+                // This ensures accurate tax calculation based on current settings.
+            } elseif ( 'pack' === $custom_data['type'] && ! empty( $custom_data['item_number'] ) ) {
                     /**
                      * Filter: wpuf_recalculate_tax_from_pack
                      *
@@ -399,10 +396,9 @@ class Paypal {
                         $custom_data['type']
                     );
 
-                    if ( $recalculated && is_array( $recalculated ) ) {
-                        $subtotal = isset( $recalculated['subtotal'] ) ? floatval( $recalculated['subtotal'] ) : $subtotal;
-                        $tax = isset( $recalculated['tax'] ) ? floatval( $recalculated['tax'] ) : $tax;
-                    }
+                if ( $recalculated && is_array( $recalculated ) ) {
+                    $subtotal = isset( $recalculated['subtotal'] ) ? floatval( $recalculated['subtotal'] ) : $subtotal;
+                    $tax = isset( $recalculated['tax'] ) ? floatval( $recalculated['tax'] ) : $tax;
                 }
             }
 
@@ -782,7 +778,6 @@ class Paypal {
             if ( $is_in_trial ) {
                 $this->create_trial_payment_record( $user_id, $custom_data['item_number'], $subscription_id );
             }
-
         } catch ( \Exception $e ) {
             throw $e;
         }
@@ -1093,26 +1088,23 @@ class Paypal {
                     if ( isset( $custom_data['subtotal'] ) && isset( $custom_data['tax'] ) ) {
                         $subtotal = floatval( $custom_data['subtotal'] );
                         $tax = floatval( $custom_data['tax'] );
-                    } else {
-                        // Recalculate: assume tax is correct, adjust subtotal
-                        // Or if subtotal seems wrong (equals total), calculate from total - tax
-                        if ( abs( $subtotal - $total_amount ) < 0.01 && $tax > 0 ) {
-                            // Subtotal equals total, which is wrong - recalculate
-                            $subtotal = $total_amount - $tax;
-                        } elseif ( $tax > 0 && $subtotal > 0 ) {
-                            // Both exist but don't add up - trust the total and recalculate
-                            $subtotal = $total_amount - $tax;
-                        }
+                        // Recalculate: assume tax is correct, adjust subtotal.
+                        // Or if subtotal seems wrong (equals total), calculate from total - tax.
+                    } elseif ( abs( $subtotal - $total_amount ) < 0.01 && $tax > 0 ) {
+                        // Subtotal equals total, which is wrong - recalculate
+                        $subtotal = $total_amount - $tax;
+                    } elseif ( $tax > 0 && $subtotal > 0 ) {
+                        // Both exist but don't add up - trust the total and recalculate
+                        $subtotal = $total_amount - $tax;
                     }
                 }
             } elseif ( isset( $custom_data['subtotal'] ) && isset( $custom_data['tax'] ) ) {
                 // Fallback: Use custom_id data if breakdown not available
                 $subtotal = floatval( $custom_data['subtotal'] );
                 $tax = floatval( $custom_data['tax'] );
-            } else {
-                // Fallback: Try to recalculate from subscription pack
-                // This ensures accurate tax calculation based on current settings
-                if ( $pack_id > 0 ) {
+                // Fallback: Try to recalculate from subscription pack.
+                // This ensures accurate tax calculation based on current settings.
+            } elseif ( $pack_id > 0 ) {
                     /**
                      * Filter: wpuf_recalculate_tax_from_pack
                      *
@@ -1138,26 +1130,25 @@ class Paypal {
                         'pack'
                     );
 
-                    if ( $recalculated && is_array( $recalculated ) ) {
-                        $subtotal = isset( $recalculated['subtotal'] ) ? floatval( $recalculated['subtotal'] ) : $subtotal;
-                        $tax = isset( $recalculated['tax'] ) ? floatval( $recalculated['tax'] ) : $tax;
-                    } else {
-                        // If recalculation failed, try subscription plan tax percentage
-                        $tax_percentage = $this->get_subscription_tax_percentage( $subscription_id );
-                        if ( $tax_percentage > 0 ) {
-                            // Reverse calculate: subtotal = total / (1 + tax_percentage/100)
-                            $subtotal = $total_amount / ( 1 + ( $tax_percentage / 100 ) );
-                            $tax = $total_amount - $subtotal;
-                        }
-                    }
+                if ( $recalculated && is_array( $recalculated ) ) {
+                    $subtotal = isset( $recalculated['subtotal'] ) ? floatval( $recalculated['subtotal'] ) : $subtotal;
+                    $tax = isset( $recalculated['tax'] ) ? floatval( $recalculated['tax'] ) : $tax;
                 } else {
-                    // If no pack_id, try subscription plan tax percentage
+                    // If recalculation failed, try subscription plan tax percentage
                     $tax_percentage = $this->get_subscription_tax_percentage( $subscription_id );
                     if ( $tax_percentage > 0 ) {
                         // Reverse calculate: subtotal = total / (1 + tax_percentage/100)
                         $subtotal = $total_amount / ( 1 + ( $tax_percentage / 100 ) );
                         $tax = $total_amount - $subtotal;
                     }
+                }
+            } else {
+                // If no pack_id, try subscription plan tax percentage
+                $tax_percentage = $this->get_subscription_tax_percentage( $subscription_id );
+                if ( $tax_percentage > 0 ) {
+                    // Reverse calculate: subtotal = total / (1 + tax_percentage/100)
+                    $subtotal = $total_amount / ( 1 + ( $tax_percentage / 100 ) );
+                    $tax = $total_amount - $subtotal;
                 }
             }
 
@@ -1733,7 +1724,7 @@ class Paypal {
                 // Add PayPal to allowed hosts just before redirect
                 add_filter(
                     'allowed_redirect_hosts',
-                    function( $hosts ) {
+                    function ( $hosts ) {
                         return array_merge( $hosts, $this->get_paypal_allowed_hosts() );
                     },
                     10,
@@ -1827,7 +1818,7 @@ class Paypal {
                 // Add PayPal to allowed hosts just before redirect
                 add_filter(
                     'allowed_redirect_hosts',
-                    function( $hosts ) {
+                    function ( $hosts ) {
                         return array_merge( $hosts, $this->get_paypal_allowed_hosts() );
                     },
                     10,
@@ -2024,7 +2015,6 @@ class Paypal {
             $response_code = wp_remote_retrieve_response_code( $response );
             $body = json_decode( wp_remote_retrieve_body( $response ), true );
 
-
             if ( ! isset( $body['id'] ) ) {
                 throw new \Exception( 'Invalid response from PayPal - no plan ID' );
             }
@@ -2156,7 +2146,6 @@ class Paypal {
 
             wp_safe_redirect( $success_url );
             exit;
-
         } catch ( \Exception $e ) {
             wp_safe_redirect( $this->get_error_page_url( $e->getMessage() ) );
             exit;
@@ -2270,9 +2259,11 @@ class Paypal {
         }
 
         // Check if this is a subscription return (has subscription_id parameter or type is pack with recurring)
+        $return_type  = isset( $_GET['type'] ) ? sanitize_text_field( wp_unslash( $_GET['type'] ) ) : '';
+        $return_token = isset( $_GET['token'] ) ? sanitize_text_field( wp_unslash( $_GET['token'] ) ) : '';
+
         $is_subscription_return = isset( $_GET['subscription_id'] ) || isset( $_GET['ba_token'] ) ||
-                                 ( isset( $_GET['type'] ) && $_GET['type'] === 'pack' &&
-                                   ( isset( $_GET['token'] ) && strpos( $_GET['token'], 'I-' ) === 0 ) );
+                                 ( 'pack' === $return_type && 0 === strpos( $return_token, 'I-' ) );
 
         // For subscription returns, nonce verification might fail due to PayPal's redirect process
         // So we'll be more lenient with subscription returns
@@ -2553,7 +2544,10 @@ class Paypal {
                 }
             }
         } catch ( \Exception $e ) {
-            throw new \Exception( 'Error handling subscription activation: ' . $e->getMessage(), 0, $e );
+            $message = 'Error handling subscription activation: ' . $e->getMessage();
+
+            // phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- $e is the chained previous exception, not output; the message is escaped above.
+            throw new \Exception( esc_html( $message ), 0, $e );
         }
     }
 
@@ -2591,7 +2585,10 @@ class Paypal {
                     return floatval( $subscription_details['plan']['taxes']['percentage'] );
                 }
             }
-        } catch ( \Exception $e ) {}
+        } catch ( \Exception $e ) {
+            // The tax percentage is optional; fall through to the default below.
+            unset( $e );
+        }
 
         return 0;
     }
@@ -2666,7 +2663,7 @@ class Paypal {
         // Add them to item_total
         $supported_keys = array_keys( $breakdown_map );
         foreach ( $breakdown as $key => $value ) {
-            if ( ! in_array( $key, $supported_keys ) && is_numeric( $value ) && $value > 0 ) {
+            if ( ! in_array( $key, $supported_keys, true ) && is_numeric( $value ) && $value > 0 ) {
                 // Add unsupported breakdown items to item_total
                 if ( ! isset( $paypal_breakdown['item_total'] ) ) {
                     $paypal_breakdown['item_total'] = [

--- a/includes/Ajax/Frontend_Form_Ajax.php
+++ b/includes/Ajax/Frontend_Form_Ajax.php
@@ -133,9 +133,12 @@ class Frontend_Form_Ajax {
             foreach ( $protected_shortcodes as $shortcode ) {
                 $search_for = '[' . $shortcode;
                 if ( strpos( $current_data, $search_for ) !== false ) {
-                    wpuf()->ajax->send_error( sprintf(
+                    wpuf()->ajax->send_error(
+                        sprintf(
                         // translators: %s is shortcode
-                        __( 'Using %s as shortcode is restricted', 'wp-user-frontend' ), $shortcode ) );
+                            __( 'Using %s as shortcode is restricted', 'wp-user-frontend' ), $shortcode
+                        )
+                    );
                 }
             }
         }
@@ -346,10 +349,8 @@ class Frontend_Form_Ajax {
             if ( 'pending' === get_post_meta( $post_id, '_wpuf_payment_status', true ) ) {
                 $postarr['post_status'] = 'pending';
             }
-        } else {
-            if ( isset( $this->form_settings['comment_status'] ) ) {
+        } elseif ( isset( $this->form_settings['comment_status'] ) ) {
                 $postarr['comment_status'] = $this->form_settings['comment_status'];
-            }
         }
 
         // check the form status, it might be already a draft
@@ -507,16 +508,14 @@ class Frontend_Form_Ajax {
             } else {
                 $redirect_to = get_permalink( $post_id );
             }
-        } else {
-            if ( $this->form_settings['redirect_to'] === 'page' ) {
+        } elseif ( $this->form_settings['redirect_to'] === 'page' ) {
                 $redirect_to = get_permalink( $this->form_settings['page_id'] );
-            } elseif ( $this->form_settings['redirect_to'] === 'url' ) {
-                $redirect_to = $this->form_settings['url'];
-            } elseif ( $this->form_settings['redirect_to'] === 'same' ) {
-                $show_message = true;
-            } else {
-                $redirect_to = get_permalink( $post_id );
-            }
+        } elseif ( $this->form_settings['redirect_to'] === 'url' ) {
+            $redirect_to = $this->form_settings['url'];
+        } elseif ( $this->form_settings['redirect_to'] === 'same' ) {
+            $show_message = true;
+        } else {
+            $redirect_to = get_permalink( $post_id );
         }
 
         if ( $charging_enabled === 'yes' && isset( $this->form_settings['payment_options'] )
@@ -583,15 +582,16 @@ class Frontend_Form_Ajax {
                 $to     = implode(
                     ',',
                     array_filter(
-                        array_map( static function ( $addr ) {
-                            $addr = trim( $addr );
-                            return is_email( $addr ) ? $addr : null;
-                        }, explode( ',', $to_raw ) )
+                        array_map(
+                            static function ( $addr ) {
+                                $addr = trim( $addr );
+                                return is_email( $addr ) ? $addr : null;
+                            }, explode( ',', $to_raw )
+                        )
                     )
                 );
-                if ( empty( $to ) ) {
-                    // Nothing valid to send to – skip mail sending
-                } else {
+                // Skip mail sending when there is no valid recipient.
+                if ( ! empty( $to ) ) {
                     $subject   = $this->prepare_mail_body( $edit_subject, $post_author, $post_id );
                     $subject   = wp_strip_all_tags( $subject );
                     $mail_body = get_formatted_mail_body( $mail_body, $subject );
@@ -613,15 +613,16 @@ class Frontend_Form_Ajax {
                 $to     = implode(
                     ',',
                     array_filter(
-                        array_map( static function ( $addr ) {
-                            $addr = trim( $addr );
-                            return is_email( $addr ) ? $addr : null;
-                        }, explode( ',', $to_raw ) )
+                        array_map(
+                            static function ( $addr ) {
+                                $addr = trim( $addr );
+                                return is_email( $addr ) ? $addr : null;
+                            }, explode( ',', $to_raw )
+                        )
                     )
                 );
-                if ( empty( $to ) ) {
-                    // Nothing valid to send to – skip mail sending
-                } else {
+                // Skip mail sending when there is no valid recipient.
+                if ( ! empty( $to ) ) {
                     $subject   = $this->prepare_mail_body( $new_notification['subject'], $post_author, $post_id );
                     $subject   = wp_strip_all_tags( $subject );
                     $mail_body = get_formatted_mail_body( $mail_body, $subject );
@@ -722,7 +723,7 @@ class Frontend_Form_Ajax {
                 $to      = isset( $notification_conf['to'] ) ? $notification_conf['to'] : '';
                 $subject = isset( $notification_conf['subject'] ) ? $notification_conf['subject'] : '';
 
-            // 2) Legacy flat flag: string 'on' at notification[type]
+                // 2) Legacy flat flag: string 'on' at notification[type]
             } elseif ( is_string( $notification_conf ) && wpuf_is_checkbox_or_toggle_on( $notification_conf ) ) {
                 $enabled = true;
                 $body    = isset( $this->form_settings['notification'][ $type . '_body' ] ) ? $this->form_settings['notification'][ $type . '_body' ] : '';
@@ -732,12 +733,12 @@ class Frontend_Form_Ajax {
         }
 
         // 3) Very old separate fields (only for edit notifications)
-        if ( ! $enabled && 'edit' === $type && ! empty( $this->form_settings['notification_' . $type ] )
-             && wpuf_is_checkbox_or_toggle_on( $this->form_settings['notification_' . $type ] ) ) {
+        if ( ! $enabled && 'edit' === $type && ! empty( $this->form_settings[ 'notification_' . $type ] )
+             && wpuf_is_checkbox_or_toggle_on( $this->form_settings[ 'notification_' . $type ] ) ) {
             $enabled = true;
-            $body    = isset( $this->form_settings['notification_' . $type . '_body' ] ) ? $this->form_settings['notification_' . $type . '_body' ] : '';
-            $to      = isset( $this->form_settings['notification_' . $type . '_to' ] ) ? $this->form_settings['notification_' . $type . '_to' ] : '';
-            $subject = isset( $this->form_settings['notification_' . $type . '_subject' ] ) ? $this->form_settings['notification_' . $type . '_subject' ] : '';
+            $body    = isset( $this->form_settings[ 'notification_' . $type . '_body' ] ) ? $this->form_settings[ 'notification_' . $type . '_body' ] : '';
+            $to      = isset( $this->form_settings[ 'notification_' . $type . '_to' ] ) ? $this->form_settings[ 'notification_' . $type . '_to' ] : '';
+            $subject = isset( $this->form_settings[ 'notification_' . $type . '_subject' ] ) ? $this->form_settings[ 'notification_' . $type . '_subject' ] : '';
         }
 
         return [
@@ -773,7 +774,7 @@ class Frontend_Form_Ajax {
         if ( ! is_user_logged_in() ) {
             if ( isset( $this->form_settings['post_permission'] ) && 'guest_post' === $this->form_settings['post_permission'] && ! empty( $this->form_settings['guest_details'] ) && wpuf_is_checkbox_or_toggle_on(
                 $this->form_settings['guest_details']
-            )) {
+            ) ) {
                 $guest_name = isset( $_POST['guest_name'] ) ? sanitize_text_field( wp_unslash( $_POST['guest_name'] ) ) : '';
                 $guest_email = isset( $_POST['guest_email'] ) ? sanitize_email(
                     wp_unslash( $_POST['guest_email'] )
@@ -1053,5 +1054,4 @@ class Frontend_Form_Ajax {
 
         return $url ? $url : $value;
     }
-
 }

--- a/includes/Ajax/Frontend_Form_Ajax.php
+++ b/includes/Ajax/Frontend_Form_Ajax.php
@@ -38,6 +38,16 @@ class Frontend_Form_Ajax {
         @header( 'Content-Type: application/json; charset=' . get_option( 'blog_charset' ) );
 
         $form_id               = isset( $_POST['form_id'] ) ? intval( wp_unslash( $_POST['form_id'] ) ) : 0;
+
+        // The nonce is action-wide, not bound to a form, so form_id is fully
+        // attacker-controlled. Pointing it at an ordinary post/page id yields a
+        // form with empty settings, which then defaults to publishing a `post`
+        // authored by the requester regardless of their capabilities. Only accept
+        // a real WPUF form id.
+        if ( ! $form_id || 'wpuf_forms' !== get_post_type( $form_id ) ) {
+            wpuf()->ajax->send_error( __( 'Invalid form.', 'wp-user-frontend' ) );
+        }
+
         $form                  = new Form( $form_id );
         $this->form_settings   = $form->get_settings();
         // Load notification settings and merge them with existing notification data
@@ -445,7 +455,12 @@ class Frontend_Form_Ajax {
                         $url           = str_replace( [ '"', "'", '\\' ], '', $url );
                         $attachment_id = wpuf_get_attachment_id_from_url( $url );
 
-                        if ( $attachment_id ) {
+                        // Only reparent an attachment the requester may actually
+                        // associate: one that already belongs to this post, or is
+                        // unattached AND owned by the requester. Without this a
+                        // crafted post_content <img> could reparent any Media
+                        // Library item (the first half of the file-deletion IDOR).
+                        if ( $attachment_id && self::is_attachment_associable( $attachment_id, $post_id ) ) {
                             wpuf_associate_attachment( $attachment_id, $post_id );
                         }
                     }
@@ -734,9 +749,22 @@ class Frontend_Form_Ajax {
     }
 
     public function wpuf_get_post_user() {
-        $nonce = isset( $_REQUEST['_wpnonce'] ) ? sanitize_key( wp_unslash( $_REQUEST['_wpnonce'] ) ) : '';
+        // submit_post() gates the request with check_ajax_referer( 'wpuf_form_add' ),
+        // which accepts the nonce in either _ajax_nonce or _wpnonce. Reading only
+        // _wpnonce here let an attacker move a valid nonce into _ajax_nonce: this
+        // check then failed on an empty value and returned null, and the caller
+        // persisted post_author = 0 for a logged-out request, minting the
+        // author-less post the email-verification publisher looks for. Verify the
+        // same nonce the referer check honoured.
+        $nonce = '';
 
-        if ( isset( $nonce ) && ! wp_verify_nonce( $nonce, 'wpuf_form_add' ) ) {
+        if ( isset( $_REQUEST['_wpnonce'] ) ) {
+            $nonce = sanitize_key( wp_unslash( $_REQUEST['_wpnonce'] ) );
+        } elseif ( isset( $_REQUEST['_ajax_nonce'] ) ) {
+            $nonce = sanitize_key( wp_unslash( $_REQUEST['_ajax_nonce'] ) );
+        }
+
+        if ( ! wp_verify_nonce( $nonce, 'wpuf_form_add' ) ) {
             return;
         }
 

--- a/includes/Frontend/Frontend_Form.php
+++ b/includes/Frontend/Frontend_Form.php
@@ -432,9 +432,26 @@ class Frontend_Form extends Frontend_Render_Form {
             wp_die( esc_html__( 'This post has already been published.', 'wp-user-frontend' ) );
         }
 
-        $form_settings  = wpuf_get_form_settings( $form_id );
+        // p_id and f_id are encrypted independently with the same primitive and
+        // are never bound to each other. Replaying the post-id token as f_id makes
+        // the charging decision run against a non-form object, whose empty settings
+        // read as uncharged and publish the post for free. Trust only the form id
+        // the post itself was submitted through, and refuse a f_id that does not
+        // match it, so the paywall is always evaluated against the real form.
+        $real_form_id = absint( get_post_meta( $post_id, self::$config_id, true ) );
+        $form_id      = absint( $form_id );
+
+        if ( ! $real_form_id || get_post_type( $real_form_id ) !== 'wpuf_forms' ) {
+            wp_die( esc_html__( 'Invalid post.', 'wp-user-frontend' ) );
+        }
+
+        if ( $form_id !== $real_form_id ) {
+            wp_die( esc_html__( 'This post cannot be published via email verification.', 'wp-user-frontend' ) );
+        }
+
+        $form_settings  = wpuf_get_form_settings( $real_form_id );
         $payment_status = new Subscription();
-        $form           = new Form( $form_id );
+        $form           = new Form( $real_form_id );
         $pay_per_post   = $form->is_enabled_pay_per_post();
         $force_pack     = $form->is_enabled_force_pack();
 

--- a/includes/Traits/FieldableTrait.php
+++ b/includes/Traits/FieldableTrait.php
@@ -554,7 +554,24 @@ trait FieldableTrait {
 
                 //if file numbers are greated than allowed number, prevent it from being uploaded
                 if ( $file_numbers >= $file_input['count'] ) {
-                    wp_delete_attachment( $attachment_id );
+                    // Only ever delete an over-limit file the requester actually
+                    // owns (their own fresh upload) or can delete. A crafted
+                    // wpuf_files value that repeats an attachment id past the
+                    // field count must not become an arbitrary-file-deletion
+                    // primitive against another user's media.
+                    $overflow_attachment = get_post( $attachment_id );
+
+                    if (
+                        $overflow_attachment instanceof \WP_Post
+                        && 'attachment' === $overflow_attachment->post_type
+                        && (
+                            self::current_user_owns_attachment( $overflow_attachment )
+                            || current_user_can( 'delete_post', $attachment_id )
+                        )
+                    ) {
+                        wp_delete_attachment( $attachment_id );
+                    }
+
                     continue;
                 }
 

--- a/includes/Traits/FieldableTrait.php
+++ b/includes/Traits/FieldableTrait.php
@@ -85,22 +85,26 @@ trait FieldableTrait {
             $wpuf_post_types[] = 'download';
         }
 
-        $ignore_taxonomies = apply_filters( 'wpuf-ignore-taxonomies', [
-            'post_format',
-        ] );
+        $ignore_taxonomies = apply_filters(
+            'wpuf-ignore-taxonomies', [
+                'post_format',
+            ]
+        );
         foreach ( $wpuf_post_types as $post_type ) {
             $this->wp_post_types[ $post_type ] = [];
             $taxonomies = get_object_taxonomies( $post_type, 'object' );
             foreach ( $taxonomies as $tax_name => $taxonomy ) {
-                if ( ! in_array( $tax_name, $ignore_taxonomies ) ) {
+                if ( ! in_array( $tax_name, $ignore_taxonomies, true ) ) {
                     $this->wp_post_types[ $post_type ][ $tax_name ] = [
                         'title'        => $taxonomy->label,
                         'hierarchical' => $taxonomy->hierarchical,
                     ];
-                    $this->wp_post_types[ $post_type ][ $tax_name ]['terms'] = get_terms( [
-                        'taxonomy'   => $tax_name,
-                        'hide_empty' => false,
-                    ] );
+                    $this->wp_post_types[ $post_type ][ $tax_name ]['terms'] = get_terms(
+                        [
+                            'taxonomy'   => $tax_name,
+                            'hide_empty' => false,
+                        ]
+                    );
                 }
             }
 
@@ -150,7 +154,7 @@ trait FieldableTrait {
     }
 
     /**
-     * get Input fields
+     * Get input fields
      *
      * @param array $form_vars
      *
@@ -158,7 +162,9 @@ trait FieldableTrait {
      */
     public function get_input_fields( $form_vars ) {
         $ignore_lists = [ 'section_break', 'html' ];
-        $post_vars    = $meta_vars = $taxonomy_vars = [];
+        $post_vars     = [];
+        $meta_vars     = [];
+        $taxonomy_vars = [];
 
         foreach ( $form_vars as $key => $value ) {
             // get column field input fields
@@ -169,7 +175,7 @@ trait FieldableTrait {
                     if ( ! empty( $column_fields ) ) {
                         // ignore section break and HTML input type
                         foreach ( $column_fields as $column_field_key => $column_field ) {
-                            if ( in_array( $column_field['input_type'], $ignore_lists ) ) {
+                            if ( in_array( $column_field['input_type'], $ignore_lists, true ) ) {
                                 continue;
                             }
 
@@ -197,7 +203,7 @@ trait FieldableTrait {
             }
 
             // ignore section break and HTML input type
-            if ( in_array( $value['input_type'], $ignore_lists ) ) {
+            if ( in_array( $value['input_type'], $ignore_lists, true ) ) {
                 continue;
             }
 
@@ -294,6 +300,7 @@ trait FieldableTrait {
             return;
         }
 
+        // phpcs:ignore WordPress.Security.NonceVerification.Missing -- nonce is verified by the submit/draft handler that calls this.
         $token = ! empty( $_POST['cf-turnstile-response'] ) ? sanitize_text_field( wp_unslash( $_POST['cf-turnstile-response'] ) ) : '';
 
         if ( empty( $token ) ) {
@@ -356,7 +363,7 @@ trait FieldableTrait {
     }
 
     /**
-     * reCaptcha Validation
+     * Validate reCaptcha
      *
      * @return void
      */
@@ -376,9 +383,9 @@ trait FieldableTrait {
             }
 
             $response  = null;
-            $reCaptcha = new \WPUF_ReCaptcha( $private_key );
+            $re_captcha = new \WPUF_ReCaptcha( $private_key );
 
-            $resp = $reCaptcha->verifyResponse(
+            $resp = $re_captcha->verifyResponse(
                 $remote_addr,
                 $g_recaptcha_response
             );
@@ -402,7 +409,7 @@ trait FieldableTrait {
 
             $response = $object->verifyResponse( $recaptcha );
 
-            if ( isset( $response['success'] ) and $response['success'] != true ) {
+            if ( isset( $response['success'] ) && $response['success'] != true ) {
                 $this->send_error( __( 'Invisible reCAPTCHA validation failed', 'wp-user-frontend' ) );
             }
         }
@@ -416,6 +423,7 @@ trait FieldableTrait {
      * @return array
      */
     private function adjust_thumbnail_id( $postarr ) {
+        // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Missing -- each element is cast with absint() immediately below; the nonce is verified by the submit/draft handler that calls this.
         $wpuf_files_raw = ! empty( $_POST['wpuf_files'] ) ? wp_unslash( $_POST['wpuf_files'] ) : [];
         $wpuf_files = [];
 
@@ -633,7 +641,7 @@ trait FieldableTrait {
             return true;
         }
 
-        // Attached to a different post — never allow hijacking it.
+        // Attached to a different post: never allow hijacking it.
         if ( $parent ) {
             return false;
         }
@@ -702,7 +710,7 @@ trait FieldableTrait {
     }
 
     /**
-     * set custom taxonomy
+     * Set custom taxonomy
      *
      * @param int   $post_id
      * @param array $taxonomy_vars
@@ -781,39 +789,34 @@ trait FieldableTrait {
                         if ( isset( $taxonomy['woo_attr'] ) && $taxonomy['woo_attr'] == 'yes' && ! empty( $taxonomy_name ) ) {
                             $woo_attr[ $taxonomy['name'] ] = $this->woo_attribute( $taxonomy );
                         }
-                    } else {
-                        if ( is_taxonomy_hierarchical( $taxonomy['name'] ) ) {
+                    } elseif ( is_taxonomy_hierarchical( $taxonomy['name'] ) ) {
                             wp_set_post_terms( $post_id, $taxonomy_name, $taxonomy['name'] );
 
                             // woocommerce check
-                            if ( isset( $taxonomy['woo_attr'] ) && $taxonomy['woo_attr'] == 'yes' && ! empty( $taxonomy_name ) ) {
-                                $woo_attr[ $taxonomy['name'] ] = $this->woo_attribute( $taxonomy );
+                        if ( isset( $taxonomy['woo_attr'] ) && $taxonomy['woo_attr'] == 'yes' && ! empty( $taxonomy_name ) ) {
+                            $woo_attr[ $taxonomy['name'] ] = $this->woo_attribute( $taxonomy );
+                        }
+                    } elseif ( $tax ) {
+                            $non_hierarchical = [];
+
+                        foreach ( $tax as $value ) {
+                            $term = get_term_by( 'id', $value, $taxonomy['name'] );
+
+                            if ( $term && ! is_wp_error( $term ) ) {
+                                $non_hierarchical[] = $term->name;
                             }
-                        } else {
-                            if ( $tax ) {
-                                $non_hierarchical = [];
+                        }
 
-                                foreach ( $tax as $value ) {
-                                    $term = get_term_by( 'id', $value, $taxonomy['name'] );
+                            wp_set_post_terms( $post_id, $non_hierarchical, $taxonomy['name'] );
 
-                                    if ( $term && ! is_wp_error( $term ) ) {
-                                        $non_hierarchical[] = $term->name;
-                                    }
-                                }
-
-                                wp_set_post_terms( $post_id, $non_hierarchical, $taxonomy['name'] );
-
-                                // woocommerce check
-                                if ( isset( $taxonomy['woo_attr'] ) && $taxonomy['woo_attr'] == 'yes' && ! empty( $_POST[ $taxonomy['name'] ] ) ) {
-                                    $woo_attr[ $taxonomy['name'] ] = $this->woo_attribute( $taxonomy );
-                                }
-                            }
-                        } // hierarchical
-                    } // is text
+                            // woocommerce check
+                        if ( isset( $taxonomy['woo_attr'] ) && $taxonomy['woo_attr'] == 'yes' && ! empty( $_POST[ $taxonomy['name'] ] ) ) {
+                            $woo_attr[ $taxonomy['name'] ] = $this->woo_attribute( $taxonomy );
+                        }
+                    } // hierarchical / is text
                 } // is object tax
-            } // isset tax
-
-            else {
+                // isset tax
+            } else {
                 if ( isset( $taxonomy_name ) && 0 === absint( $taxonomy_name ) ) {
                     wp_set_post_terms( $post_id, $taxonomy_name, $taxonomy['name'] );
                 }
@@ -833,7 +836,7 @@ trait FieldableTrait {
     }
 
     /**
-     * prepare meta fields
+     * Prepare meta fields
      *
      * @param array $meta_vars
      *
@@ -845,7 +848,8 @@ trait FieldableTrait {
         // process repeatable fields separately
         // if the input is array type, implode with separator in a field
         // /check_ajax_referer( 'wpuf_form_add' );
-        $post_data = wp_unslash( $_POST ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+        // phpcs:ignore WordPress.Security.NonceVerification.Missing -- nonce is verified by the submit/draft handler that calls this.
+        $post_data = wp_unslash( $_POST );
         $files          = [];
         $meta_key_value = [];
         $multi_repeated = []; //multi repeated fields will in sotre duplicated meta key
@@ -861,7 +865,11 @@ trait FieldableTrait {
                 $meta_key_value[ $value['name'] ] = $wpuf_field->sanitize_field_data( $posted_field_data, $value );
                 continue;
             } elseif ( isset( $post_data[ $value['name'] ] ) && is_array( $post_data[ $value['name'] ] ) ) {
-                $value_name = isset( $post_data[ $value['name'] ] ) ? array_map( function( $item ) { return strip_shortcodes( sanitize_text_field( $item ) ); }, wp_unslash( $post_data[ $value['name'] ] ) ) : '';
+                $value_name = isset( $post_data[ $value['name'] ] ) ? array_map(
+                    function ( $item ) {
+                        return strip_shortcodes( sanitize_text_field( $item ) );
+                    }, wp_unslash( $post_data[ $value['name'] ] )
+                ) : '';
             } else {
                 $value_name = isset( $post_data[ $value['name'] ] ) ? strip_shortcodes( sanitize_text_field( wp_unslash( $post_data[ $value['name'] ] ) ) ) : '';
             }
@@ -890,12 +898,13 @@ trait FieldableTrait {
                     break;
 
                 case 'repeat':
+                    // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Missing -- each element is sanitised below before use; the nonce is verified by the submit/draft handler that calls this.
                     $repeater_value = isset( $_POST[ $value['name'] ] ) ? wp_unslash( $_POST[ $value['name'] ] ) : [];
 
                     // If this repeat field has inner_fields and the value is an array of rows (ACF-style)
                     if ( ! empty( $value['inner_fields'] ) && is_array(
-                            $repeater_value
-                        ) && isset( $repeater_value[0] ) && is_array( $repeater_value[0] ) ) {
+                        $repeater_value
+                    ) && isset( $repeater_value[0] ) && is_array( $repeater_value[0] ) ) {
                         $rows = [];
                         foreach ( $repeater_value as $row ) {
                             $sanitized_row = [];
@@ -904,10 +913,14 @@ trait FieldableTrait {
 
                                 // Handle different field types appropriately
                                 if ( isset( $row[ $fname ] ) ) {
-                                    if ( in_array( $inner_field['template'], [ 'checkbox_field', 'multiple_select' ] ) ) {
+                                    if ( in_array( $inner_field['template'], [ 'checkbox_field', 'multiple_select' ], true ) ) {
                                         // For checkbox and multiselect, keep as array and sanitize each element
                                         if ( is_array( $row[ $fname ] ) ) {
-                                            $sanitized_row[ $fname ] = array_map( function( $item ) { return strip_shortcodes( sanitize_text_field( $item ) ); }, $row[ $fname ] );
+                                            $sanitized_row[ $fname ] = array_map(
+                                                function ( $item ) {
+                                                    return strip_shortcodes( sanitize_text_field( $item ) );
+                                                }, $row[ $fname ]
+                                            );
                                         } else {
                                             $sanitized_row[ $fname ] = strip_shortcodes( sanitize_text_field( $row[ $fname ] ) );
                                         }
@@ -1049,6 +1062,4 @@ trait FieldableTrait {
             'is_taxonomy'  => 1,
         ];
     }
-
-
 }


### PR DESCRIPTION
Fixes the three Patchstack reports against 4.3.11. I reproduced all three **live** first (PoC harnesses driving the real code paths on a running install), fixed them, and re-ran each to confirm it is closed while the legitimate flow still works.

| # | Report | CVSS | Root cause | Reproduced | After fix |
|---|--------|------|-----------|-----------|-----------|
| 1 | wpuf-pro#1691 Subscriber+ arbitrary file deletion | 6.5 | attachment reparent + over-limit delete, both without ownership checks | admin attachment destroyed by a Subscriber | attachment survives; foreign reparent skipped |
| 2 | wpuf-pro#1692 unauth guest pay-per-post publish bypass | 5.3 | `p_id`/`f_id` never bound; author-0 via nonce-param confusion | pending unpaid post published | stays pending, redirects to payment |
| 3 | wpuf-pro#1693 recurring pack on unapproved/unpaid PayPal CREATED | 6.5 | grant on `APPROVAL_PENDING`; wrong quota key | limited pack granted **unlimited**, no payment | no grant until `ACTIVE`; limited quota preserved |

## 1. Arbitrary file deletion (wpuf-pro#1691)

Two chained IDORs. The `post_content` `<img>` handler reparented **any** same-site attachment to the attacker's post with no ownership check; the file field's over-limit loop then passed that now-"associable" id straight to `wp_delete_attachment()`.

- `submit_post()` — reparent an embedded image only when `is_attachment_associable()` (already this post's, or unattached **and** owned by the requester), the same guard the featured-image path already uses.
- `FieldableTrait` file loop — delete an over-limit attachment only when the requester actually owns it or can delete it.
- `submit_post()` — reject a `form_id` that is not a real `wpuf_forms` post, which also closes the reported "action-wide nonce → arbitrary published post" case.

## 2. Guest pay-per-post publish bypass (wpuf-pro#1692)

`p_id` and `f_id` are encrypted independently and never bound, so replaying the post-id token as `f_id` ran the paywall against a non-form object with empty settings and published the post for free while payment stayed pending. A nonce-parameter confusion produced the author-0 post the verifier looks for.

- `publish_guest_post()` — derive the charging decision from the post's own stored `_wpuf_form_id`, reject an `f_id` that does not match it, require a real `wpuf_forms` id. The paywall is always evaluated against the real form.
- `wpuf_get_post_user()` — verify the nonce from whichever parameter `check_ajax_referer()` honoured (`_wpnonce` or `_ajax_nonce`), so a moved nonce no longer silently yields `post_author = 0`.

## 3. PayPal CREATED lifecycle abuse (wpuf-pro#1693)

`BILLING.SUBSCRIPTION.CREATED` fires while the subscription is still `APPROVAL_PENDING` with no payment, yet the handler wrote the pack as completed/recurring with an empty (never-expiring) expiry, and a quota-key bug turned a limited pack unlimited.

- `handle_subscription_created()` — grant only when PayPal reports the subscription genuinely `ACTIVE`; otherwise wait for `ACTIVATED` / `PAYMENT.SALE.COMPLETED`.
- read the real per-post-type quota key (`_post_type_name` + additional CPT options) instead of the non-existent `_post_types`, so a limited pack stays limited.
- handle `EXPIRED` / `SUSPENDED` to revoke the local pack (only `CANCELLED` did).
- `get_or_create_plan()` — reuse a cached PayPal plan only when its price, currency and billing period/interval still match the pack, closing the stale-plan-cache underpayment variant.

## Preserving existing behaviour

No hook, filter, REST route, template path or public method signature changed; every guard is additive.

Verified on a running install:
- Legitimate uncharged guest post still **publishes** after email verification.
- Legitimate paid recurring `ACTIVE` grant still lands, with the **limited** quota (not unlimited).
- Over-limit upload cleanup still deletes the user's own excess files.
- A subscriber's own freshly-uploaded image still associates to their post; only reparenting a foreign attachment is blocked.

## Checks

- `php -l` clean on all four files.
- PHPCS: **zero new errors vs base** on every changed file (verified by diffing the per-file error profile against `develop`; the pre-existing legacy-file debt is unchanged, matching the #1962 precedent).

Closes weDevsOfficial/wpuf-pro#1691
Closes weDevsOfficial/wpuf-pro#1692
Closes weDevsOfficial/wpuf-pro#1693

https://claude.ai/code/session_019KGP9sp935QBeu32pGt5WY
