### PR TITLE
fix(security): blank the profile email at the source for anonymous visitors

### DIFF
--- a/modules/user-directory/Helpers.php
+++ b/modules/user-directory/Helpers.php
@@ -462,12 +462,18 @@ function wpuf_ud_get_profile_data( $user, $template_data = [], $layout = 'layout
     $avatar_size = isset( $template_data['avatar_size'] ) ? $template_data['avatar_size'] : 192;
     $back_url    = isset( $template_data['back_url'] ) ? $template_data['back_url'] : '';
 
+    // The contact-visibility rule is applied here, at the source, so no layout or
+    // consumer of this array can surface the address by accident. The key is kept
+    // and blanked rather than dropped, so anything reading it gets an empty string
+    // instead of an undefined value.
+    $show_contact_info = wpuf_ud_show_contact_info( $user );
+
     // Build user_meta array
     $user_meta = [
         'display_name' => $full_name,
         'first_name'   => $first_name,
         'last_name'    => $last_name,
-        'email'        => $user->user_email,
+        'email'        => $show_contact_info ? $user->user_email : '',
         'website'      => $user->user_url,
         'bio'          => get_user_meta( $user->ID, 'description', true ),
     ];
@@ -551,7 +557,7 @@ function wpuf_ud_get_profile_data( $user, $template_data = [], $layout = 'layout
         'full_name'       => $full_name,
         'first_name'      => $first_name,
         'last_name'       => $last_name,
-        'email'           => $user->user_email,
+        'email'           => $show_contact_info ? $user->user_email : '',
         'website'         => $user->user_url,
         'bio'             => get_user_meta( $user->ID, 'description', true ),
         'avatar_size'     => $avatar_size,


### PR DESCRIPTION
Free-side companion to the Pro User Directory hardening in weDevsOfficial/wpuf-pro#1640.

## What this changes

`wpuf_ud_get_profile_data()` returned the member's address twice — in `$user_meta['email']` and in the top-level `'email'` — without consulting the contact-visibility rule. Only the `contact_info` items built alongside them were gated.

Both now go through the same gate the rest of the module uses, `wpuf_ud_show_contact_info( $user )`: signed-in viewers by default, filterable via `wpuf_ud_show_contact_info` so an owner can opt a deliberately public directory back in.

The key is **kept and blanked**, not dropped, so anything reading it gets an empty string rather than an undefined value.

## Severity: defence in depth, not a live leak

No shipped layout renders those two keys today — they render contact through `contact_info`, which weDevsOfficial/wp-user-frontend#1914 already gated. So the reported disclosure was closed. This removes the value from the array anyway, so a future layout, a filter on `wpuf_ud_profile_data`, or anything that serialises the array cannot surface it by accident.

## Free module sweep

Audited every remaining contact emission in `modules/user-directory/`; the rest were already correct and are untouched:

| site | state |
|---|---|
| `views/directory/template-parts/row-3.php` (email + phone) | already gated (#1914) |
| `views/profile/layout-2.php` | renders gated `contact_info` |
| `Api/Directory.php` | published-directory required, `user_email` excluded from public search (#1914) |
| `Helpers.php` `contact_info` builder | already gated (#1914) |
| `Admin_Menu.php` | admin-only |

No user-directory widget exists in either plugin, so nothing to change there.

## Testing

Verified on a live install with the free helper loaded, anonymous vs signed-in:

- anonymous → `email` is `''` in both `$user_meta` and the top-level key; `contact_info` has no email item
- signed-in → both carry the address, unchanged
- `add_filter( 'wpuf_ud_show_contact_info', '__return_true' )` → anonymous gets the address back, confirming the owner opt-in path

PHPCS on the changed file: clean, no violations.

Refs weDevsOfficial/wpuf-pro#1696
Refs weDevsOfficial/wpuf-pro#1643

https://claude.ai/code/session_019KGP9sp935QBeu32pGt5WY
